### PR TITLE
Fix Numpad hotkeys and block default behavior in InputWidget

### DIFF
--- a/src/client/Hotkey.cpp
+++ b/src/client/Hotkey.cpp
@@ -146,13 +146,12 @@ HotkeyEnum Hotkey::qtKeyToHotkeyBase(int key, bool isNumpad)
 #define X_QT_CHECK(id, qkey, num) \
     if (isNumpad == num && key == qkey) \
         return HotkeyEnum::id;
-
-    if (isNumpad) {
-        XFOREACH_HOTKEY_SECONDARY_MAPPINGS(X_QT_CHECK)
-    }
-
 #define X_BASE_QT_CHECK(id, name, qkey, num) X_QT_CHECK(id, qkey, num)
-    XFOREACH_HOTKEY_BASE_KEYS(X_BASE_QT_CHECK)
+#define S_QT_CHECK(id, qkey, num) X_QT_CHECK(id, qkey, num)
+
+    XFOREACH_HOTKEY_BASE_KEYS(X_BASE_QT_CHECK, S_QT_CHECK)
+
+#undef S_QT_CHECK
 #undef X_BASE_QT_CHECK
 #undef X_QT_CHECK
 
@@ -164,7 +163,9 @@ std::string Hotkey::hotkeyBaseToName(HotkeyEnum base)
 #define X_NAME_CHECK(id, name, qkey, num) \
     if (base == HotkeyEnum::id) \
         return name;
-    XFOREACH_HOTKEY_BASE_KEYS(X_NAME_CHECK)
+#define S_IGNORE(...)
+    XFOREACH_HOTKEY_BASE_KEYS(X_NAME_CHECK, S_IGNORE)
+#undef S_IGNORE
 #undef X_NAME_CHECK
     return {};
 }
@@ -176,18 +177,20 @@ HotkeyEnum Hotkey::nameToHotkeyBase(std::string_view name)
 #define X_NAME_TO_ENUM(id, str, qkey, num) \
     if (upperName == str) \
         return HotkeyEnum::id;
-    XFOREACH_HOTKEY_BASE_KEYS(X_NAME_TO_ENUM)
+#define S_IGNORE(...)
+    XFOREACH_HOTKEY_BASE_KEYS(X_NAME_TO_ENUM, S_IGNORE)
+#undef S_IGNORE
 #undef X_NAME_TO_ENUM
     return HotkeyEnum::INVALID;
 }
 
 std::vector<std::string> Hotkey::getAvailableKeyNames()
 {
-    return {
 #define X_STR(id, name, key, numpad) name,
-        XFOREACH_HOTKEY_BASE_KEYS(X_STR)
+#define S_IGNORE(...)
+    return {XFOREACH_HOTKEY_BASE_KEYS(X_STR, S_IGNORE)};
+#undef S_IGNORE
 #undef X_STR
-    };
 }
 
 std::vector<std::string> Hotkey::getAvailableModifiers()

--- a/src/client/Hotkey.cpp
+++ b/src/client/Hotkey.cpp
@@ -143,28 +143,19 @@ uint8_t Hotkey::qtModifiersToMask(Qt::KeyboardModifiers mods)
 
 HotkeyEnum Hotkey::qtKeyToHotkeyBase(int key, bool isNumpad)
 {
+#define X_QT_CHECK(id, qkey, num) \
+    if (isNumpad == num && key == qkey) \
+        return HotkeyEnum::id;
+
     if (isNumpad) {
-        switch (key) {
-        case Qt::Key_Up: return HotkeyEnum::NUMPAD8;
-        case Qt::Key_Down: return HotkeyEnum::NUMPAD2;
-        case Qt::Key_Left: return HotkeyEnum::NUMPAD4;
-        case Qt::Key_Right: return HotkeyEnum::NUMPAD6;
-        case Qt::Key_Home: return HotkeyEnum::NUMPAD7;
-        case Qt::Key_End: return HotkeyEnum::NUMPAD1;
-        case Qt::Key_PageUp: return HotkeyEnum::NUMPAD9;
-        case Qt::Key_PageDown: return HotkeyEnum::NUMPAD3;
-        case Qt::Key_Insert: return HotkeyEnum::NUMPAD0;
-        case Qt::Key_Delete: return HotkeyEnum::NUMPAD_PERIOD;
-        case Qt::Key_Clear: return HotkeyEnum::NUMPAD5;
-        default: break;
-        }
+        XFOREACH_HOTKEY_SECONDARY_MAPPINGS(X_QT_CHECK)
     }
 
-#define X_QT_CHECK(id, name, qkey, num) \
-    if (key == qkey && isNumpad == num) \
-        return HotkeyEnum::id;
-    XFOREACH_HOTKEY_BASE_KEYS(X_QT_CHECK)
+#define X_BASE_QT_CHECK(id, name, qkey, num) X_QT_CHECK(id, qkey, num)
+    XFOREACH_HOTKEY_BASE_KEYS(X_BASE_QT_CHECK)
+#undef X_BASE_QT_CHECK
 #undef X_QT_CHECK
+
     return HotkeyEnum::INVALID;
 }
 

--- a/src/client/Hotkey.cpp
+++ b/src/client/Hotkey.cpp
@@ -143,6 +143,23 @@ uint8_t Hotkey::qtModifiersToMask(Qt::KeyboardModifiers mods)
 
 HotkeyEnum Hotkey::qtKeyToHotkeyBase(int key, bool isNumpad)
 {
+    if (isNumpad) {
+        switch (key) {
+        case Qt::Key_Up: return HotkeyEnum::NUMPAD8;
+        case Qt::Key_Down: return HotkeyEnum::NUMPAD2;
+        case Qt::Key_Left: return HotkeyEnum::NUMPAD4;
+        case Qt::Key_Right: return HotkeyEnum::NUMPAD6;
+        case Qt::Key_Home: return HotkeyEnum::NUMPAD7;
+        case Qt::Key_End: return HotkeyEnum::NUMPAD1;
+        case Qt::Key_PageUp: return HotkeyEnum::NUMPAD9;
+        case Qt::Key_PageDown: return HotkeyEnum::NUMPAD3;
+        case Qt::Key_Insert: return HotkeyEnum::NUMPAD0;
+        case Qt::Key_Delete: return HotkeyEnum::NUMPAD_PERIOD;
+        case Qt::Key_Clear: return HotkeyEnum::NUMPAD5;
+        default: break;
+        }
+    }
+
 #define X_QT_CHECK(id, name, qkey, num) \
     if (key == qkey && isNumpad == num) \
         return HotkeyEnum::id;

--- a/src/client/Hotkey.h
+++ b/src/client/Hotkey.h
@@ -66,6 +66,20 @@
     X(HYPHEN, "HYPHEN", Qt::Key_Minus, false) \
     X(EQUAL, "EQUAL", Qt::Key_Equal, false)
 
+// Secondary mappings for Numpad keys (e.g. navigation keys)
+#define XFOREACH_HOTKEY_SECONDARY_MAPPINGS(X) \
+    X(NUMPAD8, Qt::Key_Up, true) \
+    X(NUMPAD2, Qt::Key_Down, true) \
+    X(NUMPAD4, Qt::Key_Left, true) \
+    X(NUMPAD6, Qt::Key_Right, true) \
+    X(NUMPAD7, Qt::Key_Home, true) \
+    X(NUMPAD1, Qt::Key_End, true) \
+    X(NUMPAD9, Qt::Key_PageUp, true) \
+    X(NUMPAD3, Qt::Key_PageDown, true) \
+    X(NUMPAD0, Qt::Key_Insert, true) \
+    X(NUMPAD_PERIOD, Qt::Key_Delete, true) \
+    X(NUMPAD5, Qt::Key_Clear, true)
+
 // Macro to define default hotkeys
 // X(SerializedKey, Command)
 #define XFOREACH_DEFAULT_HOTKEYS(X) \

--- a/src/client/Hotkey.h
+++ b/src/client/Hotkey.h
@@ -14,8 +14,14 @@
 #include <Qt>
 
 // Macro to define all supported base keys and their Qt mappings.
+//
 // X(EnumName, StringName, QtKey, IsNumpad) -> Defines a unique identity
 // S(EnumName, QtKey, IsNumpad)             -> Defines an additional mapping (alias)
+//
+// Secondary mappings (aliases) are needed because Qt often reports navigation keys
+// (e.g. Qt::Key_Left instead of Qt::Key_4) for Numpad keys when Shift is held or
+// NumLock is off, but it still includes the Qt::KeypadModifier. Aliases allow
+// these events to be correctly mapped back to the NUMPAD hotkey identity.
 #define XFOREACH_HOTKEY_BASE_KEYS(X, S) \
     X(F1, "F1", Qt::Key_F1, false) \
     X(F2, "F2", Qt::Key_F2, false) \

--- a/src/client/Hotkey.h
+++ b/src/client/Hotkey.h
@@ -13,9 +13,10 @@
 #include <QString>
 #include <Qt>
 
-// Macro to define all supported base keys
-// X(EnumName, StringName, QtKey, IsNumpad)
-#define XFOREACH_HOTKEY_BASE_KEYS(X) \
+// Macro to define all supported base keys and their Qt mappings.
+// X(EnumName, StringName, QtKey, IsNumpad) -> Defines a unique identity
+// S(EnumName, QtKey, IsNumpad)             -> Defines an additional mapping (alias)
+#define XFOREACH_HOTKEY_BASE_KEYS(X, S) \
     X(F1, "F1", Qt::Key_F1, false) \
     X(F2, "F2", Qt::Key_F2, false) \
     X(F3, "F3", Qt::Key_F3, false) \
@@ -29,20 +30,31 @@
     X(F11, "F11", Qt::Key_F11, false) \
     X(F12, "F12", Qt::Key_F12, false) \
     X(NUMPAD0, "NUMPAD0", Qt::Key_0, true) \
+    S(NUMPAD0, Qt::Key_Insert, true) \
     X(NUMPAD1, "NUMPAD1", Qt::Key_1, true) \
+    S(NUMPAD1, Qt::Key_End, true) \
     X(NUMPAD2, "NUMPAD2", Qt::Key_2, true) \
+    S(NUMPAD2, Qt::Key_Down, true) \
     X(NUMPAD3, "NUMPAD3", Qt::Key_3, true) \
+    S(NUMPAD3, Qt::Key_PageDown, true) \
     X(NUMPAD4, "NUMPAD4", Qt::Key_4, true) \
+    S(NUMPAD4, Qt::Key_Left, true) \
     X(NUMPAD5, "NUMPAD5", Qt::Key_5, true) \
+    S(NUMPAD5, Qt::Key_Clear, true) \
     X(NUMPAD6, "NUMPAD6", Qt::Key_6, true) \
+    S(NUMPAD6, Qt::Key_Right, true) \
     X(NUMPAD7, "NUMPAD7", Qt::Key_7, true) \
+    S(NUMPAD7, Qt::Key_Home, true) \
     X(NUMPAD8, "NUMPAD8", Qt::Key_8, true) \
+    S(NUMPAD8, Qt::Key_Up, true) \
     X(NUMPAD9, "NUMPAD9", Qt::Key_9, true) \
+    S(NUMPAD9, Qt::Key_PageUp, true) \
     X(NUMPAD_SLASH, "NUMPAD_SLASH", Qt::Key_Slash, true) \
     X(NUMPAD_ASTERISK, "NUMPAD_ASTERISK", Qt::Key_Asterisk, true) \
     X(NUMPAD_MINUS, "NUMPAD_MINUS", Qt::Key_Minus, true) \
     X(NUMPAD_PLUS, "NUMPAD_PLUS", Qt::Key_Plus, true) \
     X(NUMPAD_PERIOD, "NUMPAD_PERIOD", Qt::Key_Period, true) \
+    S(NUMPAD_PERIOD, Qt::Key_Delete, true) \
     X(HOME, "HOME", Qt::Key_Home, false) \
     X(END, "END", Qt::Key_End, false) \
     X(INSERT, "INSERT", Qt::Key_Insert, false) \
@@ -65,20 +77,6 @@
     X(K_9, "9", Qt::Key_9, false) \
     X(HYPHEN, "HYPHEN", Qt::Key_Minus, false) \
     X(EQUAL, "EQUAL", Qt::Key_Equal, false)
-
-// Secondary mappings for Numpad keys (e.g. navigation keys)
-#define XFOREACH_HOTKEY_SECONDARY_MAPPINGS(X) \
-    X(NUMPAD8, Qt::Key_Up, true) \
-    X(NUMPAD2, Qt::Key_Down, true) \
-    X(NUMPAD4, Qt::Key_Left, true) \
-    X(NUMPAD6, Qt::Key_Right, true) \
-    X(NUMPAD7, Qt::Key_Home, true) \
-    X(NUMPAD1, Qt::Key_End, true) \
-    X(NUMPAD9, Qt::Key_PageUp, true) \
-    X(NUMPAD3, Qt::Key_PageDown, true) \
-    X(NUMPAD0, Qt::Key_Insert, true) \
-    X(NUMPAD_PERIOD, Qt::Key_Delete, true) \
-    X(NUMPAD5, Qt::Key_Clear, true)
 
 // Macro to define default hotkeys
 // X(SerializedKey, Command)
@@ -138,8 +136,11 @@
 #define PERMUTE_3(key) PERMUTE_2(key) PERMUTE_2(ALT_##key)
 #define PERMUTE_4(key) PERMUTE_3(key) PERMUTE_3(META_##key)
 #define X_GENERATE_ALL_MODS(id, name, key, numpad) PERMUTE_4(id)
+#define S_IGNORE(...)
 
-enum class HotkeyEnum : uint16_t { XFOREACH_HOTKEY_BASE_KEYS(X_GENERATE_ALL_MODS) INVALID };
+enum class HotkeyEnum : uint16_t {
+    XFOREACH_HOTKEY_BASE_KEYS(X_GENERATE_ALL_MODS, S_IGNORE) INVALID
+};
 
 #undef PERMUTE_0
 #undef PERMUTE_1
@@ -147,11 +148,14 @@ enum class HotkeyEnum : uint16_t { XFOREACH_HOTKEY_BASE_KEYS(X_GENERATE_ALL_MODS
 #undef PERMUTE_3
 #undef PERMUTE_4
 #undef X_GENERATE_ALL_MODS
+#undef S_IGNORE
 
 namespace {
 #define X_COUNT_BASE(id, name, key, numpad) +1
-static constexpr int NUM_BASES = 0 XFOREACH_HOTKEY_BASE_KEYS(X_COUNT_BASE);
+#define S_IGNORE(...)
+static constexpr int NUM_BASES = 0 XFOREACH_HOTKEY_BASE_KEYS(X_COUNT_BASE, S_IGNORE);
 #undef X_COUNT_BASE
+#undef S_IGNORE
 #define X_COUNT_MODS(name, modifier, shift) +1
 static constexpr int NUM_MOD_BITS = 0 XFOREACH_HOTKEY_MODIFIER(X_COUNT_MODS);
 #undef X_COUNT_MODS
@@ -171,8 +175,10 @@ constexpr bool isUppercase(const char *s)
 }
 #define X_CHECK_UPPER(id, name, qkey, num) \
     static_assert(isUppercase(name), "Hotkey name must be uppercase: " name);
-XFOREACH_HOTKEY_BASE_KEYS(X_CHECK_UPPER)
+#define S_IGNORE(...)
+XFOREACH_HOTKEY_BASE_KEYS(X_CHECK_UPPER, S_IGNORE)
 #undef X_CHECK_UPPER
+#undef S_IGNORE
 } // namespace
 
 class NODISCARD Hotkey final

--- a/src/client/HotkeyManager.cpp
+++ b/src/client/HotkeyManager.cpp
@@ -14,6 +14,9 @@ HotkeyManager::HotkeyManager()
     setConfig().hotkeys.registerChangeCallback(m_configLifetime,
                                                [this]() { this->syncFromConfig(); });
     syncFromConfig();
+    if (m_hotkeys.empty()) {
+        resetToDefaults();
+    }
 }
 
 void HotkeyManager::syncFromConfig()
@@ -25,9 +28,6 @@ void HotkeyManager::syncFromConfig()
         if (hk.isValid()) {
             m_hotkeys[hk.toEnum()] = mmqt::toStdStringUtf8(it.value().toString());
         }
-    }
-    if (m_hotkeys.empty()) {
-        resetToDefaults();
     }
 }
 
@@ -81,7 +81,6 @@ std::vector<std::pair<Hotkey, std::string>> HotkeyManager::getAllHotkeys() const
 
 void HotkeyManager::resetToDefaults()
 {
-    m_hotkeys.clear();
     QVariantMap data;
 #define X_DEFAULT(key, cmd) data[key] = QString(cmd);
     XFOREACH_DEFAULT_HOTKEYS(X_DEFAULT)
@@ -91,6 +90,5 @@ void HotkeyManager::resetToDefaults()
 
 void HotkeyManager::clear()
 {
-    m_hotkeys.clear();
     setConfig().hotkeys.setData(QVariantMap());
 }

--- a/src/client/inputwidget.cpp
+++ b/src/client/inputwidget.cpp
@@ -94,11 +94,19 @@ void InputWidget::keyPressEvent(QKeyEvent *const event)
     }
 
     // 1. Try Hotkeys FIRST
-    const auto base = Hotkey::qtKeyToHotkeyBase(key, mods & Qt::KeypadModifier);
+    const bool isNumpad = mods & Qt::KeypadModifier;
+    const auto base = Hotkey::qtKeyToHotkeyBase(key, isNumpad);
     if (base != HotkeyEnum::INVALID) {
         const Hotkey hk(base, Hotkey::qtModifiersToMask(mods));
         if (auto command = m_outputs.getHotkey(hk)) {
             sendCommandWithSeparator(*command);
+            event->accept();
+            return;
+        }
+
+        // Always block Numpad keys from falling through to default behavior
+        // (like text selection or history navigation) even if no hotkey is bound.
+        if (isNumpad) {
             event->accept();
             return;
         }

--- a/src/parser/AbstractParser-Hotkey.cpp
+++ b/src/parser/AbstractParser-Hotkey.cpp
@@ -100,8 +100,16 @@ std::string getInstructionalError(std::string_view keyCombo)
         error += "Invalid key combo.\n";
     }
 
-    error += "Valid modifiers: CTRL, SHIFT, ALT, META\n";
-    error += "Valid keys include: F1-F12, 0-9, UP, DOWN, etc.\n";
+    error += "Valid modifiers: ";
+    for (size_t i = 0; i < validMods.size(); ++i) {
+        error += validMods[i] + (i == validMods.size() - 1 ? "" : ", ");
+    }
+    error += "\nValid keys include: ";
+    std::sort(validKeys.begin(), validKeys.end());
+    for (size_t i = 0; i < std::min<size_t>(validKeys.size(), 10); ++i) {
+        error += validKeys[i] + ", ";
+    }
+    error += "etc.\n";
     return error;
 }
 } // namespace
@@ -197,9 +205,15 @@ void AbstractParser::parseHotkey(StringView input)
            << "  -hotkey bind <key_combo> <command>\n"
            << "  -hotkey list\n"
            << "  -hotkey unbind <key_combo>\n"
-           << "\n"
-           << "Valid modifiers: CTRL, SHIFT, ALT, META\n" // TODO: Change this to be programmatic
-           << "Valid keys:\n";
+           << "\n";
+
+        os << "Valid modifiers: ";
+        auto mods = Hotkey::getAvailableModifiers();
+        for (size_t i = 0; i < mods.size(); ++i) {
+            os << mods[i] << (i == mods.size() - 1 ? "" : ", ");
+        }
+
+        os << "\nValid keys:\n";
 
         // Programmatically list all valid keys
         auto keys = Hotkey::getAvailableKeyNames();

--- a/src/parser/AbstractParser-Hotkey.cpp
+++ b/src/parser/AbstractParser-Hotkey.cpp
@@ -71,21 +71,16 @@ std::string getInstructionalError(std::string_view keyCombo)
 
     for (const auto &part : parts) {
         const std::string p = toUpperUtf8(part);
-        for (const auto &vm : validMods) {
-            if (p == vm) {
-                continue;
-            }
+
+        auto isMatch = [&](const auto &list) {
+            return std::any_of(list.begin(), list.end(), [&](const auto &s) { return p == s; });
+        };
+
+        if (isMatch(validMods)) {
+            continue;
         }
 
-        bool found = false;
-        for (const auto &vk : validKeys) {
-            if (p == vk) {
-                found = true;
-                break;
-            }
-        }
-
-        if (!found) {
+        if (!isMatch(validKeys)) {
             unrecognized = part;
             break;
         }

--- a/tests/TestHotkeyManager.cpp
+++ b/tests/TestHotkeyManager.cpp
@@ -48,21 +48,18 @@ void TestHotkeyManager::keyNormalizationTest()
     HotkeyManager manager;
     manager.clear();
 
-    // Test all base keys defined in macro
+    // Test all base keys and secondary mappings defined in macro
 #define X_TEST_KEY(id, name, qkey, num) \
     QVERIFY(manager.setHotkey(Hotkey{name}, "cmd_" name)); \
     checkHk(manager, Hotkey{name}, "cmd_" name); \
     checkHk(manager, Hotkey{qkey, num ? Qt::KeypadModifier : Qt::NoModifier}, "cmd_" name);
 
-    XFOREACH_HOTKEY_BASE_KEYS(X_TEST_KEY)
-#undef X_TEST_KEY
-
-    // Test secondary Numpad navigation mappings
-#define X_TEST_SECONDARY(id, qkey, num) \
+#define S_TEST_KEY(id, qkey, num) \
     checkHk(manager, Hotkey{qkey, num ? Qt::KeypadModifier : Qt::NoModifier}, "cmd_" #id);
 
-    XFOREACH_HOTKEY_SECONDARY_MAPPINGS(X_TEST_SECONDARY)
-#undef X_TEST_SECONDARY
+    XFOREACH_HOTKEY_BASE_KEYS(X_TEST_KEY, S_TEST_KEY)
+#undef X_TEST_KEY
+#undef S_TEST_KEY
 
     // Test that modifiers are normalized to canonical order: SHIFT+CTRL+ALT+META
 

--- a/tests/TestHotkeyManager.h
+++ b/tests/TestHotkeyManager.h
@@ -6,6 +6,9 @@
 
 #include <QObject>
 
+class Hotkey;
+class HotkeyManager;
+
 class NODISCARD_QOBJECT TestHotkeyManager final : public QObject
 {
     Q_OBJECT
@@ -33,6 +36,9 @@ private Q_SLOTS:
     void commentPreservationTest();
     void settingsPersistenceTest();
     void directLookupTest();
+
+private:
+    void checkHk(const HotkeyManager &manager, const Hotkey &hk, std::string_view expected);
 
 private:
     // Original QSettings namespace (restored in cleanupTestCase)


### PR DESCRIPTION
Fixed the issue where SHIFT+NUMPAD4/8 were selecting text instead of running hotkeys. Improved Numpad key mapping in `Hotkey::qtKeyToHotkeyBase` to handle navigation keys with `KeypadModifier`. Updated `InputWidget` to block default behavior for all Numpad keys. Also fixed a recursion bug in `HotkeyManager`.

---
*PR created automatically by Jules for task [16042774527781443040](https://jules.google.com/task/16042774527781443040) started by @nschimme*