### PR TITLE
Fix clang code coverage and enable for macOS

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -167,7 +167,7 @@ jobs:
             LLVM_COV="xcrun llvm-cov"
           fi
           $LLVM_PROFDATA merge -sparse $PROFRAW_FILES -o coverage.profdata
-          OBJECT_FILES=$(find . -type f -executable \( -name "mmapper" -o -name "Test*" \))
+          OBJECT_FILES=$(find . -type f -perm +111 \( -name "mmapper" -o -name "Test*" \))
           $LLVM_COV export -format=lcov -instr-profile=coverage.profdata $OBJECT_FILES --ignore-filename-regex='.*/external/.*|.*/tests/.*|.*moc_.*\.cpp|.*ui_.*\.h|.*qrc_.*\.cpp' > filtered.info
         else # gcc
           lcov --directory . --capture --initial --output-file coverage.base

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -58,7 +58,7 @@ jobs:
     - if: runner.os == 'Linux' && matrix.compiler == 'clang'
       name: Install Clang for Ubuntu
       run: |
-        sudo apt install -y clang-18 binutils lcov
+        sudo apt install -y clang-18 binutils
         echo "QMAKESPEC=linux-clang" >> $GITHUB_ENV
         echo "CC=clang-18" >> $GITHUB_ENV
         echo "CXX=clang++-18" >> $GITHUB_ENV
@@ -80,8 +80,8 @@ jobs:
     - if: runner.os == 'macOS'
       name: Install Packages for Mac
       run: |
-        brew install lcov
-        echo "MMAPPER_CMAKE_EXTRA=-DCMAKE_PREFIX_PATH=$env:QT_ROOT_DIR" >> $GITHUB_ENV
+        echo "MMAPPER_CMAKE_EXTRA=-DUSE_CODE_COVERAGE=true -DCMAKE_PREFIX_PATH=$env:QT_ROOT_DIR" >> $GITHUB_ENV
+        echo "COVERAGE=true" >> $GITHUB_ENV
 
       #
       # Install Packages (Windows)
@@ -136,9 +136,6 @@ jobs:
       #
       # Run tests
       #
-    - if: env.COVERAGE == 'true'
-      name: Prepare lcov counters
-      run: cd build && lcov --zerocounters --directory .
     - name: Run unit tests
       run: cd build && ctest -V --no-compress-output -T test --output-junit ../ctest-to-junit-results.xml
       env:
@@ -150,14 +147,32 @@ jobs:
         name: test-results ${{ matrix.os }} ${{ matrix.compiler }}
         path: ctest-to-junit-results.xml
     - if: env.COVERAGE == 'true'
-      name: Run lcov
+      name: Generate coverage report
       run: |
         cd build
-        lcov --directory . --capture --initial --output-file coverage.base
-        lcov --directory . --capture --output-file coverage.run
-        lcov --add-tracefile coverage.base --add-tracefile coverage.run --output-file coverage.info
-        lcov --list coverage.info
-        lcov --remove coverage.info '/usr/*' '*/external/*' '*/moc_*.cpp' '*/ui_*.h' '*/qrc_*.cpp' '*/src/gen/*' --output-file filtered.info --ignore-errors unused
+        if [ "${{ matrix.compiler }}" = "clang" ]; then
+          PROFRAW_FILES=$(find . -name "*.profraw")
+          if [ -z "$PROFRAW_FILES" ]; then
+            echo "No .profraw files found. Skipping coverage generation."
+            exit 0
+          fi
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            LLVM_PROFDATA=llvm-profdata-18
+            LLVM_COV=llvm-cov-18
+          else # macOS
+            LLVM_PROFDATA=llvm-profdata
+            LLVM_COV=llvm-cov
+          fi
+          $LLVM_PROFDATA merge -sparse $PROFRAW_FILES -o coverage.profdata
+          OBJECT_FILES=$(find . -type f -name "mmapper" -o -name "Test*")
+          $LLVM_COV export -format=lcov -instr-profile=coverage.profdata $OBJECT_FILES --ignore-filename-regex='.*/external/.*|.*/tests/.*|.*moc_.*\.cpp|.*ui_.*\.h|.*qrc_.*\.cpp' > filtered.info
+        else # gcc
+          lcov --zerocounters --directory .
+          lcov --directory . --capture --initial --output-file coverage.base
+          lcov --directory . --capture --output-file coverage.run
+          lcov --add-tracefile coverage.base --add-tracefile coverage.run --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' '*/external/*' '*/moc_*.cpp' '*/ui_*.h' '*/qrc_*.cpp' '*/src/gen/*' --output-file filtered.info --ignore-errors unused
+        fi
     - if: env.COVERAGE == 'true'
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -136,6 +136,9 @@ jobs:
       #
       # Run tests
       #
+    - if: env.COVERAGE == 'true' && matrix.compiler == 'gcc'
+      name: Initialize GCC coverage counters
+      run: cd build && lcov --zerocounters --directory .
     - name: Run unit tests
       run: cd build && ctest -V --no-compress-output -T test --output-junit ../ctest-to-junit-results.xml
       env:
@@ -164,10 +167,9 @@ jobs:
             LLVM_COV="xcrun llvm-cov"
           fi
           $LLVM_PROFDATA merge -sparse $PROFRAW_FILES -o coverage.profdata
-          OBJECT_FILES=$(find . -type f -name "mmapper" -o -name "Test*")
+          OBJECT_FILES=$(find . -type f -executable \( -name "mmapper" -o -name "Test*" \))
           $LLVM_COV export -format=lcov -instr-profile=coverage.profdata $OBJECT_FILES --ignore-filename-regex='.*/external/.*|.*/tests/.*|.*moc_.*\.cpp|.*ui_.*\.h|.*qrc_.*\.cpp' > filtered.info
         else # gcc
-          lcov --zerocounters --directory .
           lcov --directory . --capture --initial --output-file coverage.base
           lcov --directory . --capture --output-file coverage.run
           lcov --add-tracefile coverage.base --add-tracefile coverage.run --output-file coverage.info

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -162,12 +162,14 @@ jobs:
           if [ "${{ runner.os }}" = "Linux" ]; then
             LLVM_PROFDATA=llvm-profdata-18
             LLVM_COV=llvm-cov-18
+            FIND_EXEC_CMD="-executable"
           else # macOS
             LLVM_PROFDATA="xcrun llvm-profdata"
             LLVM_COV="xcrun llvm-cov"
+            FIND_EXEC_CMD="-perm -u+x"
           fi
           $LLVM_PROFDATA merge -sparse $PROFRAW_FILES -o coverage.profdata
-          OBJECT_FILES=$(find . -type f -perm +111 \( -name "mmapper" -o -name "Test*" \))
+          OBJECT_FILES=$(find . -type f ${FIND_EXEC_CMD} \( -name "mmapper" -o -name "Test*" \))
           $LLVM_COV export -format=lcov -instr-profile=coverage.profdata $OBJECT_FILES --ignore-filename-regex='.*/external/.*|.*/tests/.*|.*moc_.*\.cpp|.*ui_.*\.h|.*qrc_.*\.cpp' > filtered.info
         else # gcc
           lcov --directory . --capture --initial --output-file coverage.base

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -160,8 +160,8 @@ jobs:
             LLVM_PROFDATA=llvm-profdata-18
             LLVM_COV=llvm-cov-18
           else # macOS
-            LLVM_PROFDATA=llvm-profdata
-            LLVM_COV=llvm-cov
+            LLVM_PROFDATA="xcrun llvm-profdata"
+            LLVM_COV="xcrun llvm-cov"
           fi
           $LLVM_PROFDATA merge -sparse $PROFRAW_FILES -o coverage.profdata
           OBJECT_FILES=$(find . -type f -name "mmapper" -o -name "Test*")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,19 +191,32 @@ endif()
 
 # Code Coverage Configuration
 add_library(coverage_config INTERFACE)
-if(USE_CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+if(USE_CODE_COVERAGE)
     message(STATUS "Enabling code coverage reporting")
-    # Add required flags (GCC & LLVM/Clang)
-    target_compile_options(coverage_config INTERFACE
-        -O0        # no optimization
-        -g         # generate debug info
-        --coverage # sets all required flags
-        -fprofile-update=atomic
-    )
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
-        target_link_options(coverage_config INTERFACE --coverage)
-    else()
-        target_link_libraries(coverage_config INTERFACE --coverage)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(coverage_config INTERFACE
+            -O0 # no optimization
+            -g # generate debug info
+            -fprofile-instr-generate
+            -fcoverage-mapping
+        )
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+            target_link_options(coverage_config INTERFACE -fprofile-instr-generate)
+        else()
+            target_link_libraries(coverage_config INTERFACE -fprofile-instr-generate)
+        endif()
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        # Add required flags (GCC)
+        target_compile_options(coverage_config INTERFACE
+            -O0        # no optimization
+            -g         # generate debug info
+            --coverage # sets all required flags
+        )
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+            target_link_options(coverage_config INTERFACE --coverage)
+        else()
+            target_link_libraries(coverage_config INTERFACE --coverage)
+        endif()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ if(USE_CODE_COVERAGE)
             -O0        # no optimization
             -g         # generate debug info
             --coverage # sets all required flags
+            -fprofile-update=atomic
         )
         if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
             target_link_options(coverage_config INTERFACE --coverage)


### PR DESCRIPTION
Switches clang builds from using lcov to the native llvm-cov toolchain for generating code coverage information. This resolves a gcov version incompatibility error that was causing CI failures.

- Modifies CMakeLists.txt to use native clang coverage flags (-fprofile-instr-generate, -fcoverage-mapping).
- Updates the build-test.yml workflow to:
  - Use llvm-profdata and llvm-cov for clang builds on Linux and macOS.
  - Keep the existing lcov implementation for gcc builds.
  - Enable code coverage for macOS builds.
  - Remove lcov as a dependency for clang and macOS builds.