### PR TITLE
Upgrade Snap build to core24

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-snap:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v6
@@ -22,7 +22,7 @@ jobs:
       id: snapcraft
       uses: snapcore/action-build@v1
 
-    - name: Generate SHA256 checksum for AppImage
+    - name: Generate SHA256 checksum for Snap
       run: |
         BUILT_SNAP_PATH="${{ steps.snapcraft.outputs.snap }}"
         CANONICAL_SNAP_BASENAME=$(basename "${BUILT_SNAP_PATH}" .snap)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -71,9 +71,17 @@ parts:
       - duktape-dev
       - libproxy-dev
       - libsecret-1-dev
+      - libzstd-dev
+      - libkrb5-dev
     stage-packages:
       - libssl3t64
       - zlib1g
+      - libduktape207
+      - libproxy1v5
+      - libsecret-1-0
+      - libxkbcommon0
+      - libzstd1
+      - libgssapi-krb5-2
     override-pull: |
       craftctl default
       craftctl set version=$(git describe --tags --always --long --exclude beta | sed 's/^v//')
@@ -87,7 +95,7 @@ parts:
       - -usr/share/ECM/*
       - -usr/share/man/*
       - -usr/bin/X11
-      - -usr/lib/gcc/$CRAFT_ARCH_TRIPLET_BUILD_FOR/6.0.0
+      - -usr/lib/gcc/*/6.0.0
       - -usr/lib/aspell/*
       - -usr/share/lintian
   gpu-2404:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,7 +11,7 @@ description: |
 
 grade: stable
 confinement: strict
-base: core22
+base: core24
 compression: lzo
 
 architectures:
@@ -20,7 +20,7 @@ architectures:
 
 apps:
   mmapper:
-    command: usr/bin/mmapper
+    command: bin/gpu-2404-wrapper usr/bin/mmapper
     common-id: org.mume.MMapper
     desktop: usr/share/applications/org.mume.MMapper.desktop
     extensions:
@@ -31,16 +31,6 @@ apps:
       - network-bind
       - opengl
 
-package-repositories:
-  - type: apt
-    components:
-      - main
-    suites:
-      - jammy
-    key-id: 444DABCF3667D0283F894EDDE6D4736255751E5D
-    url: http://origin.archive.neon.kde.org/user
-    key-server: keyserver.ubuntu.com
-
 parts:
   mmapper:
     parse-info:
@@ -48,6 +38,9 @@ parts:
     plugin: cmake
     source: .
     source-type: local
+    build-snaps:
+      - kde-qt6-core24-sdk/latest/beta
+      - kf6-core24-sdk/latest/beta
     cmake-generator: Ninja
     cmake-parameters:
       - -DPACKAGE_TYPE=Snap
@@ -70,7 +63,7 @@ parts:
       - libssl-dev
       - zlib1g-dev
     stage-packages:
-      - libssl3
+      - libssl3t64
       - zlib1g
     override-pull: |
       craftctl default
@@ -80,6 +73,7 @@ parts:
       sed -i 's|Icon=org.mume.MMapper|Icon=${SNAP}/usr/share/icons/hicolor/256x256/apps/org.mume.MMapper.png|g' $CRAFT_PART_INSTALL/usr/share/applications/org.mume.MMapper.desktop
     prime:
       - -usr/lib/*/cmake/*
+      - -usr/lib/*/pkgconfig/*
       - -usr/include/*
       - -usr/share/ECM/*
       - -usr/share/man/*
@@ -87,15 +81,25 @@ parts:
       - -usr/lib/gcc/$CRAFT_ARCH_TRIPLET_BUILD_FOR/6.0.0
       - -usr/lib/aspell/*
       - -usr/share/lintian
+  gpu-2404:
+    after: [mmapper]
+    source: https://github.com/canonical/gpu-snap.git
+    plugin: dump
+    override-prime: |
+      craftctl default
+      ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404
+    prime:
+      - bin/gpu-2404-wrapper
   cleanup:
     after:
       - mmapper
+      - gpu-2404
     plugin: nil
     build-snaps:
-      - core22
-      - kf6-core22
+      - core24
+      - kf6-core24
     override-prime: |
       set -eux
-      for snap in "core22" "kf6-core22"; do
+      for snap in "core24" "kf6-core24"; do
           cd "/snap/$snap/current" && find . -type f,l -exec rm -rf "${CRAFT_PRIME}/{}" \;
       done

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -20,7 +20,7 @@ platforms:
 
 apps:
   mmapper:
-    command: bin/gpu-2404-wrapper usr/bin/mmapper
+    command: usr/bin/mmapper
     common-id: org.mume.MMapper
     desktop: usr/share/applications/org.mume.MMapper.desktop
     extensions:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,8 +39,8 @@ parts:
     source: .
     source-type: local
     build-snaps:
-      - kde-qt6-core24-sdk/latest/beta
-      - kf6-core24-sdk/latest/beta
+      - kde-qt6-core24-sdk/latest/stable
+      - kf6-core24-sdk/latest/stable
     cmake-generator: Ninja
     cmake-parameters:
       - -DPACKAGE_TYPE=Snap

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -68,7 +68,7 @@ parts:
       - libgl-dev
       - libegl-dev
       - libvulkan-dev
-      - libduktape-dev
+      - duktape-dev
       - libproxy-dev
       - libsecret-1-dev
     stage-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -68,6 +68,9 @@ parts:
       - libgl-dev
       - libegl-dev
       - libvulkan-dev
+      - libduktape-dev
+      - libproxy-dev
+      - libsecret-1-dev
     stage-packages:
       - libssl3t64
       - zlib1g

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -62,6 +62,10 @@ parts:
       - libglm-dev
       - libssl-dev
       - zlib1g-dev
+      - libxkbcommon-dev
+      - libgl-dev
+      - libegl-dev
+      - libvulkan-dev
     stage-packages:
       - libssl3t64
       - zlib1g

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -30,6 +30,8 @@ apps:
       - network
       - network-bind
       - opengl
+      - wayland
+      - x11
 
 parts:
   mmapper:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,9 +14,9 @@ confinement: strict
 base: core24
 compression: lzo
 
-architectures:
-  - build-on: arm64
-  - build-on: amd64
+platforms:
+  amd64:
+  arm64:
 
 apps:
   mmapper:


### PR DESCRIPTION
This change upgrades the Snap build configuration from core22 to core24, aligning with modern Snapcraft practices for Qt6/KF6 applications. It removes the legacy apt-based repository configuration in favor of official SDK snaps and incorporates the gpu-2404 wrapper for better graphics hardware support. The GitHub Actions workflow is also updated to use the ubuntu-24.04 runner.

---
*PR created automatically by Jules for task [3626927021872022359](https://jules.google.com/task/3626927021872022359) started by @nschimme*