### PR TITLE
The code coverage report was previously incomplete because it only in…

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -81,7 +81,7 @@ jobs:
       run: |
         brew install lcov
         echo "MMAPPER_CMAKE_EXTRA=-DCMAKE_PREFIX_PATH=$env:QT_ROOT_DIR -DUSE_CODE_COVERAGE=true" >> $GITHUB_ENV
-        echo "COVERAGE=true" >> $GITHUB_ENV
+        echo "COVERAGE=false" >> $GITHUB_ENV
 
       #
       # Install Packages (Windows)
@@ -157,7 +157,7 @@ jobs:
         lcov --directory . --capture --output-file coverage.run
         lcov --add-tracefile coverage.base --add-tracefile coverage.run --output-file coverage.info
         lcov --list coverage.info
-        lcov --remove coverage.info '/usr/*' '*/external/*' '*/moc_*.cpp' '*/ui_*.h' '*/qrc_*.cpp' --output-file filtered.info
+        lcov --remove coverage.info '/usr/*' '*/external/*' '*/moc_*.cpp' '*/ui_*.h' '*/qrc_*.cpp' '*/src/gen/*' --output-file filtered.info
     - if: env.COVERAGE == 'true'
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -157,7 +157,7 @@ jobs:
         lcov --directory . --capture --output-file coverage.run
         lcov --add-tracefile coverage.base --add-tracefile coverage.run --output-file coverage.info
         lcov --list coverage.info
-        lcov --remove coverage.info '/usr/*' '*/external/*' '*/mmapper_autogen/*' '*/CMakeFiles/*' --output-file filtered.info
+        lcov --remove coverage.info '/usr/*' '*/external/*' '*/moc_*.cpp' '*/ui_*.h' '*/qrc_*.cpp' --output-file filtered.info
     - if: env.COVERAGE == 'true'
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -157,7 +157,7 @@ jobs:
         lcov --directory . --capture --output-file coverage.run
         lcov --add-tracefile coverage.base --add-tracefile coverage.run --output-file coverage.info
         lcov --list coverage.info
-        lcov --remove coverage.info '/usr/*' '*/external/*' '*/mmapper_autogen/*' --output-file filtered.info
+        lcov --remove coverage.info '/usr/*' '*/external/*' '*/mmapper_autogen/*' '*/CMakeFiles/*' --output-file filtered.info
     - if: env.COVERAGE == 'true'
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -153,7 +153,9 @@ jobs:
       name: Run lcov
       run: |
         cd build
-        lcov --directory . --capture --output-file coverage.info
+        lcov --directory . --capture --initial --output-file coverage.base
+        lcov --directory . --capture --output-file coverage.run
+        lcov --add-tracefile coverage.base --add-tracefile coverage.run --output-file coverage.info
         lcov --list coverage.info
         lcov --remove coverage.info '/usr/*' --output-file filtered.info
     - if: env.COVERAGE == 'true'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -81,7 +81,7 @@ jobs:
       run: |
         brew install lcov
         echo "MMAPPER_CMAKE_EXTRA=-DCMAKE_PREFIX_PATH=$env:QT_ROOT_DIR -DUSE_CODE_COVERAGE=true" >> $GITHUB_ENV
-        echo "COVERAGE=false" >> $GITHUB_ENV
+        echo "COVERAGE=true" >> $GITHUB_ENV
 
       #
       # Install Packages (Windows)

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -157,7 +157,7 @@ jobs:
         lcov --directory . --capture --output-file coverage.run
         lcov --add-tracefile coverage.base --add-tracefile coverage.run --output-file coverage.info
         lcov --list coverage.info
-        lcov --remove coverage.info '/usr/*' --output-file filtered.info
+        lcov --remove coverage.info '/usr/*' '*/external/*' '*/mmapper_autogen/*' --output-file filtered.info
     - if: env.COVERAGE == 'true'
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -157,7 +157,7 @@ jobs:
         lcov --directory . --capture --output-file coverage.run
         lcov --add-tracefile coverage.base --add-tracefile coverage.run --output-file coverage.info
         lcov --list coverage.info
-        lcov --remove coverage.info '/usr/*' '*/external/*' '*/moc_*.cpp' '*/ui_*.h' '*/qrc_*.cpp' '*/src/gen/*' --output-file filtered.info
+        lcov --remove coverage.info '/usr/*' '*/external/*' '*/moc_*.cpp' '*/ui_*.h' '*/qrc_*.cpp' '*/src/gen/*' --output-file filtered.info --ignore-errors unused
     - if: env.COVERAGE == 'true'
       uses: codecov/codecov-action@v5
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ if(USE_CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         -O0        # no optimization
         -g         # generate debug info
         --coverage # sets all required flags
+        -fprofile-update=atomic
     )
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
         target_link_options(coverage_config INTERFACE --coverage)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -717,6 +717,11 @@ target_link_libraries(mm_map PUBLIC
     Qt6::Core
     Qt6::Widgets
 )
+if(USE_CODE_COVERAGE)
+    target_link_libraries(mmapper PUBLIC coverage_config)
+    target_link_libraries(mm_global PUBLIC coverage_config)
+    target_link_libraries(mm_map PUBLIC coverage_config)
+endif()
 add_dependencies(mmapper mm_global mm_map)
 add_dependencies(mm_map mm_global)
 


### PR DESCRIPTION
…cluded files that were exercised by the test suite. Files that are part of the main executable but not touched by any tests (such as files in `src/parser`) were not being included in the report at all.

This change addresses the issue in two ways:

1.  **Instrument all targets:** The `mmapper` executable and its associated static libraries (`mm_global`, `mm_map`) are now linked against the `coverage_config` interface library in CMake. This ensures they are compiled with the `--coverage` flag when `USE_CODE_COVERAGE` is enabled, generating the necessary `.gcno` instrumentation files.

2.  **Generate baseline coverage:** The `lcov` process in the `build-test.yml` GitHub Actions workflow has been updated. It now first creates an initial baseline report (`coverage.base`) using `lcov --capture --initial`. This report includes all instrumented files with 0% coverage. This baseline is then merged with the actual coverage data from the test run (`coverage.run`) to produce the final `coverage.info` file.

This ensures that the final code coverage report is comprehensive and includes all source files compiled for the project, providing a true measure of test coverage.