### PR TITLE
Fix Numpad Hotkey Mapping and Interception

### DIFF
--- a/src/client/Hotkey.cpp
+++ b/src/client/Hotkey.cpp
@@ -75,9 +75,10 @@ Hotkey::Hotkey(std::string_view s)
     *this = Hotkey(base, mods);
 }
 
-Hotkey::Hotkey(int key, Qt::KeyboardModifiers modifiers, bool isNumpad)
+Hotkey::Hotkey(int key, Qt::KeyboardModifiers modifiers, std::optional<bool> isNumpad)
 {
-    HotkeyEnum base = Hotkey::qtKeyToHotkeyBase(key, isNumpad);
+    bool numpad = isNumpad.value_or(modifiers.testFlag(Qt::KeypadModifier));
+    HotkeyEnum base = Hotkey::qtKeyToHotkeyBase(key, numpad);
     if (base == HotkeyEnum::INVALID) {
         return;
     }
@@ -142,6 +143,22 @@ uint8_t Hotkey::qtModifiersToMask(Qt::KeyboardModifiers mods)
 
 HotkeyEnum Hotkey::qtKeyToHotkeyBase(int key, bool isNumpad)
 {
+    if (isNumpad) {
+        switch (key) {
+        case Qt::Key_Home: return HotkeyEnum::NUMPAD7;
+        case Qt::Key_Up: return HotkeyEnum::NUMPAD8;
+        case Qt::Key_PageUp: return HotkeyEnum::NUMPAD9;
+        case Qt::Key_Left: return HotkeyEnum::NUMPAD4;
+        case Qt::Key_Clear: return HotkeyEnum::NUMPAD5;
+        case Qt::Key_Right: return HotkeyEnum::NUMPAD6;
+        case Qt::Key_End: return HotkeyEnum::NUMPAD1;
+        case Qt::Key_Down: return HotkeyEnum::NUMPAD2;
+        case Qt::Key_PageDown: return HotkeyEnum::NUMPAD3;
+        case Qt::Key_Insert: return HotkeyEnum::NUMPAD0;
+        case Qt::Key_Delete: return HotkeyEnum::NUMPAD_PERIOD;
+        }
+    }
+
 #define X_QT_CHECK(id, name, qkey, num) \
     if (key == qkey && isNumpad == num) \
         return HotkeyEnum::id;

--- a/src/client/Hotkey.h
+++ b/src/client/Hotkey.h
@@ -6,6 +6,7 @@
 #include "../global/macros.h"
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -179,7 +180,7 @@ public:
     Hotkey(const char *s)
         : Hotkey(std::string_view(s))
     {}
-    Hotkey(int key, Qt::KeyboardModifiers modifiers, bool isNumpad);
+    Hotkey(int key, Qt::KeyboardModifiers modifiers, std::optional<bool> isNumpad = std::nullopt);
 
     NODISCARD bool isValid() const { return m_hotkey != HotkeyEnum::INVALID; }
 

--- a/src/client/inputwidget.cpp
+++ b/src/client/inputwidget.cpp
@@ -367,7 +367,7 @@ bool InputWidget::event(QEvent *const event)
 {
     if (event->type() == QEvent::ShortcutOverride) {
         auto *const keyEvent = static_cast<QKeyEvent *>(event);
-        const Hotkey hk(keyEvent->key(), keyEvent->modifiers(), true);
+        const Hotkey hk(keyEvent->key(), keyEvent->modifiers());
         if (hk.isValid()) {
             // If it has modifiers, we try to handle it immediately in ShortcutOverride
             // because some modifier combinations might not result in a KeyPress event.

--- a/tests/TestHotkeyManager.cpp
+++ b/tests/TestHotkeyManager.cpp
@@ -313,6 +313,14 @@ void TestHotkeyManager::directLookupTest()
 
     // Test arrow keys (isNumpad=false)
     checkHk(Hotkey{Qt::Key_Up, (Qt::ShiftModifier | Qt::AltModifier), false}, "north");
+
+    // Test SHIFT+NUMPAD4 (NumLock ON) which often comes as Qt::Key_Left + Shift + Keypad
+    std::ignore = manager.setHotkey(Hotkey{"SHIFT+NUMPAD4"}, "pick west");
+    checkHk(Hotkey{Qt::Key_Left, (Qt::ShiftModifier | Qt::KeypadModifier)}, "pick west");
+
+    // Test NUMPAD8 (NumLock OFF) which comes as Qt::Key_Up + Keypad
+    std::ignore = manager.setHotkey(Hotkey{"NUMPAD8"}, "north");
+    checkHk(Hotkey{Qt::Key_Up, Qt::KeypadModifier}, "north");
 }
 
 QTEST_MAIN(TestHotkeyManager)


### PR DESCRIPTION
This change fixes an issue where numpad hotkeys (like Shift+Numpad4) were not being recognized, causing them to fall through to default widget behaviors like text selection.

The fix involves:
1. Enhancing `Hotkey::qtKeyToHotkeyBase` to map navigation keys to `NUMPAD` equivalents when the keypad modifier is set.
2. Updating the `Hotkey` constructor to automatically infer the `isNumpad` flag from `Qt::KeypadModifier`.
3. Updating `InputWidget` to use the improved constructor and correctly intercept these hotkeys in `ShortcutOverride`.
4. Adding unit tests for these specific numpad scenarios.

---
*PR created automatically by Jules for task [6676547914334653421](https://jules.google.com/task/6676547914334653421) started by @nschimme*