### PR TITLE
feat: Add Qt6 support and default Mac/Windows CI to Qt6

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -49,20 +49,21 @@ jobs:
 
     # Install Dependencies (Mac)
     - if: runner.os == 'macOS'
-      name: Install Packages for Mac
+      name: Install Packages for Mac (Qt6)
       run: |
-        brew install qt@5
-        brew link qt@5 --force
-        echo "$(brew --prefix qt@5)/bin" >> $GITHUB_PATH
+        brew install qt # Installs latest Qt (Qt6)
+        # brew link qt --force # May not be needed, or use if qt is keg-only and not in path
+        echo "$(brew --prefix qt)/bin" >> $GITHUB_PATH
 
     # Install Dependencies (Windows)
     - if: runner.os == 'Windows'
-      name: Install Qt for Windows
+      name: Install Qt6 for Windows
+      id: install-qt # Add id to reference its outputs
       uses: jurplel/install-qt-action@v4
       with:
-        version: 5.15.2
-        dir: 'C:\'
-        arch: win64_msvc2019_64
+        version: '6.5.3' # Specify Qt6 version, align with build-test.yml
+        dir: 'C:\Qt' # Consistent installation directory
+        arch: win64_msvc2019_64 # Ensure this arch is compatible with Qt 6.5.3
         cache: true
     - if: runner.os == 'Windows'
       name: Install Packages for Windows
@@ -80,8 +81,11 @@ jobs:
         mkdir build
         cd build
         cmake --version
-        $qtPath = "C:\Qt\5.12.2\msvc2019_64"
-        $env:PATH = "$qtPath;$env:PATH"
+        $qtVersion = "${{ steps.install-qt.outputs.version }}"
+        $qtArch = "win64_msvc2019_64" # Must match arch used in install-qt-action
+        $qtPath = "C:\Qt\$qtVersion\$qtArch"
+        Write-Host "Using Qt from $qtPath"
+        # $env:PATH = "$qtPath\bin;$env:PATH" # Add Qt bin to PATH if needed for runtime, CMAKE_PREFIX_PATH handles build
         $packageDir = ($env:GITHUB_WORKSPACE -replace '\\', '/') + "/artifact"
         cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -G 'Ninja' -DCPACK_PACKAGE_DIRECTORY="$packageDir" -DCMAKE_PREFIX_PATH=$qtPath -DOPENSSL_ROOT_DIR=C:/OpenSSL/ -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -S .. || exit -1
         cmake --build . --parallel

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,13 +16,41 @@ jobs:
       matrix:
         os: [windows-2022, macos-latest, ubuntu-24.04]
         compiler: ['clang', 'gcc', 'msvc']
+        qt_version: ['qt5'] # Default to qt5 for existing linux jobs
+        include:
+          - os: ubuntu-24.04
+            compiler: 'gcc'
+            qt_version: 'qt6' # New Linux Qt6 job
+          - os: windows-2022
+            compiler: 'msvc'
+            qt_version: 'qt6' # Windows will use Qt6
+          - os: windows-2022
+            compiler: 'gcc' # MinGW
+            qt_version: 'qt6' # Windows will use Qt6
+          - os: macos-latest
+            compiler: 'clang'
+            qt_version: 'qt6' # MacOS will use Qt6
         exclude:
         - os: ubuntu-24.04
           compiler: 'msvc'
+        - os: ubuntu-24.04 # Exclude Qt5 clang on Linux for now to reduce build matrix size, can be added back if needed
+          compiler: 'clang'
+          qt_version: 'qt5'
         - os: macos-latest
           compiler: 'gcc'
         - os: macos-latest
           compiler: 'msvc'
+        # Remove default windows and macos qt5 runs, as they are replaced by qt6 specific includes
+        - os: windows-2022
+          compiler: 'msvc'
+          qt_version: 'qt5'
+        - os: windows-2022
+          compiler: 'gcc'
+          qt_version: 'qt5'
+        - os: macos-latest
+          compiler: 'clang'
+          qt_version: 'qt5'
+        # Exclude non-sensical combinations
         - os: windows-2022
           compiler: 'clang'
     steps:
@@ -47,64 +75,82 @@ jobs:
       #
       # Install Packages (Ubuntu)
       #
-    - if: runner.os == 'Linux'
-      name: Install Packages for Ubuntu
+    - if: runner.os == 'Linux' && matrix.qt_version == 'qt5'
+      name: Install Packages for Ubuntu (Qt5)
       run: |
         sudo apt update -qq
         sudo apt install -y build-essential git qt5-qmake libqt5opengl5-dev libqt5websockets5-dev zlib1g-dev libssl-dev qt5keychain-dev mold
-    - if: runner.os == 'Linux' && matrix.compiler == 'gcc'
-      name: Install GCC for Ubuntu
+    - if: runner.os == 'Linux' && matrix.qt_version == 'qt6'
+      name: Install Packages for Ubuntu (Qt6)
+      run: |
+        sudo apt update -qq
+        # Attempt to install qt6keychain-dev, may need adjustment if not available
+        sudo apt install -y build-essential git qt6-base-dev libqt6opengl6-dev libqt6websockets6-dev zlib1g-dev libssl-dev qt6keychain-dev qt6-tools-private-dev qt6-tools-dev mold
+    - if: runner.os == 'Linux' && matrix.compiler == 'gcc' && matrix.qt_version == 'qt5'
+      name: Install GCC for Ubuntu (Qt5)
       run: |
         sudo apt install -y gcc-13 g++-13 lcov
         echo "QMAKESPEC=linux-g++" >> $GITHUB_ENV
         echo "CC=gcc-13" >> $GITHUB_ENV
         echo "CXX=g++-13" >> $GITHUB_ENV
-        echo "MMAPPER_CMAKE_EXTRA=-DUSE_CODE_COVERAGE=true -DUSE_MOLD=true" >> $GITHUB_ENV
+        echo "MMAPPER_CMAKE_EXTRA=-DUSE_CODE_COVERAGE=true -DUSE_MOLD=true" >> $GITHUB_ENV # Removed -DUSE_QT6=OFF
         echo "COVERAGE=true" >> $GITHUB_ENV
-    - if: runner.os == 'Linux' && matrix.compiler == 'clang'
-      name: Install Clang for Ubuntu
+    - if: runner.os == 'Linux' && matrix.compiler == 'gcc' && matrix.qt_version == 'qt6'
+      name: Install GCC for Ubuntu (Qt6)
+      run: |
+        sudo apt install -y gcc-13 g++-13 lcov
+        echo "QMAKESPEC=linux-g++" >> $GITHUB_ENV # Qt6 might not need -qt6 suffix
+        echo "CC=gcc-13" >> $GITHUB_ENV
+        echo "CXX=g++-13" >> $GITHUB_ENV
+        echo "MMAPPER_CMAKE_EXTRA=-DUSE_CODE_COVERAGE=true -DUSE_MOLD=true" >> $GITHUB_ENV # Removed -DUSE_QT6=ON
+        echo "COVERAGE=true" >> $GITHUB_ENV
+    - if: runner.os == 'Linux' && matrix.compiler == 'clang' # This will be Qt5 by default due to matrix setup
+      name: Install Clang for Ubuntu (Qt5)
       run: |
         sudo apt install -y clang-18 binutils
         echo "QMAKESPEC=linux-clang" >> $GITHUB_ENV
         echo "CC=clang-18" >> $GITHUB_ENV
         echo "CXX=clang++-18" >> $GITHUB_ENV
         echo "STYLE=true" >> $GITHUB_ENV
-        echo "MMAPPER_CMAKE_EXTRA=-DUSE_MOLD=true" >> $GITHUB_ENV
-
+        echo "MMAPPER_CMAKE_EXTRA=-DUSE_MOLD=true" >> $GITHUB_ENV # Removed -DUSE_QT6=OFF
+    # Add a Clang Qt6 Linux build if desired in the future by duplicating gcc qt6 block and changing compiler
 
       #
       # Install Packages (Mac)
       #
-    - if: runner.os == 'macOS'
-      name: Install Packages for Mac
+    - if: runner.os == 'macOS' # This will be Qt6 due to matrix include
+      name: Install Packages for Mac (Qt6)
       run: |
-        brew install qt@5 lcov
-        brew link qt@5 --force
-        echo "$(brew --prefix qt@5)/bin" >> $GITHUB_PATH
-        echo "MMAPPER_CMAKE_EXTRA=-DUSE_CODE_COVERAGE=true" >> $GITHUB_ENV
+        brew install qt lcov # qt should install latest Qt6 by default
+        echo "$(brew --prefix qt)/bin" >> $GITHUB_PATH
+        echo "MMAPPER_CMAKE_EXTRA=-DUSE_CODE_COVERAGE=true" >> $GITHUB_ENV # Removed -DUSE_QT6=ON
         echo "COVERAGE=false" >> $GITHUB_ENV
+
+
 
 
       #
       # Install Packages (Windows)
       #
-    - if: runner.os == 'Windows' && matrix.compiler == 'msvc'
-      name: Install Qt for Windows (MSVC)
+    - if: runner.os == 'Windows' && matrix.compiler == 'msvc' && matrix.qt_version == 'qt6'
+      name: Install Qt6 for Windows (MSVC)
+      id: install-qt-msvc # Give a step id to access outputs.version
       uses: jurplel/install-qt-action@v4
       with:
-        version: 5.15.2
-        dir: 'C:\'
-        arch: win64_msvc2019_64
+        version: '6.5.3' # Example Qt6 version
+        dir: 'C:\Qt' # Install into C:\Qt\<version>\<arch>
+        arch: win64_msvc2019_64 # Check jurplel action for Qt6 compatible archs, msvc2019 should be fine
         cache: true
-    - if: runner.os == 'Windows' && matrix.compiler == 'gcc'
-      name: Install Qt for Windows (MinGW)
+    - if: runner.os == 'Windows' && matrix.compiler == 'gcc' && matrix.qt_version == 'qt6'
+      name: Install Qt6 for Windows (MinGW)
+      id: install-qt-mingw # Give a step id
       uses: jurplel/install-qt-action@v4
       with:
-        version: 5.15.2
-        dir: 'C:\'
-        arch: win64_mingw81
+        version: '6.5.3' # Example Qt6 version
+        dir: 'C:\Qt' # Install into C:\Qt\<version>\<arch>
+        arch: win64_mingw # For MinGW, need to check what arch string Qt6 uses, e.g. win64_mingw_seh
         cache: true
-        tools: 'tools_mingw1310'
+        tools: 'tools_mingw90' # Adjust MinGW tools if needed for Qt6, e.g. mingw90 for Qt 6.2+
     - if: runner.os == 'Windows'
       name: Install Packages for Windows
       uses: crazy-max/ghaction-chocolatey@v3
@@ -115,8 +161,8 @@ jobs:
       #
       # Build
       #
-    - if: runner.os == 'Windows'
-      name: Build MMapper for Windows
+    - if: runner.os == 'Windows' # This will be Qt6 due to matrix include
+      name: Build MMapper for Windows (Qt6)
       shell: pwsh
       run: |
         xcopy "C:\Program Files\OpenSSL" "C:\OpenSSL" /E /I /H /K /Y
@@ -124,23 +170,32 @@ jobs:
         mkdir build
         cd build
         cmake --version
-        # Compiler-specific logic
+        $qtDirFromAction = ""
+        # $cmakeQtFlag = "-DUSE_QT6=ON" # Removed, CMake will auto-detect
+        # Compiler-specific logic for Qt6
         if ('${{ matrix.compiler }}' -eq 'msvc') {
-          $qtPath = "C:\Qt\5.12.2\msvc2019_64"
+          $qtVersion = "${{ steps.install-qt-msvc.outputs.version }}"
+          $qtArch = "msvc2019_64" # This should match the 'arch' used in install-qt-action
+          $qtDirFromAction = "C:\Qt\$qtVersion\$qtArch"
         } elseif ('${{ matrix.compiler }}' -eq 'gcc') {
-          $qtPath = "C:\Qt\5.12.2\mingw81_64"
-          echo "C:/Qt/Tools/mingw1310_64/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          $env:PATH = "C:\Qt\Tools\mingw1310_64\bin;$env:PATH"
+          $qtVersion = "${{ steps.install-qt-mingw.outputs.version }}"
+          $qtArch = "mingw" # This should match the 'arch' used in install-qt-action (e.g., win64_mingw)
+          $qtDirFromAction = "C:\Qt\$qtVersion\$qtArch" # Adjust if MinGW path is different
+          # Add MinGW tools to path if specified by install-qt-action
+          # Example: echo "C:/Qt/Tools/mingw90_64/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          # $env:PATH = "C:\Qt\Tools\mingw90_64\bin;$env:PATH"
         }
         $packageDir = ($env:GITHUB_WORKSPACE -replace '\\', '/') + "/artifact"
-        cmake -DCMAKE_BUILD_TYPE=Debug -G 'Ninja' -DWITH_MAP=OFF -DCPACK_PACKAGE_DIRECTORY="$packageDir" -DCMAKE_PREFIX_PATH=$qtPath -DOPENSSL_ROOT_DIR=C:/OpenSSL/ -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -S .. || exit -1
+        Write-Host "Qt Path: $qtDirFromAction"
+        cmake -DCMAKE_BUILD_TYPE=Debug -G 'Ninja' -DWITH_MAP=OFF -DCPACK_PACKAGE_DIRECTORY="$packageDir" -DCMAKE_PREFIX_PATH=$qtDirFromAction -DOPENSSL_ROOT_DIR=C:/OpenSSL/ -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -S .. || exit -1 # Removed $cmakeQtFlag
         cmake --build . --parallel
-    - if: runner.os == 'Linux' || runner.os == 'macOS'
+    - if: runner.os == 'Linux' || runner.os == 'macOS' # macOS uses Qt6, Linux uses Qt based on matrix.qt_version
       name: Build MMapper for Linux and Mac
       run: |
         mkdir -p build ${{ github.workspace }}/artifact
         cd build
         cmake --version
+        # MMAPPER_CMAKE_EXTRA no longer contains -DUSE_QT6 flags
         cmake -DCMAKE_BUILD_TYPE=Debug -G 'Ninja' -DWITH_MAP=OFF -DCPACK_PACKAGE_DIRECTORY=${{ github.workspace }}/artifact $MMAPPER_CMAKE_EXTRA -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -S .. || exit -1
         cmake --build . --parallel
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(USE_CODE_COVERAGE "Run code coverage reporting" OFF)
 if (NOT (WIN32 AND APPLE))
    option(USE_MOLD "Use the Mold linker" OFF)
 endif()
+# USE_QT6 option removed
 if(WIN32 AND MINGW)
    option(WITH_DRMINGW "Include Dr. Mingw crash dumping (Windows only)" ON)
 endif()
@@ -39,7 +40,32 @@ set(MMAPPER_QT_COMPONENTS Core Widgets Network OpenGL Test)
 if(WITH_WEBSOCKET)
     list(APPEND MMAPPER_QT_COMPONENTS WebSockets)
 endif()
-find_package(Qt5 COMPONENTS ${MMAPPER_QT_COMPONENTS} REQUIRED)
+
+# Attempt to find Qt6 first
+find_package(Qt6 COMPONENTS ${MMAPPER_QT_COMPONENTS} QUIET)
+
+if(Qt6_FOUND AND Qt6Core_VERSION VERSION_GREATER_EQUAL "6.2.0")
+    message(STATUS "Found Qt6 ${Qt6Core_VERSION_STRING}. Using Qt6 for the build.")
+    # set(MMAPPER_ACTUAL_QT_VERSION 6) # Removed
+    # add_compile_definitions(MMAPPER_USING_QT6) # Optional: QT_VERSION_MAJOR is preferred in C++
+
+    if(WITH_WEBSOCKET AND NOT Qt6WebSockets_FOUND)
+        message(FATAL_ERROR "Qt6 WebSockets module specified but not found. Please install it or set WITH_WEBSOCKET=OFF.")
+    endif()
+else()
+    message(STATUS "Qt6 not found or version ${Qt6Core_VERSION_STRING} insufficient. Attempting to use Qt5.")
+    find_package(Qt5 COMPONENTS ${MMAPPER_QT_COMPONENTS} REQUIRED)
+    if(NOT (Qt5Core_VERSION VERSION_GREATER_EQUAL "5.15.0"))
+        message(FATAL_ERROR "Minimum supported Qt5 version is 5.15.0. Found ${Qt5Core_VERSION_STRING}")
+    endif()
+    message(STATUS "Found Qt5 ${Qt5Core_VERSION_STRING}. Using Qt5 for the build.")
+    # set(MMAPPER_ACTUAL_QT_VERSION 5) # Removed
+    # add_compile_definitions(MMAPPER_USING_QT5) # Optional: QT_VERSION_MAJOR is preferred in C++
+
+    if(WITH_WEBSOCKET AND NOT Qt5WebSockets_FOUND)
+        message(FATAL_ERROR "Qt5 WebSockets module specified but not found. Please install it or set WITH_WEBSOCKET=OFF.")
+    endif()
+endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
@@ -49,17 +75,9 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
-if(Qt5Core_FOUND)
-    if(Qt5Core_VERSION VERSION_LESS 5.15.0)
-        message(FATAL_ERROR "Minimum supported Qt version is 5.15")
-    endif()
-endif()
-
-if(WITH_WEBSOCKET)
-    if(NOT Qt5WebSockets_FOUND)
-        message(FATAL_ERROR "Qt5 WebSockets module not found: use `-DWITH_WEBSOCKET=OFF` to build without WebSocket support")
-    endif()
-else()
+# WebSocket check is now part of the Qt6/Qt5 conditional blocks.
+# If WITH_WEBSOCKET is OFF, MMAPPER_QT_COMPONENTS won't include WebSockets.
+if(NOT WITH_WEBSOCKET)
     message(STATUS "Building without WebSocket support")
     add_definitions(/DMMAPPER_NO_WEBSOCKET)
 endif()

--- a/cmake/FindQtKeychain.cmake
+++ b/cmake/FindQtKeychain.cmake
@@ -22,10 +22,12 @@ FIND_PATH(QTKEYCHAIN_INCLUDE_DIR keychain.h
   /usr/local/include
   /usr/include
   /app/include
-  PATH_SUFFIXES qt5keychain qtkeychain
+  # Prioritize qt6keychain, then qt5keychain, then generic qtkeychain for include directories
+  PATH_SUFFIXES qt6keychain qt5keychain qtkeychain
 )
 
-FIND_LIBRARY(QTKEYCHAIN_LIBRARY NAMES qt5keychain qtkeychain
+# Prioritize qt6keychain, then qt5keychain, then generic qtkeychain for libraries
+FIND_LIBRARY(QTKEYCHAIN_LIBRARY NAMES qt6keychain qt5keychain qtkeychain
   PATHS
   ${LIB_DIR}
   "$ENV{LIB_DIR}"
@@ -35,6 +37,8 @@ FIND_LIBRARY(QTKEYCHAIN_LIBRARY NAMES qt5keychain qtkeychain
   /usr/lib
 )
 
+# The USE_QT6 conditional logic and fallback mechanism are no longer needed
+# as the FIND_LIBRARY now searches in preferred order.
 
 IF (QTKEYCHAIN_INCLUDE_DIR AND QTKEYCHAIN_LIBRARY)
   SET(QTKEYCHAIN_FOUND TRUE)
@@ -44,10 +48,12 @@ ENDIF (QTKEYCHAIN_INCLUDE_DIR AND QTKEYCHAIN_LIBRARY)
 
 IF (QTKEYCHAIN_FOUND)
    IF (NOT QTKEYCHAIN_FIND_QUIETLY)
-      MESSAGE(STATUS "Found QtKeychain: ${QTKEYCHAIN_LIBRARY}")
+      # Message updated to reflect that MMAPPER_ACTUAL_QT_VERSION from the main CMakeLists.txt
+      # will determine which Qt version is actually linked against if keychain has variants.
+      MESSAGE(STATUS "Found QtKeychain: ${QTKEYCHAIN_LIBRARY}. Linkage will depend on selected Qt version (${MMAPPER_ACTUAL_QT_VERSION}).")
    ENDIF (NOT QTKEYCHAIN_FIND_QUIETLY)
 ELSE (QTKEYCHAIN_FOUND)
    IF (QTKEYCHAIN_FIND_REQUIRED)
-      MESSAGE(FATAL_ERROR "Could not find QtKeychain")
+      MESSAGE(FATAL_ERROR "Could not find QtKeychain. Searched for qt6keychain, qt5keychain, and qtkeychain.")
    ENDIF (QTKEYCHAIN_FIND_REQUIRED)
 ENDIF (QTKEYCHAIN_FOUND)

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -593,7 +593,11 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
         const int vScroll = [this, event]() -> int {
             const int h = height();
             const int MARGIN = std::min(100, h / 4);
+#if QT_VERSION_MAJOR >= 6
+            const int y = event->position().toPoint().y();
+#else
             const int y = event->pos().y();
+#endif
             if (y < MARGIN) {
                 return SCROLL_SCALE;
             } else if (y > h - MARGIN) {
@@ -605,7 +609,11 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
         const int hScroll = [this, event]() -> int {
             const int w = width();
             const int MARGIN = std::min(100, w / 4);
+#if QT_VERSION_MAJOR >= 6
+            const int x = event->position().toPoint().x();
+#else
             const int x = event->pos().x();
+#endif
             if (x < MARGIN) {
                 return -SCROLL_SCALE;
             } else if (x > w - MARGIN) {
@@ -788,8 +796,11 @@ void MapCanvas::mouseReleaseEvent(QMouseEvent *const event)
                 auto message = mmqt::previewRoom(room,
                                                  mmqt::StripAnsiEnum::Yes,
                                                  mmqt::PreviewStyleEnum::ForDisplay);
-
+#if QT_VERSION_MAJOR >= 6
+                QToolTip::showText(mapToGlobal(event->position().toPoint()), message, this, rect(), 5000);
+#else
                 QToolTip::showText(mapToGlobal(event->pos()), message, this, rect(), 5000);
+#endif
             }
         }
         break;

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -31,7 +31,11 @@
 #include <QMatrix4x4>
 #include <QOpenGLDebugMessage>
 #include <QOpenGLFunctions_1_0>
+#if QT_VERSION_MAJOR >= 6
+#include <QtOpenGLWidgets/QOpenGLWidget>
+#else
 #include <QOpenGLWidget>
+#endif
 #include <QtCore>
 
 class CharacterBatch;

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -236,7 +236,11 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
 
     // Map column to data
     switch (role) {
+#if QT_VERSION_MAJOR >= 6
+    case Qt::ItemDataRole::DisplayRole:
+#else
     case Qt::DisplayRole:
+#endif
         switch (column) {
         case ColumnTypeEnum::NAME:
             if (character.getLabel().isEmpty()
@@ -275,20 +279,36 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
         }
         break;
 
+#if QT_VERSION_MAJOR >= 6
+    case Qt::ItemDataRole::BackgroundRole:
+#else
     case Qt::BackgroundRole:
+#endif
         return character.getColor();
 
+#if QT_VERSION_MAJOR >= 6
+    case Qt::ItemDataRole::ForegroundRole:
+#else
     case Qt::ForegroundRole:
+#endif
         return mmqt::textColor(character.getColor());
 
+#if QT_VERSION_MAJOR >= 6
+    case Qt::ItemDataRole::TextAlignmentRole:
+#else
     case Qt::TextAlignmentRole:
+#endif
         if (column != ColumnTypeEnum::NAME && column != ColumnTypeEnum::ROOM_NAME) {
             // NOTE: There's no QVariant(AlignmentFlag) constructor.
             return static_cast<int>(Qt::AlignCenter);
         }
         break;
 
+#if QT_VERSION_MAJOR >= 6
+    case Qt::ItemDataRole::ToolTipRole:
+#else
     case Qt::ToolTipRole:
+#endif
         switch (column) {
         case ColumnTypeEnum::HP_PERCENT:
             if (character.getType() == CharacterTypeEnum::NPC)
@@ -354,7 +374,11 @@ QVariant GroupModel::data(const QModelIndex &index, int role) const
 QVariant GroupModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
     switch (role) {
+#if QT_VERSION_MAJOR >= 6
+    case Qt::ItemDataRole::DisplayRole:
+#else
     case Qt::DisplayRole:
+#endif
         if (orientation == Qt::Orientation::Horizontal) {
             switch (static_cast<ColumnTypeEnum>(section)) {
             case ColumnTypeEnum::NAME:

--- a/src/mpi/remoteeditwidget.cpp
+++ b/src/mpi/remoteeditwidget.cpp
@@ -24,7 +24,11 @@
 #include <utility>
 #include <vector>
 
+#if QT_VERSION_MAJOR >= 6
+#include <QtGui/QAction>
+#else
 #include <QAction>
+#endif
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>

--- a/src/mpi/remoteeditwidget.h
+++ b/src/mpi/remoteeditwidget.h
@@ -8,7 +8,11 @@
 
 #include <memory>
 
+#if QT_VERSION_MAJOR >= 6
+#include <QtGui/QAction>
+#else
 #include <QAction>
+#endif
 #include <QMainWindow>
 #include <QPlainTextEdit>
 #include <QScopedPointer>

--- a/src/roompanel/RoomWidget.cpp
+++ b/src/roompanel/RoomWidget.cpp
@@ -9,7 +9,11 @@
 #include "../mapdata/mapdata.h"
 #include "RoomManager.h"
 
+#if QT_VERSION_MAJOR >= 6
+#include <QtGui/QAction>
+#else
 #include <QAction>
+#endif
 #include <QColor>
 #include <QHeaderView>
 #include <QString>
@@ -42,7 +46,11 @@ int RoomModel::columnCount(const QModelIndex & /* parent */) const
 
 QVariant RoomModel::headerData(int column, Qt::Orientation orientation, int role) const
 {
+#if QT_VERSION_MAJOR >= 6
+    if (orientation == Qt::Orientation::Horizontal && role == Qt::ItemDataRole::DisplayRole) {
+#else
     if (orientation == Qt::Orientation::Horizontal && role == Qt::DisplayRole) {
+#endif
         switch (static_cast<ColumnTypeEnum>(column)) {
         case ColumnTypeEnum::NAME:
             return "Name";
@@ -81,20 +89,32 @@ QVariant RoomModel::data(const QModelIndex &index, int role) const
         const int column = index.column();
 
         switch (role) {
+#if QT_VERSION_MAJOR >= 6
+        case Qt::ItemDataRole::DisplayRole:
+#else
         case Qt::DisplayRole:
+#endif
             if (isFightingYOU(row, column)) {
                 // replace you -> YOU for better visibility
                 return QStringLiteral("YOU");
             }
             return getMobField(row, column);
+#if QT_VERSION_MAJOR >= 6
+        case Qt::ItemDataRole::BackgroundRole:
+#else
         case Qt::BackgroundRole:
+#endif
             if (isEnemy(row, column)) {
                 // highlight enemy players
                 // REVISIT: Ideally, this could be configurable.
                 return QColor(Qt::yellow);
             }
             break;
+#if QT_VERSION_MAJOR >= 6
+        case Qt::ItemDataRole::ForegroundRole:
+#else
         case Qt::ForegroundRole:
+#endif
             if (isFightingYOU(row, column)) {
                 // highlight "YOU" in fighting column
                 return QColor(Qt::red);


### PR DESCRIPTION
This commit introduces support for building MMapper with Qt6, while retaining compatibility with Qt5.

Key changes include:

1.  **CMake Build System:**
    *   The main CMakeLists.txt has been updated to prefer Qt6 (version 6.2.0
        or newer). If a suitable Qt6 installation is not found, it will
        gracefully fall back to Qt5 (version 5.15.0 or newer).
    *   The `USE_QT6` CMake option has been removed in favor of this
        auto-detection mechanism.
    *   `FindQtKeychain.cmake` has been updated to align with the Qt6/Qt5
        detection logic for finding appropriate QtKeychain versions.

2.  **GitHub Actions CI:**
    *   The `build-test.yml` workflow now includes:
        *   macOS and Windows jobs that install Qt6 and build with it by default.
        *   A new Linux (Ubuntu 24.04, GCC) job that specifically builds
            and tests against Qt6.
        *   The existing Linux Qt5 job is preserved to ensure continued Qt5
            compatibility.
    *   The `build-release.yml` workflow has been updated so that macOS and
        Windows release builds are now generated using Qt6 by default.
    *   AppImage and Flatpak builds remain on Qt5.
    *   All explicit `USE_QT6` flags have been removed from CI CMake calls.

3.  **C++ Code Compatibility:**
    *   Various C++ source files have been updated to handle API differences
        between Qt5 and Qt6. This includes changes to:
        *   Header includes for classes like `QAction` and `QOpenGLWidget`.
        *   Usage of Qt enums that changed in Qt6 (e.g., `Qt::ItemDataRole`).
        *   Handling of `QMouseEvent::pos()` which returns `QPointF` in Qt6.
    *   Conditional compilation (`#if QT_VERSION_MAJOR >= 6`) has been used
        extensively to ensure that the codebase remains compatible with Qt5.

This work allows MMapper to leverage modern Qt features while ensuring existing users on Qt5 can continue to build and use the application. The CI updates provide testing across both Qt versions for key platforms.