### PR TITLE
Refactor Hotkey system to use separate modifiers and hash on Hotkey

### DIFF
--- a/src/client/HotkeyManager.cpp
+++ b/src/client/HotkeyManager.cpp
@@ -26,7 +26,7 @@ void HotkeyManager::syncFromConfig()
     for (auto it = data.begin(); it != data.end(); ++it) {
         Hotkey hk(it.key());
         if (hk.isValid()) {
-            m_hotkeys[hk.toEnum()] = mmqt::toStdStringUtf8(it.value().toString());
+            m_hotkeys[hk] = mmqt::toStdStringUtf8(it.value().toString());
         }
     }
 }
@@ -58,7 +58,7 @@ std::optional<std::string> HotkeyManager::getCommand(const Hotkey &hk) const
         return std::nullopt;
     }
 
-    auto it = m_hotkeys.find(hk.toEnum());
+    auto it = m_hotkeys.find(hk);
     if (it == m_hotkeys.end()) {
         return std::nullopt;
     }
@@ -73,8 +73,8 @@ bool HotkeyManager::hasHotkey(const Hotkey &hk) const
 std::vector<std::pair<Hotkey, std::string>> HotkeyManager::getAllHotkeys() const
 {
     std::vector<std::pair<Hotkey, std::string>> result;
-    for (const auto &[key, cmd] : m_hotkeys) {
-        result.emplace_back(Hotkey(key), cmd);
+    for (const auto &[hk, cmd] : m_hotkeys) {
+        result.emplace_back(hk, cmd);
     }
     return result;
 }

--- a/src/client/HotkeyManager.h
+++ b/src/client/HotkeyManager.h
@@ -18,7 +18,7 @@
 class NODISCARD HotkeyManager final
 {
 private:
-    std::unordered_map<HotkeyEnum, std::string> m_hotkeys;
+    std::unordered_map<Hotkey, std::string> m_hotkeys;
     ChangeMonitor::Lifetime m_configLifetime;
 
 public:


### PR DESCRIPTION
This refactoring addresses the issue where HotkeyEnum was used to store both base keys and their modifier permutations, which was fragile and confusing. By separating the base key (HotkeyEnum) from its modifiers (using the Flags.h utility), we improve type safety. The HotkeyManager now correctly hashes on the Hotkey object itself. Existing configuration strings remain compatible.

---
*PR created automatically by Jules for task [10654777732842826616](https://jules.google.com/task/10654777732842826616) started by @nschimme*