### PR TITLE
Fix WebAssembly black screen issue on Firefox/ANGLE

### DIFF
--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -655,7 +655,7 @@ void MapCanvas::actuallyPaintGL()
     paintDifferences();
 
     gl.releaseFbo();
-    gl.blitFboToDefault();
+    gl.blitFboToDefault(defaultFramebufferObject());
 }
 
 NODISCARD bool MapCanvas::Diff::isUpToDate(const Map &saved, const Map &current) const

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -81,9 +81,9 @@ void OpenGL::releaseFbo()
     getFunctions().releaseFbo();
 }
 
-void OpenGL::blitFboToDefault()
+void OpenGL::blitFboToDefault(GLuint targetFbo)
 {
-    getFunctions().blitFboToDefault();
+    getFunctions().blitFboToDefault(targetFbo);
 }
 
 UniqueMesh OpenGL::createPointBatch(const std::vector<ColorVert> &batch)

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -63,7 +63,7 @@ public:
     void configureFbo(int samples);
     void bindFbo();
     void releaseFbo();
-    void blitFboToDefault();
+    void blitFboToDefault(GLuint targetFbo);
 
 public:
     NODISCARD UniqueMesh createPointBatch(const std::vector<ColorVert> &verts);

--- a/src/opengl/legacy/FBO.cpp
+++ b/src/opengl/legacy/FBO.cpp
@@ -5,6 +5,7 @@
 
 #include "../../global/logging.h"
 #include "../OpenGLConfig.h"
+#include "Legacy.h"
 
 namespace Legacy {
 
@@ -81,7 +82,7 @@ void FBO::release()
     }
 }
 
-void FBO::blitToDefault()
+void FBO::blitTo(Functions &gl, GLuint targetFbo)
 {
     if (!m_resolvedFbo) {
         return; // Nothing to blit from
@@ -95,11 +96,23 @@ void FBO::blitToDefault()
                                                   GL_LINEAR);
     }
 
-    // Now blit the (potentially resolved) FBO to the default framebuffer.
-    QOpenGLFramebufferObject::blitFramebuffer(nullptr,
-                                              m_resolvedFbo.get(),
-                                              GL_COLOR_BUFFER_BIT,
-                                              GL_NEAREST);
+    // Now blit the (potentially resolved) FBO to the target framebuffer.
+    const QSize size = m_resolvedFbo->size();
+    gl.glBindFramebuffer(GL_READ_FRAMEBUFFER, m_resolvedFbo->handle());
+    gl.glBindFramebuffer(GL_DRAW_FRAMEBUFFER, targetFbo);
+    gl.glBlitFramebuffer(0,
+                         0,
+                         size.width(),
+                         size.height(),
+                         0,
+                         0,
+                         size.width(),
+                         size.height(),
+                         GL_COLOR_BUFFER_BIT,
+                         GL_NEAREST);
+
+    // Restore the binding to the target FBO
+    gl.glBindFramebuffer(GL_FRAMEBUFFER, targetFbo);
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/FBO.h
+++ b/src/opengl/legacy/FBO.h
@@ -12,6 +12,8 @@
 
 namespace Legacy {
 
+class Functions;
+
 extern bool LOG_FBO_ALLOCATIONS;
 
 class FBO final
@@ -25,7 +27,7 @@ public:
     void configure(const Viewport &physicalViewport, int samples);
     void bind();
     void release();
-    void blitToDefault();
+    void blitTo(Functions &gl, GLuint targetFbo);
 
 private:
     std::unique_ptr<QOpenGLFramebufferObject> m_multisamplingFbo;

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -339,9 +339,9 @@ void Functions::releaseFbo()
     getFBO().release();
 }
 
-void Functions::blitFboToDefault()
+void Functions::blitFboToDefault(GLuint targetFbo)
 {
-    getFBO().blitToDefault();
+    getFBO().blitTo(*this, targetFbo);
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -140,10 +140,12 @@ public:
     using Base::glActiveTexture;
     using Base::glAttachShader;
     using Base::glBindBuffer;
+    using Base::glBindFramebuffer;
     using Base::glBindTexture;
     using Base::glBindVertexArray;
     using Base::glBlendFunc;
     using Base::glBlendFuncSeparate;
+    using Base::glBlitFramebuffer;
     using Base::glBufferData;
     using Base::glClear;
     using Base::glClearColor;
@@ -361,6 +363,6 @@ public:
     void configureFbo(int samples);
     void bindFbo();
     void releaseFbo();
-    void blitFboToDefault();
+    void blitFboToDefault(GLuint targetFbo);
 };
 } // namespace Legacy


### PR DESCRIPTION
The MapCanvas (a QOpenGLWidget) was manually blitting its multisampled/resolved FBO content to the system default framebuffer (FBO 0). On WebAssembly, FBO 0 represents the entire HTML canvas for the application. This resulted in the map's rendering (or lack thereof) being stretched over the whole page, covering other UI elements.

This PR:
1. Modifies the low-level `Legacy::FBO` to support blitting to a specific `targetFbo` handle using `glBlitFramebuffer`.
2. Updates `Legacy::Functions` and the `OpenGL` wrapper to propagate the target FBO handle.
3. Updates `MapCanvas::actuallyPaintGL` to pass the widget's `defaultFramebufferObject()` instead of `0`.
4. Exposes `glBindFramebuffer` and `glBlitFramebuffer` as public methods in `Legacy::Functions` to allow helper classes to perform the blit.

This fix ensures that the widget's content is correctly confined to its own area as managed by Qt's compositing system on WebAssembly.

---
*PR created automatically by Jules for task [10718340901010817310](https://jules.google.com/task/10718340901010817310) started by @nschimme*