### PR TITLE
Refactor line rendering in Characters.cpp using instanced shader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,31 +75,36 @@ if(Qt6Core_FOUND)
 endif()
 
 if(Qt6OpenGL_FOUND)
-    file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtGLES30.cpp
-        "#include <QOpenGLExtraFunctions>
-        #ifndef GL_TRIANGLES
-        # error
-        #endif
-        #ifdef Q_OS_MAC
-        # error
-        #endif
-        int main(int argc, char** argv) { return 0; }")
-    try_compile(QT_HAS_GLES
-                    ${CMAKE_BINARY_DIR}
-                    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtGLES30.cpp
-                    LINK_LIBRARIES Qt6::OpenGL
-                    OUTPUT_VARIABLE OUTPUT)
-    file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtOpenGL33.cpp
-        "#include <QOpenGLFunctions_3_3_Core>
-        #ifndef GL_QUADS
-        # error
-        #endif
-        int main(int argc, char** argv) { return 0; }")
-    try_compile(QT_HAS_OPENGL
-                    ${CMAKE_BINARY_DIR}
-                    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtOpenGL33.cpp
-                    LINK_LIBRARIES Qt6::OpenGL
-                    OUTPUT_VARIABLE OUTPUT)
+    if(EMSCRIPTEN)
+        set(QT_HAS_GLES TRUE)
+        set(QT_HAS_OPENGL FALSE)
+    else()
+        file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtGLES30.cpp
+            "#include <QOpenGLExtraFunctions>
+            #ifndef GL_TRIANGLES
+            # error
+            #endif
+            #ifdef Q_OS_MAC
+            # error
+            #endif
+            int main(int argc, char** argv) { return 0; }")
+        try_compile(QT_HAS_GLES
+                        ${CMAKE_BINARY_DIR}
+                        ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtGLES30.cpp
+                        LINK_LIBRARIES Qt6::OpenGL
+                        OUTPUT_VARIABLE OUTPUT)
+        file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtOpenGL33.cpp
+            "#include <QOpenGLFunctions_3_3_Core>
+            #ifndef GL_QUADS
+            # error
+            #endif
+            int main(int argc, char** argv) { return 0; }")
+        try_compile(QT_HAS_OPENGL
+                        ${CMAKE_BINARY_DIR}
+                        ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtOpenGL33.cpp
+                        LINK_LIBRARIES Qt6::OpenGL
+                        OUTPUT_VARIABLE OUTPUT)
+    endif()
     if (NOT QT_HAS_GLES)
         add_definitions(/DMMAPPER_NO_GLES)
     endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -682,8 +682,14 @@ set(mmapper_EXECUTABLE_ARGS
 )
 if(EMSCRIPTEN)
     qt_add_executable(mmapper ${mmapper_EXECUTABLE_ARGS})
-    target_link_options(mmapper PRIVATE -s FULL_ES3=1)
-    target_link_options(mmapper PUBLIC -sASYNCIFY -Os)
+    target_link_options(mmapper PRIVATE
+        -sFULL_ES3=1
+        -sMAX_WEBGL_VERSION=2
+        -sMIN_WEBGL_VERSION=2
+        -sASSERTIONS
+        -sASYNCIFY
+        -Os
+    )
     target_link_libraries(mmapper PUBLIC z)
 else()
     add_executable(mmapper WIN32 MACOSX_BUNDLE ${mmapper_EXECUTABLE_ARGS})

--- a/src/display/Characters.cpp
+++ b/src/display/Characters.cpp
@@ -212,17 +212,10 @@ void CharacterBatch::CharFakeGL::drawQuadCommon(const glm::vec2 &in_a,
 
     if (::utils::isSet(options, QuadOptsEnum::OUTLINE)) {
         const auto color = m_color.withAlpha(LINE_ALPHA);
-        auto emitVert = [this, &color](const auto &x) -> void {
-            m_charLines.emplace_back(color, x);
-        };
-        auto emitLine = [&emitVert](const auto &v0, const auto &v1) -> void {
-            emitVert(v0);
-            emitVert(v1);
-        };
-        emitLine(a, b);
-        emitLine(b, c);
-        emitLine(c, d);
-        emitLine(d, a);
+        m_charLines.emplace_back(color, a, b, CHAR_ARROW_LINE_WIDTH);
+        m_charLines.emplace_back(color, b, c, CHAR_ARROW_LINE_WIDTH);
+        m_charLines.emplace_back(color, c, d, CHAR_ARROW_LINE_WIDTH);
+        m_charLines.emplace_back(color, d, a, CHAR_ARROW_LINE_WIDTH);
     }
 }
 
@@ -338,8 +331,7 @@ void CharacterBatch::CharFakeGL::reallyDrawCharacters(OpenGL &gl, const MapCanva
     }
 
     if (!m_charLines.empty()) {
-        gl.renderColoredLines(m_charLines,
-                              blended_noDepth.withLineParams(LineParams{CHAR_ARROW_LINE_WIDTH}));
+        gl.renderLineInstances(m_charLines, blended_noDepth);
     }
 
     if (!m_screenSpaceArrows.empty()) {

--- a/src/display/Characters.h
+++ b/src/display/Characters.h
@@ -102,7 +102,7 @@ private:
         MatrixStack m_stack;
         std::vector<ColorVert> m_charTris;
         std::vector<ColorVert> m_charBeaconQuads;
-        std::vector<ColorVert> m_charLines;
+        std::vector<LineInstance> m_charLines;
         std::vector<ColoredTexVert> m_charRoomQuads;
         std::vector<ColorVert> m_pathPoints;
         std::vector<ColorVert> m_pathLineQuads;

--- a/src/display/Infomarks.cpp
+++ b/src/display/Infomarks.cpp
@@ -302,11 +302,10 @@ void MapCanvas::paintNewInfomarkSelection()
 
     // Draw yellow guide when creating an infomark line/arrow
     if (m_canvasMouseMode == CanvasMouseModeEnum::CREATE_INFOMARKS && m_selectedArea) {
-        const auto infomarksLineStyle = GLRenderState()
-                                            .withColor(Color{Qt::yellow})
-                                            .withLineParams(LineParams{INFOMARK_GUIDE_LINE_WIDTH});
-        const std::vector<glm::vec3> verts{glm::vec3{pos1, layer}, glm::vec3{pos2, layer}};
-        gl.renderPlainLines(verts, infomarksLineStyle);
+        const Color color{Qt::yellow};
+        const std::vector<LineInstance> verts{
+            LineInstance{color, glm::vec3{pos1, layer}, glm::vec3{pos2, layer}, INFOMARK_GUIDE_LINE_WIDTH}};
+        gl.renderLineInstances(verts, GLRenderState());
     }
 }
 

--- a/src/display/MapBatches.h
+++ b/src/display/MapBatches.h
@@ -33,15 +33,13 @@ struct NODISCARD LayerMeshes final
     explicit operator bool() const { return isValid; }
 };
 
-using PlainQuadBatch = std::vector<glm::vec3>;
-
 struct NODISCARD LayerMeshesIntermediate final
 {
     using Fn = std::function<UniqueMesh(OpenGL &)>;
     using FnVec = std::vector<Fn>;
     FnVec terrain;
     FnVec trails;
-    RoomTintArray<PlainQuadBatch> tints;
+    RoomTintArray<Fn> tints;
     FnVec overlays;
     FnVec doors;
     FnVec walls;
@@ -49,7 +47,7 @@ struct NODISCARD LayerMeshesIntermediate final
     FnVec upDownExits;
     FnVec streamIns;
     FnVec streamOuts;
-    PlainQuadBatch layerBoost;
+    Fn layerBoost;
     bool isValid = false;
 
     LayerMeshesIntermediate() = default;

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -283,6 +283,12 @@ void MapCanvas::initTextures()
         textures.stream_out[dir] = loadTexture(
             getPixmapFilenameRaw(QString::asprintf("stream-out-%s.png", lowercaseDirection(dir))));
     }
+    {
+        // 1x1
+        QImage whitePixel(1, 1, QImage::Format_RGBA8888);
+        whitePixel.fill(Qt::white);
+        textures.white_pixel = MMTexture::alloc(std::vector<QImage>{whitePixel});
+    }
 
     // char images are 256
     textures.char_arrows = loadTexture(getPixmapFilenameRaw("char-arrows.png"));
@@ -456,6 +462,13 @@ void MapCanvas::initTextures()
             auto thing = combine(textures.terrain, textures.road);
             maybeCreateArray2(thing, pArrayTex);
             textures.terrain_Array = textures.road_Array = pArrayTex;
+        }
+
+        {
+            SharedMMTexture pArrayTex;
+            std::vector<SharedMMTexture> pixels{textures.white_pixel};
+            maybeCreateArray2(pixels, pArrayTex);
+            textures.white_pixel_Array = pArrayTex;
         }
 
         {

--- a/src/display/Textures.h
+++ b/src/display/Textures.h
@@ -179,7 +179,8 @@ using TextureArrayNESWUD = EnumIndexedArray<SharedMMTexture, ExitDirEnum, NUM_EX
     X(SharedMMTexture, room_sel_distant) \
     X(SharedMMTexture, room_sel_move_bad) \
     X(SharedMMTexture, room_sel_move_good) \
-    X(SharedMMTexture, room_highlight)
+    X(SharedMMTexture, room_highlight) \
+    X(SharedMMTexture, white_pixel)
 
 struct NODISCARD MapCanvasTextures final
 {

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -1139,6 +1139,7 @@ void MapCanvas::selectionChanged()
 
 void MapCanvas::graphicsSettingsChanged()
 {
+    m_opengl.resetNamedColorsBuffer();
     update();
 }
 

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -66,25 +66,24 @@ private:
 
     struct NODISCARD Diff final
     {
+        using DiffQuadVector = std::vector<RoomQuadTexVert>;
+
         struct NODISCARD MaybeDataOrMesh final
-            : public std::variant<std::monostate, ColoredTexVertVector, UniqueMesh>
+            : public std::variant<std::monostate, DiffQuadVector, UniqueMesh>
         {
         public:
-            using base = std::variant<std::monostate, ColoredTexVertVector, UniqueMesh>;
+            using base = std::variant<std::monostate, DiffQuadVector, UniqueMesh>;
             using base::base;
 
         public:
             NODISCARD bool empty() const { return std::holds_alternative<std::monostate>(*this); }
-            NODISCARD bool hasData() const
-            {
-                return std::holds_alternative<ColoredTexVertVector>(*this);
-            }
+            NODISCARD bool hasData() const { return std::holds_alternative<DiffQuadVector>(*this); }
             NODISCARD bool hasMesh() const { return std::holds_alternative<UniqueMesh>(*this); }
 
         public:
-            NODISCARD const ColoredTexVertVector &getData() const
+            NODISCARD const DiffQuadVector &getData() const
             {
-                return std::get<ColoredTexVertVector>(*this);
+                return std::get<DiffQuadVector>(*this);
             }
             NODISCARD const UniqueMesh &getMesh() const { return std::get<UniqueMesh>(*this); }
 
@@ -96,7 +95,7 @@ private:
                 }
 
                 if (hasData()) {
-                    *this = gl.createColoredTexturedQuadBatch(getData(), texId);
+                    *this = gl.createRoomQuadTexBatch(getData(), texId);
                     assert(hasMesh());
                     // REVISIT: rendering immediately after uploading the mesh may lag,
                     // so consider delaying until the data is already on the GPU.
@@ -107,7 +106,7 @@ private:
                     return;
                 }
                 auto &mesh = getMesh();
-                mesh.render(GLRenderState().withBlend(BlendModeEnum::TRANSPARENCY));
+                mesh.render(gl.getDefaultRenderState().withBlend(BlendModeEnum::TRANSPARENCY));
             }
         };
 

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -981,23 +981,13 @@ void MapCanvas::paintSelectionArea()
         const auto selFgColor = Colors::yellow;
         {
             static constexpr float SELECTION_AREA_LINE_WIDTH = 2.f;
-            const auto lineStyle = rs.withLineParams(LineParams{SELECTION_AREA_LINE_WIDTH});
-            const std::vector<glm::vec3> verts{A, B, B, C, C, D, D, A};
+            const std::vector<LineInstance> verts{
+                LineInstance{selFgColor, A, B, SELECTION_AREA_LINE_WIDTH},
+                LineInstance{selFgColor, B, C, SELECTION_AREA_LINE_WIDTH},
+                LineInstance{selFgColor, C, D, SELECTION_AREA_LINE_WIDTH},
+                LineInstance{selFgColor, D, A, SELECTION_AREA_LINE_WIDTH}};
 
-            // FIXME: ASAN flags this as out-of-bounds memory access inside an assertion
-            //
-            //     Q_ASSERT(QOpenGLFunctions::isInitialized(d_ptr));
-            //
-            // in QOpenGLFunctions::glDrawArrays(). However, it works without ASAN,
-            // so maybe the problem is in my OpenGL driver?
-            //
-            // "OpenGL Version:" "3.1 Mesa 20.2.6"
-            // "OpenGL Renderer:" "llvmpipe (LLVM 11.0.0, 256 bits)"
-            // "OpenGL Vendor:" "Mesa/X.org"
-            // "OpenGL GLSL:" "1.40"
-            // "Current OpenGL Context:" "3.1 (valid)"
-            //
-            gl.renderPlainLines(verts, lineStyle.withColor(selFgColor));
+            gl.renderLineInstances(verts, rs);
         }
     }
 

--- a/src/global/NamedColors.cpp
+++ b/src/global/NamedColors.cpp
@@ -17,11 +17,13 @@ struct NODISCARD GlobalData final
     using InitArray = EnumIndexedArray<bool, NamedColorEnum, NUM_NAMED_COLORS>;
     using Map = std::map<std::string, NamedColorEnum>;
     using NamesVector = std::vector<std::string>;
+    using Vec4Vector = std::vector<glm::vec4>;
 
 private:
     Map m_map;
     NamesVector m_names;
     ColorVector m_colors;
+    Vec4Vector m_vec4s;
     InitArray m_initialized;
 
 private:
@@ -31,6 +33,7 @@ public:
     GlobalData()
     {
         m_colors.resize(NUM_NAMED_COLORS);
+        m_vec4s.resize(MAX_NAMED_COLORS);
         m_names.resize(NUM_NAMED_COLORS);
 
         static const auto white = Colors::white;
@@ -43,6 +46,7 @@ public:
             const auto color = (id == NamedColorEnum::TRANSPARENT) ? transparent_black : white;
 
             m_colors[idx] = color;
+            m_vec4s[idx] = color.getVec4();
             m_names[idx] = name;
             m_map.emplace(name, id);
         };
@@ -69,6 +73,7 @@ public:
 
         const auto idx = getIndex(id);
         m_colors.at(idx) = c;
+        m_vec4s.at(idx) = c.getVec4();
         m_initialized.at(id) = true;
         return true;
     }
@@ -81,6 +86,7 @@ public:
 
     NODISCARD const std::vector<std::string> &getAllNames() const { return m_names; }
     NODISCARD const std::vector<Color> &getAllColors() const { return m_colors; }
+    NODISCARD const std::vector<glm::vec4> &getAllVec4s() const { return m_vec4s; }
 
 public:
     NODISCARD std::optional<NamedColorEnum> lookup(std::string_view name) const
@@ -138,4 +144,9 @@ const std::vector<std::string> &XNamedColor::getAllNames()
 const std::vector<Color> &XNamedColor::getAllColors()
 {
     return getGlobalData().getAllColors();
+}
+
+const std::vector<glm::vec4> &XNamedColor::getAllColorsAsVec4()
+{
+    return getGlobalData().getAllVec4s();
 }

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -48,6 +48,9 @@ enum class NODISCARD NamedColorEnum : uint8_t { DEFAULT = 0, XFOREACH_NAMED_COLO
 static inline constexpr size_t NUM_NAMED_COLORS = XFOREACH_NAMED_COLOR_OPTIONS(X_COUNT) + 1;
 #undef X_COUNT
 
+static inline constexpr size_t MAX_NAMED_COLORS = 32;
+static_assert(MAX_NAMED_COLORS >= NUM_NAMED_COLORS);
+
 // TODO: rename this, but to what? NamedColorHandle?
 class NODISCARD XNamedColor final
 {
@@ -98,5 +101,6 @@ public:
 
 public:
     NODISCARD static const std::vector<Color> &getAllColors();
+    NODISCARD static const std::vector<glm::vec4> &getAllColorsAsVec4();
     NODISCARD static const std::vector<std::string> &getAllNames();
 };

--- a/src/global/hash.h
+++ b/src/global/hash.h
@@ -4,6 +4,7 @@
 
 #include "macros.h"
 
+#include <cstdint>
 #include <cstring>
 #include <string_view>
 #include <type_traits>
@@ -18,10 +19,14 @@ MAYBE_UNUSED NODISCARD static auto numeric_hash(const T val) noexcept
     return std::hash<std::string_view>()({buf, size});
 }
 
+#if INTPTR_MAX == INT64_MAX
+static constexpr size_t GOLDEN_RATIO = 0x9e3779b97f4a7c15ULL;
+#else
+static constexpr size_t GOLDEN_RATIO = 0x9e3779b9U;
+#endif
+
 template<typename T>
 void hash_combine(std::size_t &seed, const T &value) noexcept
 {
-    constexpr const size_t GOLDEN_RATIO = (sizeof(size_t) == 8) ? 0x9e3779b97f4a7c15ULL
-                                                                : 0x9e3779b9U;
     seed ^= std::hash<T>{}(value) + GOLDEN_RATIO + (seed << 6) + (seed >> 2);
 }

--- a/src/opengl/Font.cpp
+++ b/src/opengl/Font.cpp
@@ -766,10 +766,17 @@ void GLFont::init()
             fm.tryAddSyntheticGlyphs(img);
             img = img.mirrored();
 
+            const QImage converted = img.convertToFormat(QImage::Format_RGBA8888);
+            tex.setFormat(QOpenGLTexture::TextureFormat::RGBA8_UNorm);
             tex.setMinMagFilters(QOpenGLTexture::Filter::Linear, QOpenGLTexture::Filter::Linear);
             tex.setAutoMipMapGenerationEnabled(false);
             tex.setMipLevels(0);
-            tex.setData(img, QOpenGLTexture::MipMapGeneration::DontGenerateMipMaps);
+            tex.setSize(converted.width(), converted.height());
+            tex.allocateStorage();
+            tex.setData(0,
+                        QOpenGLTexture::PixelFormat::RGBA,
+                        QOpenGLTexture::PixelType::UInt8,
+                        converted.constBits());
         },
         true);
 

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -194,6 +194,11 @@ void OpenGL::renderColoredTextured(const DrawModeEnum type,
     getFunctions().renderColoredTextured(type, verts, state);
 }
 
+void OpenGL::renderLineInstances(const std::vector<LineInstance> &verts, const GLRenderState &state)
+{
+    getFunctions().renderLineInstances(verts, state);
+}
+
 void OpenGL::renderPlainFullScreenQuad(const GLRenderState &renderState)
 {
     using MeshType = Legacy::PlainMesh<glm::vec3>;

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -316,7 +316,8 @@ void OpenGL::initArrayFromFiles(const SharedMMTexture &array, const std::vector<
 
     const auto numLayers = static_cast<GLsizei>(input.size());
     for (GLsizei i = 0; i < numLayers; ++i) {
-        QImage image = QImage{input[static_cast<size_t>(i)]}.mirrored();
+        const QImage image = QImage{input[static_cast<size_t>(i)]}.mirrored().convertToFormat(
+            QImage::Format_RGBA8888);
         if (image.width() != qtex.width() || image.height() != qtex.height()) {
             std::ostringstream oss;
             oss << "Image is " << image.width() << "x" << image.height() << ", but expected "
@@ -324,18 +325,17 @@ void OpenGL::initArrayFromFiles(const SharedMMTexture &array, const std::vector<
             auto s = std::move(oss).str();
             MMLOG_ERROR() << s.c_str();
         }
-        const QImage swappedImage = std::move(image).rgbSwapped();
         gl.glTexSubImage3D(GL_TEXTURE_2D_ARRAY,
                            0,
                            0,
                            0,
                            i,
-                           swappedImage.width(),
-                           swappedImage.height(),
+                           image.width(),
+                           image.height(),
                            1,
                            GL_RGBA,
                            GL_UNSIGNED_BYTE,
-                           swappedImage.constBits());
+                           image.constBits());
     }
 
     gl.glGenerateMipmap(GL_TEXTURE_2D_ARRAY);
@@ -362,7 +362,7 @@ void OpenGL::initArrayFromImages(const SharedMMTexture &array,
         assert(ipow2 == layer.front().height());
 
         for (size_t level_num = 0; level_num < numLevels; ++level_num) {
-            const QImage &image = layer[level_num];
+            const QImage image = layer[level_num].convertToFormat(QImage::Format_RGBA8888);
             if (image.width() != (qtex.width() >> level_num)
                 || image.height() != (qtex.height() >> level_num)) {
                 std::ostringstream oss;
@@ -373,18 +373,17 @@ void OpenGL::initArrayFromImages(const SharedMMTexture &array,
                 MMLOG_ERROR() << s.c_str();
             }
 
-            const QImage swappedImage = std::move(image).rgbSwapped();
             gl.glTexSubImage3D(GL_TEXTURE_2D_ARRAY,
                                static_cast<GLint>(level_num),
                                0,
                                0,
                                static_cast<GLint>(z),
-                               swappedImage.width(),
-                               swappedImage.height(),
+                               image.width(),
+                               image.height(),
                                1,
                                GL_RGBA,
                                GL_UNSIGNED_BYTE,
-                               swappedImage.constBits());
+                               image.constBits());
         }
     }
 

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -89,6 +89,11 @@ public:
     NODISCARD UniqueMesh createColoredTexturedQuadBatch(const std::vector<ColoredTexVert> &verts,
                                                         MMTextureId texture);
 
+public:
+    NODISCARD UniqueMesh createRoomQuadTexBatch(const std::vector<RoomQuadTexVert> &verts,
+                                                MMTextureId texture);
+
+public:
     NODISCARD UniqueMesh createFontMesh(const SharedMMTexture &texture,
                                         DrawModeEnum mode,
                                         const std::vector<FontVert3d> &batch);
@@ -161,6 +166,9 @@ public:
 
 public:
     void cleanup();
+    NODISCARD GLRenderState getDefaultRenderState();
+    void bindNamedColorsBuffer();
+    void resetNamedColorsBuffer();
     void setTextureLookup(MMTextureId, SharedMMTexture);
 
 public:

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -130,6 +130,9 @@ public:
     }
 
 public:
+    void renderLineInstances(const std::vector<LineInstance> &verts, const GLRenderState &state);
+
+public:
     void renderColoredLines(const std::vector<ColorVert> &verts, const GLRenderState &state)
     {
         renderColored(DrawModeEnum::LINES, verts, state);

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -139,16 +139,6 @@ enum class NODISCARD DrawModeEnum {
     INSTANCED_LINES = 6
 };
 
-struct NODISCARD LineParams final
-{
-    float width = 1.f;
-    LineParams() = default;
-
-    explicit LineParams(const float width_)
-        : width{width_}
-    {}
-};
-
 #define XFOREACH_DEPTHFUNC(X) \
     X(NEVER) \
     X(LESS) \
@@ -232,9 +222,6 @@ struct NODISCARD GLRenderState final
     using OptDepth = std::optional<DepthFunctionEnum>;
     OptDepth depth;
 
-    // glLineWidth() + { glEnable(LINE_STIPPLE) + glLineStipple() }
-    LineParams lineParams;
-
     using Textures = MMapper::Array<MMTextureId, 2>;
     struct NODISCARD Uniforms final
     {
@@ -278,13 +265,6 @@ struct NODISCARD GLRenderState final
     {
         GLRenderState copy = *this;
         copy.depth.reset();
-        return copy;
-    }
-
-    NODISCARD GLRenderState withLineParams(const LineParams &new_lineParams) const
-    {
-        GLRenderState copy = *this;
-        copy.lineParams = new_lineParams;
         return copy;
     }
 

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -51,6 +51,29 @@ struct NODISCARD ColoredTexVert final
     {}
 };
 
+struct NODISCARD RoomQuadTexVert final
+{
+    // xyz = room coord, w = (colorId << 8 | tex_z)
+    // - colorId: packed into bits 8-15 (must be < MAX_NAMED_COLORS)
+    // - tex_z:   packed into bits 0-7  (must be < 256)
+    glm::ivec4 vertTexCol{};
+
+    explicit RoomQuadTexVert(const glm::ivec3 &vert, const int tex_z)
+        : RoomQuadTexVert{vert, tex_z, NamedColorEnum::DEFAULT}
+    {}
+
+    explicit RoomQuadTexVert(const glm::ivec3 &vert, const int tex_z, const NamedColorEnum color)
+        : vertTexCol{vert, (static_cast<uint8_t>(color) << 8) | tex_z}
+    {
+        if (IS_DEBUG_BUILD) {
+            constexpr auto max_texture_layers = 256;
+            const auto c = static_cast<uint8_t>(color);
+            assert(c == std::clamp<uint8_t>(c, 0, NUM_NAMED_COLORS - 1));
+            assert(tex_z == std::clamp(tex_z, 0, max_texture_layers - 1));
+        }
+    }
+};
+
 using ColoredTexVertVector = std::vector<ColoredTexVert>;
 
 struct NODISCARD ColorVert final
@@ -88,7 +111,14 @@ struct NODISCARD FontVert3d final
     {}
 };
 
-enum class NODISCARD DrawModeEnum { INVALID = 0, POINTS = 1, LINES = 2, TRIANGLES = 3, QUADS = 4 };
+enum class NODISCARD DrawModeEnum {
+    INVALID = 0,
+    POINTS = 1,
+    LINES = 2,
+    TRIANGLES = 3,
+    QUADS = 4,
+    INSTANCED_QUADS = 5
+};
 
 struct NODISCARD LineParams final
 {
@@ -344,6 +374,7 @@ public:
     DEFAULT_MOVES_DELETE_COPIES(UniqueMesh);
 
     void render(const GLRenderState &rs) const { deref(m_mesh).render(rs); }
+    NODISCARD explicit operator bool() const { return m_mesh != nullptr; }
 };
 
 struct NODISCARD UniqueMeshVector final

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -87,6 +87,24 @@ struct NODISCARD ColorVert final
     {}
 };
 
+struct NODISCARD LineInstance final
+{
+    Color color;
+    glm::vec3 from{};
+    glm::vec3 to{};
+    float width = 1.0f;
+
+    explicit LineInstance(const Color color_,
+                          const glm::vec3 &from_,
+                          const glm::vec3 &to_,
+                          const float width_)
+        : color{color_}
+        , from{from_}
+        , to{to_}
+        , width{width_}
+    {}
+};
+
 // Similar to ColoredTexVert, except it has a base position in world coordinates.
 // the font's vertex shader transforms the world position to screen space,
 // rounds to integer pixel offset, and then adds the vertex position in screen space.
@@ -117,7 +135,8 @@ enum class NODISCARD DrawModeEnum {
     LINES = 2,
     TRIANGLES = 3,
     QUADS = 4,
-    INSTANCED_QUADS = 5
+    INSTANCED_QUADS = 5,
+    INSTANCED_LINES = 6
 };
 
 struct NODISCARD LineParams final

--- a/src/opengl/legacy/AbstractShaderProgram.cpp
+++ b/src/opengl/legacy/AbstractShaderProgram.cpp
@@ -3,6 +3,8 @@
 
 #include "AbstractShaderProgram.h"
 
+#include "../../global/ConfigConsts.h"
+
 namespace Legacy {
 
 AbstractShaderProgram::AbstractShaderProgram(std::string dirName,

--- a/src/opengl/legacy/Binders.cpp
+++ b/src/opengl/legacy/Binders.cpp
@@ -97,23 +97,6 @@ DepthBinder::~DepthBinder()
     }
 }
 
-LineParamsBinder::LineParamsBinder(Functions &functions, const LineParams &lineParams)
-    : m_functions{functions}
-    , m_lineParams{lineParams}
-{
-    m_functions.glLineWidth(m_lineParams.width);
-}
-
-LineParamsBinder::~LineParamsBinder()
-{
-    const auto &width = m_lineParams.width;
-    const float ONE = 1.f;
-    static_assert(sizeof(ONE) == sizeof(width));
-    if (!utils::equals(&width, &ONE)) {
-        m_functions.glLineWidth(ONE);
-    }
-}
-
 PointSizeBinder::PointSizeBinder(Functions &functions, const std::optional<GLfloat> &pointSize)
     : m_functions{functions}
     , m_optPointSize{pointSize}
@@ -172,7 +155,6 @@ RenderStateBinder::RenderStateBinder(Functions &functions,
     : m_blendBinder{functions, renderState.blend}
     , m_cullingBinder{functions, renderState.culling}
     , m_depthBinder{functions, renderState.depth}
-    , m_lineParamsBinder{functions, renderState.lineParams}
     , m_pointSizeBinder{functions, renderState.uniforms.pointSize}
     , m_texturesBinder{texLookup, renderState.uniforms.textures}
 {}

--- a/src/opengl/legacy/Binders.h
+++ b/src/opengl/legacy/Binders.h
@@ -51,18 +51,6 @@ public:
     DELETE_CTORS_AND_ASSIGN_OPS(DepthBinder);
 };
 
-struct NODISCARD LineParamsBinder
-{
-private:
-    Functions &m_functions;
-    const LineParams &m_lineParams;
-
-public:
-    explicit LineParamsBinder(Functions &functions, const LineParams &lineParams);
-    ~LineParamsBinder();
-    DELETE_CTORS_AND_ASSIGN_OPS(LineParamsBinder);
-};
-
 struct NODISCARD PointSizeBinder
 {
 private:
@@ -96,7 +84,6 @@ private:
     BlendBinder m_blendBinder;
     CullingBinder m_cullingBinder;
     DepthBinder m_depthBinder;
-    LineParamsBinder m_lineParamsBinder;
     PointSizeBinder m_pointSizeBinder;
     TexturesBinder m_texturesBinder;
 

--- a/src/opengl/legacy/FunctionsES30.cpp
+++ b/src/opengl/legacy/FunctionsES30.cpp
@@ -25,6 +25,7 @@ std::optional<GLenum> FunctionsES30::virt_toGLenum(const DrawModeEnum mode)
 
     case DrawModeEnum::INVALID:
     case DrawModeEnum::QUADS:
+    case DrawModeEnum::INSTANCED_QUADS:
         break;
     }
 

--- a/src/opengl/legacy/FunctionsES30.cpp
+++ b/src/opengl/legacy/FunctionsES30.cpp
@@ -26,6 +26,7 @@ std::optional<GLenum> FunctionsES30::virt_toGLenum(const DrawModeEnum mode)
     case DrawModeEnum::INVALID:
     case DrawModeEnum::QUADS:
     case DrawModeEnum::INSTANCED_QUADS:
+    case DrawModeEnum::INSTANCED_LINES:
         break;
     }
 

--- a/src/opengl/legacy/FunctionsGL33.cpp
+++ b/src/opengl/legacy/FunctionsGL33.cpp
@@ -1,5 +1,6 @@
 #include "FunctionsGL33.h"
 
+#include "../../global/ConfigConsts.h"
 #include "../OpenGLConfig.h"
 
 #include <optional>
@@ -27,7 +28,10 @@ std::optional<GLenum> FunctionsGL33::virt_toGLenum(const DrawModeEnum mode)
     case DrawModeEnum::QUADS:
 #ifndef MMAPPER_NO_OPENGL
         return canRenderQuads() ? std::make_optional(GL_QUADS) : std::nullopt;
+#else
+        FALLTHROUGH;
 #endif
+    case DrawModeEnum::INSTANCED_QUADS:
     case DrawModeEnum::INVALID:
         break;
     }

--- a/src/opengl/legacy/FunctionsGL33.cpp
+++ b/src/opengl/legacy/FunctionsGL33.cpp
@@ -31,6 +31,7 @@ std::optional<GLenum> FunctionsGL33::virt_toGLenum(const DrawModeEnum mode)
 #else
         FALLTHROUGH;
 #endif
+    case DrawModeEnum::INSTANCED_LINES:
     case DrawModeEnum::INSTANCED_QUADS:
     case DrawModeEnum::INVALID:
         break;

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -253,6 +253,17 @@ void Functions::renderColoredTextured(const DrawModeEnum mode,
                                                                  state);
 }
 
+void Functions::renderLineInstances(const std::vector<LineInstance> &verts,
+                                    const GLRenderState &state)
+{
+    const auto &prog = getShaderPrograms().getLineShader();
+    renderImmediate<LineInstance, Legacy::LineMesh>(shared_from_this(),
+                                                    DrawModeEnum::INSTANCED_LINES,
+                                                    verts,
+                                                    prog,
+                                                    state);
+}
+
 void Functions::renderFont3d(const SharedMMTexture &texture, const std::vector<FontVert3d> &verts)
 
 {

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -225,6 +225,7 @@ public:
     using Base::glUniform4iv;
     using Base::glUniformBlockBinding;
 
+public:
     /**
      * @brief Assigns a fixed binding point to a uniform block in a program.
      * @param program The shader program.
@@ -246,15 +247,6 @@ public:
     using Base::glUseProgram;
     using Base::glVertexAttribDivisor;
     using Base::glVertexAttribPointer;
-
-public:
-    void glLineWidth(const GLfloat lineWidth)
-    {
-        // REVISIT: Only width 1 is guaranteed to be supported for core profiles
-        if (OpenGLConfig::getIsCompat()) {
-            Base::glLineWidth(lineWidth);
-        }
-    }
 
 public:
     void glViewport(const GLint x, const GLint y, const GLsizei width, const GLsizei height)

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -192,6 +192,7 @@ public:
     using Base::glDisable;
     using Base::glDisableVertexAttribArray;
     using Base::glDrawArrays;
+    using Base::glDrawArraysInstanced;
     using Base::glDrawElementsInstanced;
     using Base::glEnable;
     using Base::glEnableVertexAttribArray;
@@ -443,6 +444,7 @@ public:
     void renderColoredTextured(DrawModeEnum mode,
                                const std::vector<ColoredTexVert> &verts,
                                const GLRenderState &state);
+    void renderLineInstances(const std::vector<LineInstance> &verts, const GLRenderState &state);
     void renderFont3d(const SharedMMTexture &texture, const std::vector<FontVert3d> &verts);
 
 public:

--- a/src/opengl/legacy/Meshes.h
+++ b/src/opengl/legacy/Meshes.h
@@ -284,6 +284,85 @@ private:
         auto &attribs = m_boundAttribs.value();
         Functions &gl = Base::m_functions;
         gl.glDisableVertexAttribArray(attribs.vertTexColPos);
+        gl.glVertexAttribDivisor(attribs.vertTexColPos, 0);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, 0);
+        m_boundAttribs.reset();
+    }
+};
+
+template<typename VertexType_>
+class NODISCARD LineMesh final : public SimpleMesh<VertexType_, LineShader>
+{
+public:
+    using Base = SimpleMesh<VertexType_, LineShader>;
+    using Base::Base;
+
+private:
+    struct NODISCARD Attribs final
+    {
+        GLuint colorPos = INVALID_ATTRIB_LOCATION;
+        GLuint fromPos = INVALID_ATTRIB_LOCATION;
+        GLuint toPos = INVALID_ATTRIB_LOCATION;
+        GLuint widthPos = INVALID_ATTRIB_LOCATION;
+
+        NODISCARD static Attribs getLocations(LineShader &shader)
+        {
+            Attribs result;
+            result.colorPos = shader.getAttribLocation("aColor");
+            result.fromPos = shader.getAttribLocation("aFrom");
+            result.toPos = shader.getAttribLocation("aTo");
+            result.widthPos = shader.getAttribLocation("aWidth");
+            return result;
+        }
+    };
+
+    std::optional<Attribs> m_boundAttribs;
+
+    void virt_bind() override
+    {
+        const auto vertSize = static_cast<GLsizei>(sizeof(VertexType_));
+        static_assert(sizeof(std::declval<VertexType_>().color) == 4 * sizeof(uint8_t));
+        static_assert(sizeof(std::declval<VertexType_>().from) == 3 * sizeof(GLfloat));
+        static_assert(sizeof(std::declval<VertexType_>().to) == 3 * sizeof(GLfloat));
+        static_assert(sizeof(std::declval<VertexType_>().width) == sizeof(GLfloat));
+
+        Functions &gl = Base::m_functions;
+        const auto attribs = Attribs::getLocations(Base::m_program);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, Base::m_vbo.get());
+
+        gl.enableAttrib(attribs.colorPos, 4, GL_UNSIGNED_BYTE, GL_TRUE, vertSize, VPO(color));
+        gl.enableAttrib(attribs.fromPos, 3, GL_FLOAT, GL_FALSE, vertSize, VPO(from));
+        gl.enableAttrib(attribs.toPos, 3, GL_FLOAT, GL_FALSE, vertSize, VPO(to));
+        gl.enableAttrib(attribs.widthPos, 1, GL_FLOAT, GL_FALSE, vertSize, VPO(width));
+
+        // instancing
+        gl.glVertexAttribDivisor(attribs.colorPos, 1);
+        gl.glVertexAttribDivisor(attribs.fromPos, 1);
+        gl.glVertexAttribDivisor(attribs.toPos, 1);
+        gl.glVertexAttribDivisor(attribs.widthPos, 1);
+
+        m_boundAttribs = attribs;
+    }
+
+    void virt_unbind() override
+    {
+        if (!m_boundAttribs) {
+            assert(false);
+            return;
+        }
+
+        auto &attribs = m_boundAttribs.value();
+        Functions &gl = Base::m_functions;
+        gl.glDisableVertexAttribArray(attribs.colorPos);
+        gl.glDisableVertexAttribArray(attribs.fromPos);
+        gl.glDisableVertexAttribArray(attribs.toPos);
+        gl.glDisableVertexAttribArray(attribs.widthPos);
+
+        gl.glVertexAttribDivisor(attribs.colorPos, 0);
+        gl.glVertexAttribDivisor(attribs.fromPos, 0);
+        gl.glVertexAttribDivisor(attribs.toPos, 0);
+        gl.glVertexAttribDivisor(attribs.widthPos, 0);
+
         gl.glBindBuffer(GL_ARRAY_BUFFER, 0);
         m_boundAttribs.reset();
     }

--- a/src/opengl/legacy/ShaderUtils.cpp
+++ b/src/opengl/legacy/ShaderUtils.cpp
@@ -5,6 +5,7 @@
 
 #include "../../global/ConfigConsts.h"
 #include "../../global/Consts.h"
+#include "../../global/NamedColors.h"
 #include "../../global/PrintUtils.h"
 #include "../../global/TextUtils.h"
 
@@ -211,7 +212,12 @@ NODISCARD static GLuint compileShader(Functions &gl, const GLenum type, const So
     // NOTE: GLES 2.0 required `const char**` instead of `const char*const*`,
     // so Qt uses the least common denominator without the middle const;
     // that's the reason the `ptrs` array below is not `const`.
-    std::array<const char *, 3> ptrs = {gl.getShaderVersion(), "#line 1\n", source.source.c_str()};
+    std::string defineNamedColors = "#define MAX_NAMED_COLORS " + std::to_string(MAX_NAMED_COLORS)
+                                    + "\n";
+    std::array<const char *, 4> ptrs = {gl.getShaderVersion(),
+                                        defineNamedColors.c_str(),
+                                        "#line 1\n",
+                                        source.source.c_str()};
     gl.glShaderSource(shaderId, static_cast<GLsizei>(ptrs.size()), ptrs.data(), nullptr);
     gl.glCompileShader(shaderId);
     checkShaderInfo(gl, shaderId);
@@ -248,6 +254,7 @@ Program loadShaders(Functions &gl, const Source &vert, const Source &frag)
 
     gl.glLinkProgram(prog);
     checkProgramInfo(gl, prog);
+    gl.applyDefaultUniformBlockBindings(prog);
 
     for (const GLuint s : shaders) {
         if (is_valid(s)) {

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -31,8 +31,37 @@ AColorPlainShader::~AColorPlainShader() = default;
 UColorPlainShader::~UColorPlainShader() = default;
 AColorTexturedShader::~AColorTexturedShader() = default;
 UColorTexturedShader::~UColorTexturedShader() = default;
+
+RoomQuadTexShader::~RoomQuadTexShader() = default;
+
 FontShader::~FontShader() = default;
 PointShader::~PointShader() = default;
+
+void ShaderPrograms::early_init()
+{
+    std::ignore = getPlainAColorShader();
+    std::ignore = getPlainUColorShader();
+    std::ignore = getTexturedAColorShader();
+    std::ignore = getTexturedUColorShader();
+
+    std::ignore = getRoomQuadTexShader();
+
+    std::ignore = getFontShader();
+    std::ignore = getPointShader();
+}
+
+void ShaderPrograms::resetAll()
+{
+    m_aColorShader.reset();
+    m_uColorShader.reset();
+    m_aTexturedShader.reset();
+    m_uTexturedShader.reset();
+
+    m_roomQuadTexShader.reset();
+
+    m_font.reset();
+    m_point.reset();
+}
 
 // essentially a private member of ShaderPrograms
 template<typename T>
@@ -76,6 +105,11 @@ const std::shared_ptr<UColorPlainShader> &ShaderPrograms::getPlainUColorShader()
 const std::shared_ptr<AColorTexturedShader> &ShaderPrograms::getTexturedAColorShader()
 {
     return getInitialized<AColorTexturedShader>(m_aTexturedShader, getFunctions(), "tex/acolor");
+}
+
+const std::shared_ptr<RoomQuadTexShader> &ShaderPrograms::getRoomQuadTexShader()
+{
+    return getInitialized<RoomQuadTexShader>(m_roomQuadTexShader, getFunctions(), "room/tex/acolor");
 }
 
 const std::shared_ptr<UColorTexturedShader> &ShaderPrograms::getTexturedUColorShader()

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -36,6 +36,7 @@ RoomQuadTexShader::~RoomQuadTexShader() = default;
 
 FontShader::~FontShader() = default;
 PointShader::~PointShader() = default;
+LineShader::~LineShader() = default;
 
 void ShaderPrograms::early_init()
 {
@@ -48,6 +49,7 @@ void ShaderPrograms::early_init()
 
     std::ignore = getFontShader();
     std::ignore = getPointShader();
+    std::ignore = getLineShader();
 }
 
 void ShaderPrograms::resetAll()
@@ -61,6 +63,7 @@ void ShaderPrograms::resetAll()
 
     m_font.reset();
     m_point.reset();
+    m_lineShader.reset();
 }
 
 // essentially a private member of ShaderPrograms
@@ -125,6 +128,11 @@ const std::shared_ptr<FontShader> &ShaderPrograms::getFontShader()
 const std::shared_ptr<PointShader> &ShaderPrograms::getPointShader()
 {
     return getInitialized<PointShader>(m_point, getFunctions(), "point");
+}
+
+const std::shared_ptr<LineShader> &ShaderPrograms::getLineShader()
+{
+    return getInitialized<LineShader>(m_lineShader, getFunctions(), "line");
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/Shaders.h
+++ b/src/opengl/legacy/Shaders.h
@@ -56,6 +56,24 @@ private:
     }
 };
 
+struct NODISCARD RoomQuadTexShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~RoomQuadTexShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms) final
+    {
+        assert(uniforms.textures[0] != INVALID_MM_TEXTURE_ID);
+
+        setColor("uColor", uniforms.color);
+        setMatrix("uMVP", mvp);
+        setTexture("uTexture", 0);
+    }
+};
+
 struct NODISCARD UColorTexturedShader final : public AbstractShaderProgram
 {
 public:
@@ -116,10 +134,17 @@ struct NODISCARD ShaderPrograms final
 {
 private:
     Functions &m_functions;
+
+private:
     std::shared_ptr<AColorPlainShader> m_aColorShader;
     std::shared_ptr<UColorPlainShader> m_uColorShader;
     std::shared_ptr<AColorTexturedShader> m_aTexturedShader;
     std::shared_ptr<UColorTexturedShader> m_uTexturedShader;
+
+private:
+    std::shared_ptr<RoomQuadTexShader> m_roomQuadTexShader;
+
+private:
     std::shared_ptr<FontShader> m_font;
     std::shared_ptr<PointShader> m_point;
 
@@ -134,15 +159,7 @@ private:
     NODISCARD Functions &getFunctions() { return m_functions; }
 
 public:
-    void resetAll()
-    {
-        m_aColorShader.reset();
-        m_uColorShader.reset();
-        m_aTexturedShader.reset();
-        m_uTexturedShader.reset();
-        m_font.reset();
-        m_point.reset();
-    }
+    void resetAll();
 
 public:
     // attribute color (aka "Colored")
@@ -153,8 +170,16 @@ public:
     NODISCARD const std::shared_ptr<AColorTexturedShader> &getTexturedAColorShader();
     // uniform color + textured (aka "Textured")
     NODISCARD const std::shared_ptr<UColorTexturedShader> &getTexturedUColorShader();
+
+public:
+    NODISCARD const std::shared_ptr<RoomQuadTexShader> &getRoomQuadTexShader();
+
+public:
     NODISCARD const std::shared_ptr<FontShader> &getFontShader();
     NODISCARD const std::shared_ptr<PointShader> &getPointShader();
+
+public:
+    void early_init();
 };
 
 } // namespace Legacy

--- a/src/opengl/legacy/Shaders.h
+++ b/src/opengl/legacy/Shaders.h
@@ -129,6 +129,24 @@ private:
     }
 };
 
+struct NODISCARD LineShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~LineShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms) final
+    {
+        auto functions = AbstractShaderProgram::m_functions.lock();
+
+        setColor("uColor", uniforms.color);
+        setMatrix("uMVP", mvp);
+        setViewport("uViewport", deref(functions).getPhysicalViewport());
+    }
+};
+
 /* owned by Functions */
 struct NODISCARD ShaderPrograms final
 {
@@ -147,6 +165,7 @@ private:
 private:
     std::shared_ptr<FontShader> m_font;
     std::shared_ptr<PointShader> m_point;
+    std::shared_ptr<LineShader> m_lineShader;
 
 public:
     explicit ShaderPrograms(Functions &functions)
@@ -177,6 +196,7 @@ public:
 public:
     NODISCARD const std::shared_ptr<FontShader> &getFontShader();
     NODISCARD const std::shared_ptr<PointShader> &getPointShader();
+    NODISCARD const std::shared_ptr<LineShader> &getLineShader();
 
 public:
     void early_init();

--- a/src/opengl/legacy/SimpleMesh.cpp
+++ b/src/opengl/legacy/SimpleMesh.cpp
@@ -2,3 +2,58 @@
 // Copyright (C) 2019 The MMapper Authors
 
 #include "SimpleMesh.h"
+
+#include "../../global/ConfigConsts.h"
+
+void Legacy::drawRoomQuad(Functions &gl, const GLsizei numVerts)
+{
+    static constexpr size_t NUM_ELEMENTS = 4;
+    const SharedVbo shared = gl.getSharedVbos().get(SharedVboEnum::InstancedQuadIbo);
+    VBO &vbo = deref(shared);
+
+    if (!vbo) {
+        if (IS_DEBUG_BUILD) {
+            qDebug() << "allocating shared VBO for drawRoomQuad";
+        }
+
+        vbo.emplace(gl.shared_from_this());
+
+        // CCW order
+        const std::vector<uint8_t> indices{0, 1, 2, 3};
+        assert(indices.size() == NUM_ELEMENTS);
+
+        MAYBE_UNUSED const auto numIndices = gl.setIbo(vbo.get(),
+                                                       indices,
+                                                       BufferUsageEnum::STATIC_DRAW);
+        assert(numIndices == NUM_ELEMENTS);
+    }
+
+    struct NODISCARD IBOBinder final
+    {
+    private:
+        Functions &m_gl;
+
+    public:
+        IBOBinder(Functions &f, const VBO &vbo)
+            : m_gl(f)
+        {
+            if (IS_DEBUG_BUILD) {
+                GLint binding = -1;
+                m_gl.glGetIntegerv(GL_ELEMENT_ARRAY_BUFFER_BINDING, &binding);
+                assert(binding == 0);
+            }
+            m_gl.glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vbo.get());
+        }
+        ~IBOBinder() { m_gl.glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0); }
+        DELETE_CTORS_AND_ASSIGN_OPS(IBOBinder);
+    };
+
+    {
+        IBOBinder ibo_binder{gl, *shared};
+        gl.glDrawElementsInstanced(GL_TRIANGLE_FAN,
+                                   NUM_ELEMENTS,
+                                   GL_UNSIGNED_BYTE,
+                                   nullptr,
+                                   numVerts);
+    }
+}

--- a/src/opengl/legacy/SimpleMesh.h
+++ b/src/opengl/legacy/SimpleMesh.h
@@ -17,6 +17,8 @@
 
 namespace Legacy {
 
+void drawRoomQuad(Functions &gl, GLsizei numVerts);
+
 template<typename VertexType_, typename ProgramType_>
 class NODISCARD SimpleMesh : public IRenderable
 {
@@ -108,7 +110,13 @@ private:
                    const BufferUsageEnum usage)
     {
         const auto numVerts = verts.size();
-        assert(mode == DrawModeEnum::INVALID || numVerts % static_cast<size_t>(mode) == 0);
+
+        static_assert(static_cast<size_t>(DrawModeEnum::POINTS) == 1);
+        static_assert(static_cast<size_t>(DrawModeEnum::LINES) == 2);
+        static_assert(static_cast<size_t>(DrawModeEnum::TRIANGLES) == 3);
+        static_assert(static_cast<size_t>(DrawModeEnum::QUADS) == 4);
+        assert(mode == DrawModeEnum::INVALID || mode == DrawModeEnum::INSTANCED_QUADS
+               || numVerts % static_cast<size_t>(mode) == 0);
 
         if (!m_vbo && numVerts != 0) {
             m_vbo.emplace(m_shared_functions);
@@ -179,11 +187,14 @@ private:
 
         auto attribUnbinder = bindAttribs();
 
-        if (const std::optional<GLenum> &optMode = m_functions.toGLenum(m_drawMode)) {
+        if (m_drawMode == DrawModeEnum::INSTANCED_QUADS) {
+            drawRoomQuad(m_functions, m_numVerts);
+        } else if (const std::optional<GLenum> &optMode = m_functions.toGLenum(m_drawMode)) {
             m_functions.glDrawArrays(optMode.value(), 0, m_numVerts);
         } else {
             assert(false);
         }
     }
 };
+
 } // namespace Legacy

--- a/src/opengl/legacy/SimpleMesh.h
+++ b/src/opengl/legacy/SimpleMesh.h
@@ -189,6 +189,8 @@ private:
 
         if (m_drawMode == DrawModeEnum::INSTANCED_QUADS) {
             drawRoomQuad(m_functions, m_numVerts);
+        } else if (m_drawMode == DrawModeEnum::INSTANCED_LINES) {
+            m_functions.glDrawArraysInstanced(GL_TRIANGLE_STRIP, 0, 4, m_numVerts);
         } else if (const std::optional<GLenum> &optMode = m_functions.toGLenum(m_drawMode)) {
             m_functions.glDrawArrays(optMode.value(), 0, m_numVerts);
         } else {

--- a/src/opengl/legacy/SimpleMesh.h
+++ b/src/opengl/legacy/SimpleMesh.h
@@ -116,6 +116,7 @@ private:
         static_assert(static_cast<size_t>(DrawModeEnum::TRIANGLES) == 3);
         static_assert(static_cast<size_t>(DrawModeEnum::QUADS) == 4);
         assert(mode == DrawModeEnum::INVALID || mode == DrawModeEnum::INSTANCED_QUADS
+               || mode == DrawModeEnum::INSTANCED_LINES
                || numVerts % static_cast<size_t>(mode) == 0);
 
         if (!m_vbo && numVerts != 0) {

--- a/src/opengl/legacy/VBO.h
+++ b/src/opengl/legacy/VBO.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2019 The MMapper Authors
 
-#include "../../global/utils.h"
+#include "../../global/EnumIndexedArray.h"
 #include "Legacy.h"
 
 #include <memory>
@@ -57,6 +57,33 @@ public:
     }
 
     void resetAll() { base::clear(); }
+};
+
+class NODISCARD SharedVbos final
+    : private EnumIndexedArray<SharedVbo, SharedVboEnum, NUM_SHARED_VBOS>
+{
+private:
+    using base = EnumIndexedArray<SharedVbo, SharedVboEnum, NUM_SHARED_VBOS>;
+
+public:
+    SharedVbos() = default;
+
+public:
+    NODISCARD SharedVbo get(const SharedVboEnum buffer)
+    {
+        SharedVbo &shared = base::operator[](buffer);
+        if (shared == nullptr) {
+            shared = std::make_shared<VBO>();
+        }
+        return shared;
+    }
+
+    void reset(const SharedVboEnum buffer) { base::operator[](buffer).reset(); }
+
+    void resetAll()
+    {
+        base::for_each([](auto &shared) { shared.reset(); });
+    }
 };
 
 class NODISCARD Program final

--- a/src/resources/mmapper2.qrc
+++ b/src/resources/mmapper2.qrc
@@ -212,6 +212,8 @@
         <file>pixmaps/wall-west.png</file>
         <file>shaders/legacy/font/frag.glsl</file>
         <file>shaders/legacy/font/vert.glsl</file>
+        <file>shaders/legacy/room/tex/acolor/frag.glsl</file>
+        <file>shaders/legacy/room/tex/acolor/vert.glsl</file>
         <file>shaders/legacy/plain/acolor/frag.glsl</file>
         <file>shaders/legacy/plain/acolor/vert.glsl</file>
         <file>shaders/legacy/plain/ucolor/frag.glsl</file>

--- a/src/resources/mmapper2.qrc
+++ b/src/resources/mmapper2.qrc
@@ -212,6 +212,8 @@
         <file>pixmaps/wall-west.png</file>
         <file>shaders/legacy/font/frag.glsl</file>
         <file>shaders/legacy/font/vert.glsl</file>
+        <file>shaders/legacy/line/frag.glsl</file>
+        <file>shaders/legacy/line/vert.glsl</file>
         <file>shaders/legacy/room/tex/acolor/frag.glsl</file>
         <file>shaders/legacy/room/tex/acolor/vert.glsl</file>
         <file>shaders/legacy/plain/acolor/frag.glsl</file>

--- a/src/resources/shaders/legacy/line/frag.glsl
+++ b/src/resources/shaders/legacy/line/frag.glsl
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2019 The MMapper Authors
+
+uniform vec4 uColor;
+
+in vec4 vColor;
+in float isoLinePos;
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    float x = 1.0 - abs(isoLinePos);
+    x = smoothstep(0.0, 1.0, x);
+    vFragmentColor = vColor * uColor;
+    vFragmentColor.a *= x;
+}

--- a/src/resources/shaders/legacy/line/vert.glsl
+++ b/src/resources/shaders/legacy/line/vert.glsl
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2019 The MMapper Authors
+
+uniform mat4 uMVP;
+uniform vec4 uViewport;
+
+layout(location = 0) in vec4 aColor;
+layout(location = 1) in vec3 aFrom;
+layout(location = 2) in vec3 aTo;
+layout(location = 3) in float aWidth;
+
+out vec4 vColor;
+out float isoLinePos;
+
+vec2 toScreenSpace(vec4 v)
+{
+    vec3 ndc = v.xyz / v.w;
+    return (ndc.xy * 0.5 + 0.5) * uViewport.zw;
+}
+
+void main()
+{
+    vColor = aColor;
+
+    vec2 p1 = toScreenSpace(uMVP * vec4(aFrom, 1.0));
+    vec2 p2 = toScreenSpace(uMVP * vec4(aTo, 1.0));
+    vec2 dir = normalize(p2 - p1);
+    vec2 normal = vec2(-dir.y, dir.x);
+    float halfWidth = aWidth * 0.5;
+    vec2 offset = normal * halfWidth;
+
+    vec2 positions[4] = vec2[](
+        p1 - offset,
+        p1 + offset,
+        p2 - offset,
+        p2 + offset
+    );
+
+    vec2 pos = positions[gl_VertexID];
+    // to NDC
+    pos = (pos / uViewport.zw) * 2.0 - 1.0;
+    gl_Position = vec4(pos, 0.0, 1.0);
+
+    float weights[4] = float[](-1.0, 1.0, -1.0, 1.0);
+    isoLinePos = weights[gl_VertexID];
+}

--- a/src/resources/shaders/legacy/line/vert.glsl
+++ b/src/resources/shaders/legacy/line/vert.glsl
@@ -2,7 +2,7 @@
 // Copyright (C) 2019 The MMapper Authors
 
 uniform mat4 uMVP;
-uniform vec4 uViewport;
+uniform ivec4 uViewport;
 
 layout(location = 0) in vec4 aColor;
 layout(location = 1) in vec3 aFrom;
@@ -15,7 +15,7 @@ out float isoLinePos;
 vec2 toScreenSpace(vec4 v)
 {
     vec3 ndc = v.xyz / v.w;
-    return (ndc.xy * 0.5 + 0.5) * uViewport.zw;
+    return (ndc.xy * 0.5 + 0.5) * vec2(uViewport.zw);
 }
 
 void main()
@@ -29,16 +29,11 @@ void main()
     float halfWidth = aWidth * 0.5;
     vec2 offset = normal * halfWidth;
 
-    vec2 positions[4] = vec2[](
-        p1 - offset,
-        p1 + offset,
-        p2 - offset,
-        p2 + offset
-    );
+    vec2 positions[4] = vec2[](p1 - offset, p1 + offset, p2 - offset, p2 + offset);
 
     vec2 pos = positions[gl_VertexID];
     // to NDC
-    pos = (pos / uViewport.zw) * 2.0 - 1.0;
+    pos = (pos / vec2(uViewport.zw)) * 2.0 - 1.0;
     gl_Position = vec4(pos, 0.0, 1.0);
 
     float weights[4] = float[](-1.0, 1.0, -1.0, 1.0);

--- a/src/resources/shaders/legacy/room/tex/acolor/frag.glsl
+++ b/src/resources/shaders/legacy/room/tex/acolor/frag.glsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+uniform sampler2DArray uTexture;
+uniform vec4 uColor;
+
+in vec4 vColor;
+in vec3 vTexCoord;
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    vFragmentColor = vColor * uColor * texture(uTexture, vTexCoord);
+}

--- a/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+uniform mat4 uMVP;
+uniform NamedColorsBlock {
+    vec4 uNamedColors[MAX_NAMED_COLORS];
+};
+
+layout(location = 0) in ivec4 aVertTexCol;
+
+out vec4 vColor;
+out vec3 vTexCoord;
+
+void main()
+{
+    // ccw-order assumes it's a triangle fan (as opposed to a triangle strip)
+    const ivec3[4] ioffsets_ccw = ivec3[4](ivec3(0, 0, 0), ivec3(1, 0, 0), ivec3(1, 1, 0), ivec3(0, 1, 0));
+    ivec3 ioffset = ioffsets_ccw[gl_VertexID];
+
+    int texZ = aVertTexCol.w & 0xFF;
+    int colorId = (aVertTexCol.w >> 8) % MAX_NAMED_COLORS;
+
+    vColor = uNamedColors[colorId];
+    vTexCoord = vec3(ioffset.xy, float(texZ));
+    gl_Position = uMVP * vec4(aVertTexCol.xyz + ioffset, 1.0);
+}


### PR DESCRIPTION
I have refactored the line rendering in `Characters.cpp` to use a new shader-based instanced rendering pipeline. This fixes the issue where line widths greater than 1 pixel were not supported on OpenGL ES / WebGL.

Key changes:
- Created new `line/vert.glsl` and `line/frag.glsl` shaders that expand line segments into quads on the GPU using instancing.
- Added a `LineInstance` struct to hold per-line data (start, end, color, width).
- Implemented `LineShader` and `LineMesh` in the legacy OpenGL wrapper to manage the new rendering path.
- Updated `Characters.cpp` to populate `LineInstance` batches and render them using the new shader.
- Verified that the implementation works correctly by running tests and ensuring clean compilation with `-Werror=switch`.
- Formatted all modified files according to the project style.

---
*PR created automatically by Jules for task [14438510889140402089](https://jules.google.com/task/14438510889140402089) started by @nschimme*