### PR TITLE
Refactor Font Rendering to use Instancing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,31 +75,36 @@ if(Qt6Core_FOUND)
 endif()
 
 if(Qt6OpenGL_FOUND)
-    file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtGLES30.cpp
-        "#include <QOpenGLExtraFunctions>
-        #ifndef GL_TRIANGLES
-        # error
-        #endif
-        #ifdef Q_OS_MAC
-        # error
-        #endif
-        int main(int argc, char** argv) { return 0; }")
-    try_compile(QT_HAS_GLES
-                    ${CMAKE_BINARY_DIR}
-                    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtGLES30.cpp
-                    LINK_LIBRARIES Qt6::OpenGL
-                    OUTPUT_VARIABLE OUTPUT)
-    file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtOpenGL33.cpp
-        "#include <QOpenGLFunctions_3_3_Core>
-        #ifndef GL_QUADS
-        # error
-        #endif
-        int main(int argc, char** argv) { return 0; }")
-    try_compile(QT_HAS_OPENGL
-                    ${CMAKE_BINARY_DIR}
-                    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtOpenGL33.cpp
-                    LINK_LIBRARIES Qt6::OpenGL
-                    OUTPUT_VARIABLE OUTPUT)
+    if(EMSCRIPTEN)
+        set(QT_HAS_GLES TRUE)
+        set(QT_HAS_OPENGL FALSE)
+    else()
+        file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtGLES30.cpp
+            "#include <QOpenGLExtraFunctions>
+            #ifndef GL_TRIANGLES
+            # error
+            #endif
+            #ifdef Q_OS_MAC
+            # error
+            #endif
+            int main(int argc, char** argv) { return 0; }")
+        try_compile(QT_HAS_GLES
+                        ${CMAKE_BINARY_DIR}
+                        ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtGLES30.cpp
+                        LINK_LIBRARIES Qt6::OpenGL
+                        OUTPUT_VARIABLE OUTPUT)
+        file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtOpenGL33.cpp
+            "#include <QOpenGLFunctions_3_3_Core>
+            #ifndef GL_QUADS
+            # error
+            #endif
+            int main(int argc, char** argv) { return 0; }")
+        try_compile(QT_HAS_OPENGL
+                        ${CMAKE_BINARY_DIR}
+                        ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckQtOpenGL33.cpp
+                        LINK_LIBRARIES Qt6::OpenGL
+                        OUTPUT_VARIABLE OUTPUT)
+    endif()
     if (NOT QT_HAS_GLES)
         add_definitions(/DMMAPPER_NO_GLES)
     endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -682,8 +682,14 @@ set(mmapper_EXECUTABLE_ARGS
 )
 if(EMSCRIPTEN)
     qt_add_executable(mmapper ${mmapper_EXECUTABLE_ARGS})
-    target_link_options(mmapper PRIVATE -s FULL_ES3=1)
-    target_link_options(mmapper PUBLIC -sASYNCIFY -Os)
+    target_link_options(mmapper PRIVATE
+        -sFULL_ES3=1
+        -sMAX_WEBGL_VERSION=2
+        -sMIN_WEBGL_VERSION=2
+        -sASSERTIONS
+        -sASYNCIFY
+        -Os
+    )
     target_link_libraries(mmapper PUBLIC z)
 else()
     add_executable(mmapper WIN32 MACOSX_BUNDLE ${mmapper_EXECUTABLE_ARGS})

--- a/src/display/Characters.h
+++ b/src/display/Characters.h
@@ -106,7 +106,7 @@ private:
         std::vector<ColoredTexVert> m_charRoomQuads;
         std::vector<ColorVert> m_pathPoints;
         std::vector<ColorVert> m_pathLineQuads;
-        std::vector<FontVert3d> m_screenSpaceArrows;
+        std::vector<FontInstanceData> m_screenSpaceArrows;
         std::map<Coordinate, int, CoordCompare> m_coordCounts;
 
     public:

--- a/src/display/Connections.cpp
+++ b/src/display/Connections.cpp
@@ -131,7 +131,7 @@ NODISCARD UniqueMesh RoomNameBatchIntermediate::getMesh(GLFont &gl) const
 
 NODISCARD RoomNameBatchIntermediate RoomNameBatch::getIntermediate(const FontMetrics &font) const
 {
-    std::vector<FontVert3d> output;
+    std::vector<FontInstanceData> output;
     ::getFontBatchRawData(font, m_names.data(), m_names.size(), output);
     return RoomNameBatchIntermediate{std::move(output)};
 }

--- a/src/display/Connections.h
+++ b/src/display/Connections.h
@@ -28,7 +28,7 @@ struct FontMetrics;
 
 struct NODISCARD RoomNameBatchIntermediate final
 {
-    std::vector<FontVert3d> verts;
+    std::vector<FontInstanceData> verts;
 
     NODISCARD UniqueMesh getMesh(GLFont &gl) const;
     NODISCARD bool empty() const { return verts.empty(); }
@@ -39,7 +39,7 @@ struct NODISCARD RoomNameBatchIntermediate final
     {
         v.insert(v.end(), other.begin(), other.end());
     }
-    void append(const std::vector<FontVert3d> &other) { append(verts, other); }
+    void append(const std::vector<FontInstanceData> &other) { append(verts, other); }
 };
 
 struct NODISCARD RoomNameBatch final

--- a/src/display/Infomarks.h
+++ b/src/display/Infomarks.h
@@ -47,7 +47,7 @@ private:
     struct NODISCARD Text final
     {
         std::vector<GLText> text;
-        std::vector<FontVert3d> verts;
+        std::vector<FontInstanceData> verts;
         bool locked = false;
     };
 
@@ -74,7 +74,9 @@ public:
                     const Color color,
                     std::optional<Color> bgcolor,
                     FontFormatFlags fontFormatFlag,
-                    int rotationAngle);
+                    int rotationAngle,
+                    std::optional<NamedColorEnum> namedColor = std::nullopt,
+                    std::optional<NamedColorEnum> namedBgColor = std::nullopt);
 
     NODISCARD InfomarksMeshes getMeshes();
     void renderImmediate(const GLRenderState &state);

--- a/src/display/MapBatches.h
+++ b/src/display/MapBatches.h
@@ -33,15 +33,13 @@ struct NODISCARD LayerMeshes final
     explicit operator bool() const { return isValid; }
 };
 
-using PlainQuadBatch = std::vector<glm::vec3>;
-
 struct NODISCARD LayerMeshesIntermediate final
 {
     using Fn = std::function<UniqueMesh(OpenGL &)>;
     using FnVec = std::vector<Fn>;
     FnVec terrain;
     FnVec trails;
-    RoomTintArray<PlainQuadBatch> tints;
+    RoomTintArray<Fn> tints;
     FnVec overlays;
     FnVec doors;
     FnVec walls;
@@ -49,7 +47,7 @@ struct NODISCARD LayerMeshesIntermediate final
     FnVec upDownExits;
     FnVec streamIns;
     FnVec streamOuts;
-    PlainQuadBatch layerBoost;
+    Fn layerBoost;
     bool isValid = false;
 
     LayerMeshesIntermediate() = default;

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -283,6 +283,12 @@ void MapCanvas::initTextures()
         textures.stream_out[dir] = loadTexture(
             getPixmapFilenameRaw(QString::asprintf("stream-out-%s.png", lowercaseDirection(dir))));
     }
+    {
+        // 1x1
+        QImage whitePixel(1, 1, QImage::Format_RGBA8888);
+        whitePixel.fill(Qt::white);
+        textures.white_pixel = MMTexture::alloc(std::vector<QImage>{whitePixel});
+    }
 
     // char images are 256
     textures.char_arrows = loadTexture(getPixmapFilenameRaw("char-arrows.png"));
@@ -456,6 +462,13 @@ void MapCanvas::initTextures()
             auto thing = combine(textures.terrain, textures.road);
             maybeCreateArray2(thing, pArrayTex);
             textures.terrain_Array = textures.road_Array = pArrayTex;
+        }
+
+        {
+            SharedMMTexture pArrayTex;
+            std::vector<SharedMMTexture> pixels{textures.white_pixel};
+            maybeCreateArray2(pixels, pArrayTex);
+            textures.white_pixel_Array = pArrayTex;
         }
 
         {

--- a/src/display/Textures.h
+++ b/src/display/Textures.h
@@ -179,7 +179,8 @@ using TextureArrayNESWUD = EnumIndexedArray<SharedMMTexture, ExitDirEnum, NUM_EX
     X(SharedMMTexture, room_sel_distant) \
     X(SharedMMTexture, room_sel_move_bad) \
     X(SharedMMTexture, room_sel_move_good) \
-    X(SharedMMTexture, room_highlight)
+    X(SharedMMTexture, room_highlight) \
+    X(SharedMMTexture, white_pixel)
 
 struct NODISCARD MapCanvasTextures final
 {

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -1139,6 +1139,7 @@ void MapCanvas::selectionChanged()
 
 void MapCanvas::graphicsSettingsChanged()
 {
+    m_opengl.resetNamedColorsBuffer();
     update();
 }
 

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -66,25 +66,24 @@ private:
 
     struct NODISCARD Diff final
     {
+        using DiffQuadVector = std::vector<RoomQuadTexVert>;
+
         struct NODISCARD MaybeDataOrMesh final
-            : public std::variant<std::monostate, ColoredTexVertVector, UniqueMesh>
+            : public std::variant<std::monostate, DiffQuadVector, UniqueMesh>
         {
         public:
-            using base = std::variant<std::monostate, ColoredTexVertVector, UniqueMesh>;
+            using base = std::variant<std::monostate, DiffQuadVector, UniqueMesh>;
             using base::base;
 
         public:
             NODISCARD bool empty() const { return std::holds_alternative<std::monostate>(*this); }
-            NODISCARD bool hasData() const
-            {
-                return std::holds_alternative<ColoredTexVertVector>(*this);
-            }
+            NODISCARD bool hasData() const { return std::holds_alternative<DiffQuadVector>(*this); }
             NODISCARD bool hasMesh() const { return std::holds_alternative<UniqueMesh>(*this); }
 
         public:
-            NODISCARD const ColoredTexVertVector &getData() const
+            NODISCARD const DiffQuadVector &getData() const
             {
-                return std::get<ColoredTexVertVector>(*this);
+                return std::get<DiffQuadVector>(*this);
             }
             NODISCARD const UniqueMesh &getMesh() const { return std::get<UniqueMesh>(*this); }
 
@@ -96,7 +95,7 @@ private:
                 }
 
                 if (hasData()) {
-                    *this = gl.createColoredTexturedQuadBatch(getData(), texId);
+                    *this = gl.createRoomQuadTexBatch(getData(), texId);
                     assert(hasMesh());
                     // REVISIT: rendering immediately after uploading the mesh may lag,
                     // so consider delaying until the data is already on the GPU.
@@ -107,7 +106,7 @@ private:
                     return;
                 }
                 auto &mesh = getMesh();
-                mesh.render(GLRenderState().withBlend(BlendModeEnum::TRANSPARENCY));
+                mesh.render(gl.getDefaultRenderState().withBlend(BlendModeEnum::TRANSPARENCY));
             }
         };
 

--- a/src/global/NamedColors.cpp
+++ b/src/global/NamedColors.cpp
@@ -17,11 +17,13 @@ struct NODISCARD GlobalData final
     using InitArray = EnumIndexedArray<bool, NamedColorEnum, NUM_NAMED_COLORS>;
     using Map = std::map<std::string, NamedColorEnum>;
     using NamesVector = std::vector<std::string>;
+    using Vec4Vector = std::vector<glm::vec4>;
 
 private:
     Map m_map;
     NamesVector m_names;
     ColorVector m_colors;
+    Vec4Vector m_vec4s;
     InitArray m_initialized;
 
 private:
@@ -31,6 +33,7 @@ public:
     GlobalData()
     {
         m_colors.resize(NUM_NAMED_COLORS);
+        m_vec4s.resize(MAX_NAMED_COLORS);
         m_names.resize(NUM_NAMED_COLORS);
 
         static const auto white = Colors::white;
@@ -43,6 +46,7 @@ public:
             const auto color = (id == NamedColorEnum::TRANSPARENT) ? transparent_black : white;
 
             m_colors[idx] = color;
+            m_vec4s[idx] = color.getVec4();
             m_names[idx] = name;
             m_map.emplace(name, id);
         };
@@ -69,6 +73,7 @@ public:
 
         const auto idx = getIndex(id);
         m_colors.at(idx) = c;
+        m_vec4s.at(idx) = c.getVec4();
         m_initialized.at(id) = true;
         return true;
     }
@@ -81,6 +86,7 @@ public:
 
     NODISCARD const std::vector<std::string> &getAllNames() const { return m_names; }
     NODISCARD const std::vector<Color> &getAllColors() const { return m_colors; }
+    NODISCARD const std::vector<glm::vec4> &getAllVec4s() const { return m_vec4s; }
 
 public:
     NODISCARD std::optional<NamedColorEnum> lookup(std::string_view name) const
@@ -138,4 +144,9 @@ const std::vector<std::string> &XNamedColor::getAllNames()
 const std::vector<Color> &XNamedColor::getAllColors()
 {
     return getGlobalData().getAllColors();
+}
+
+const std::vector<glm::vec4> &XNamedColor::getAllColorsAsVec4()
+{
+    return getGlobalData().getAllVec4s();
 }

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -48,6 +48,9 @@ enum class NODISCARD NamedColorEnum : uint8_t { DEFAULT = 0, XFOREACH_NAMED_COLO
 static inline constexpr size_t NUM_NAMED_COLORS = XFOREACH_NAMED_COLOR_OPTIONS(X_COUNT) + 1;
 #undef X_COUNT
 
+static inline constexpr size_t MAX_NAMED_COLORS = 32;
+static_assert(MAX_NAMED_COLORS >= NUM_NAMED_COLORS);
+
 // TODO: rename this, but to what? NamedColorHandle?
 class NODISCARD XNamedColor final
 {
@@ -98,5 +101,6 @@ public:
 
 public:
     NODISCARD static const std::vector<Color> &getAllColors();
+    NODISCARD static const std::vector<glm::vec4> &getAllColorsAsVec4();
     NODISCARD static const std::vector<std::string> &getAllNames();
 };

--- a/src/global/hash.h
+++ b/src/global/hash.h
@@ -4,6 +4,7 @@
 
 #include "macros.h"
 
+#include <cstdint>
 #include <cstring>
 #include <string_view>
 #include <type_traits>
@@ -18,10 +19,14 @@ MAYBE_UNUSED NODISCARD static auto numeric_hash(const T val) noexcept
     return std::hash<std::string_view>()({buf, size});
 }
 
+#if INTPTR_MAX == INT64_MAX
+static constexpr size_t GOLDEN_RATIO = 0x9e3779b97f4a7c15ULL;
+#else
+static constexpr size_t GOLDEN_RATIO = 0x9e3779b9U;
+#endif
+
 template<typename T>
 void hash_combine(std::size_t &seed, const T &value) noexcept
 {
-    constexpr const size_t GOLDEN_RATIO = (sizeof(size_t) == 8) ? 0x9e3779b97f4a7c15ULL
-                                                                : 0x9e3779b9U;
     seed ^= std::hash<T>{}(value) + GOLDEN_RATIO + (seed << 6) + (seed >> 2);
 }

--- a/src/opengl/Font.cpp
+++ b/src/opengl/Font.cpp
@@ -766,10 +766,17 @@ void GLFont::init()
             fm.tryAddSyntheticGlyphs(img);
             img = img.mirrored();
 
+            const QImage converted = img.convertToFormat(QImage::Format_RGBA8888);
+            tex.setFormat(QOpenGLTexture::TextureFormat::RGBA8_UNorm);
             tex.setMinMagFilters(QOpenGLTexture::Filter::Linear, QOpenGLTexture::Filter::Linear);
             tex.setAutoMipMapGenerationEnabled(false);
             tex.setMipLevels(0);
-            tex.setData(img, QOpenGLTexture::MipMapGeneration::DontGenerateMipMaps);
+            tex.setSize(converted.width(), converted.height());
+            tex.allocateStorage();
+            tex.setData(0,
+                        QOpenGLTexture::PixelFormat::RGBA,
+                        QOpenGLTexture::PixelType::UInt8,
+                        converted.constBits());
         },
         true);
 

--- a/src/opengl/Font.cpp
+++ b/src/opengl/Font.cpp
@@ -562,7 +562,7 @@ public:
             m_bounds.include(iVertex00 + iglyphSize);
         }
 
-        if (m_noOutput) {
+        if (m_noOutput || isEmpty) {
             return;
         }
 
@@ -574,7 +574,8 @@ public:
         uint32_t color = m_opts.fgColor.getUint32();
         if (m_opts.namedColor) {
             flags |= FONT_FLAG_NAMED_COLOR;
-            color = static_cast<uint32_t>(m_opts.namedColor.value());
+            color = (color & 0xFF000000u)
+                    | (static_cast<uint32_t>(m_opts.namedColor.value()) & 0x00FFFFFFu);
         }
 
         m_verts3d.emplace_back(m_opts.pos,
@@ -665,7 +666,8 @@ public:
                     uint32_t color = m_opts.optBgColor.value().getUint32();
                     if (m_opts.namedBgColor) {
                         flags |= FONT_FLAG_NAMED_COLOR;
-                        color = static_cast<uint32_t>(m_opts.namedBgColor.value());
+                        color = (color & 0xFF000000u)
+                                | (static_cast<uint32_t>(m_opts.namedBgColor.value()) & 0x00FFFFFFu);
                     }
                     emitSpecialInstance(color,
                                         flags,
@@ -682,7 +684,8 @@ public:
                     uint32_t color = m_opts.fgColor.getUint32();
                     if (m_opts.namedColor) {
                         flags |= FONT_FLAG_NAMED_COLOR;
-                        color = static_cast<uint32_t>(m_opts.namedColor.value());
+                        color = (color & 0xFF000000u)
+                                | (static_cast<uint32_t>(m_opts.namedColor.value()) & 0x00FFFFFFu);
                     }
                     emitSpecialInstance(color,
                                         flags,
@@ -834,7 +837,12 @@ void FontMetrics::getFontBatchRawData(const GLText *const text,
             }
 
             for (const char &c : it->text) {
-                if (lookupGlyph(c) != nullptr || hasOops) {
+                const Glyph *g = lookupGlyph(c);
+                if (g == nullptr && hasOops) {
+                    g = lookupGlyph(char_consts::C_QUESTION_MARK);
+                }
+
+                if (g != nullptr && !std::isspace(static_cast<unsigned char>(g->id))) {
                     numGlyphs++;
                 }
             }

--- a/src/opengl/Font.cpp
+++ b/src/opengl/Font.cpp
@@ -901,7 +901,7 @@ std::vector<FontInstanceData> GLFont::getFontMeshIntermediate(const std::vector<
 
 UniqueMesh GLFont::getFontMesh(const std::vector<FontInstanceData> &rawVerts)
 {
-    return m_gl.createFontMesh(m_texture, DrawModeEnum::QUADS, rawVerts);
+    return m_gl.createFontMesh(m_texture, rawVerts);
 }
 
 void GLFont::renderTextCentered(const QString &text,

--- a/src/opengl/Font.cpp
+++ b/src/opengl/Font.cpp
@@ -38,9 +38,6 @@ static const bool VERBOSE_FONT_DEBUG = std::invoke([]() -> bool {
     return false;
 });
 
-static constexpr uint32_t MASK_RGB = 0x00FFFFFFu;
-static constexpr uint32_t MASK_ALPHA = 0xFF000000u;
-
 // NOTE: Rect doesn't actually include the hi value.
 struct NODISCARD Rect final
 {
@@ -577,8 +574,7 @@ public:
         uint32_t color = m_opts.fgColor.getUint32();
         if (m_opts.namedColor) {
             flags |= FONT_FLAG_NAMED_COLOR;
-            color = (color & MASK_ALPHA)
-                    | (static_cast<uint32_t>(m_opts.namedColor.value()) & MASK_RGB);
+            flags |= static_cast<uint16_t>(static_cast<uint16_t>(m_opts.namedColor.value()) << 8);
         }
 
         m_verts3d.emplace_back(m_opts.pos,
@@ -669,8 +665,7 @@ public:
                     uint32_t color = m_opts.optBgColor.value().getUint32();
                     if (m_opts.namedBgColor) {
                         flags |= FONT_FLAG_NAMED_COLOR;
-                        color = (color & MASK_ALPHA)
-                                | (static_cast<uint32_t>(m_opts.namedBgColor.value()) & MASK_RGB);
+                        flags |= static_cast<uint16_t>(static_cast<uint16_t>(m_opts.namedBgColor.value()) << 8);
                     }
                     emitSpecialInstance(color,
                                         flags,
@@ -687,8 +682,7 @@ public:
                     uint32_t color = m_opts.fgColor.getUint32();
                     if (m_opts.namedColor) {
                         flags |= FONT_FLAG_NAMED_COLOR;
-                        color = (color & MASK_ALPHA)
-                                | (static_cast<uint32_t>(m_opts.namedColor.value()) & MASK_RGB);
+                        flags |= static_cast<uint16_t>(static_cast<uint16_t>(m_opts.namedColor.value()) << 8);
                     }
                     emitSpecialInstance(color,
                                         flags,

--- a/src/opengl/Font.cpp
+++ b/src/opengl/Font.cpp
@@ -629,9 +629,6 @@ public:
         {
             const auto emitSpecialInstance =
                 [this](uint32_t color, uint16_t flags, const Rect &vert, const Rect &tc) {
-                    if (m_noOutput) {
-                        return;
-                    }
                     m_verts3d.emplace_back(m_opts.pos,
                                            color,
                                            static_cast<int16_t>(vert.lo.x),

--- a/src/opengl/Font.cpp
+++ b/src/opengl/Font.cpp
@@ -38,6 +38,9 @@ static const bool VERBOSE_FONT_DEBUG = std::invoke([]() -> bool {
     return false;
 });
 
+static constexpr uint32_t MASK_RGB = 0x00FFFFFFu;
+static constexpr uint32_t MASK_ALPHA = 0xFF000000u;
+
 // NOTE: Rect doesn't actually include the hi value.
 struct NODISCARD Rect final
 {
@@ -574,8 +577,8 @@ public:
         uint32_t color = m_opts.fgColor.getUint32();
         if (m_opts.namedColor) {
             flags |= FONT_FLAG_NAMED_COLOR;
-            color = (color & 0xFF000000u)
-                    | (static_cast<uint32_t>(m_opts.namedColor.value()) & 0x00FFFFFFu);
+            color = (color & MASK_ALPHA)
+                    | (static_cast<uint32_t>(m_opts.namedColor.value()) & MASK_RGB);
         }
 
         m_verts3d.emplace_back(m_opts.pos,
@@ -666,8 +669,8 @@ public:
                     uint32_t color = m_opts.optBgColor.value().getUint32();
                     if (m_opts.namedBgColor) {
                         flags |= FONT_FLAG_NAMED_COLOR;
-                        color = (color & 0xFF000000u)
-                                | (static_cast<uint32_t>(m_opts.namedBgColor.value()) & 0x00FFFFFFu);
+                        color = (color & MASK_ALPHA)
+                                | (static_cast<uint32_t>(m_opts.namedBgColor.value()) & MASK_RGB);
                     }
                     emitSpecialInstance(color,
                                         flags,
@@ -684,8 +687,8 @@ public:
                     uint32_t color = m_opts.fgColor.getUint32();
                     if (m_opts.namedColor) {
                         flags |= FONT_FLAG_NAMED_COLOR;
-                        color = (color & 0xFF000000u)
-                                | (static_cast<uint32_t>(m_opts.namedColor.value()) & 0x00FFFFFFu);
+                        color = (color & MASK_ALPHA)
+                                | (static_cast<uint32_t>(m_opts.namedColor.value()) & MASK_RGB);
                     }
                     emitSpecialInstance(color,
                                         flags,

--- a/src/opengl/Font.cpp
+++ b/src/opengl/Font.cpp
@@ -328,13 +328,16 @@ struct NODISCARD FontMetrics final
 
     void getFontBatchRawData(const GLText *text,
                              size_t count,
-                             std::vector<FontVert3d> &output) const;
+                             std::vector<FontInstanceData> &output) const;
 };
+
+static constexpr uint16_t FONT_FLAG_ITALICS = 1 << 0;
+static constexpr uint16_t FONT_FLAG_NAMED_COLOR = 1 << 1;
 
 void getFontBatchRawData(const FontMetrics &fm,
                          const GLText *const text,
                          const size_t count,
-                         std::vector<FontVert3d> &output)
+                         std::vector<FontInstanceData> &output)
 {
     fm.getFontBatchRawData(text, count, output);
 }
@@ -490,12 +493,13 @@ private:
         glm::vec3 pos{0.f};
         Color fgColor;
         std::optional<Color> optBgColor;
+        std::optional<NamedColorEnum> namedColor;
+        std::optional<NamedColorEnum> namedBgColor;
         bool wantItalics = false;
         bool wantUnderline = false;
         bool wantAlignCenter = false;
         bool wantAlignRight = false;
         int rotationDegrees = 0;
-        std::optional<glm::mat4> rotation = glm::mat4(1.f);
 
         explicit Opts() = default;
 
@@ -506,17 +510,13 @@ private:
             , pos{text.pos}
             , fgColor{text.color}
             , optBgColor{text.bgcolor}
+            , namedColor{text.namedColor}
+            , namedBgColor{text.namedBgColor}
             , wantItalics{text.fontFormatFlag.contains(FontFormatFlagEnum::ITALICS)}
             , wantUnderline{text.fontFormatFlag.contains(FontFormatFlagEnum::UNDERLINE)}
             , wantAlignCenter{text.fontFormatFlag.contains(FontFormatFlagEnum::HALIGN_CENTER)}
             , wantAlignRight{text.fontFormatFlag.contains(FontFormatFlagEnum::HALIGN_RIGHT)}
             , rotationDegrees{text.rotationAngle}
-            , rotation{(rotationDegrees == 0)
-                           ? std::optional<glm::mat4>(std::nullopt)
-                           : std::optional<glm::mat4>(
-                                 glm::rotate(glm::mat4(1),
-                                             glm::radians(static_cast<float>(rotationDegrees)),
-                                             glm::vec3(0, 0, 1)))}
         {}
     };
 
@@ -533,8 +533,7 @@ private:
 
 private:
     const FontMetrics &m_fm;
-    const glm::ivec2 m_iTexSize{};
-    std::vector<FontVert3d> &m_verts3d;
+    std::vector<FontInstanceData> &m_verts3d;
     Opts m_opts;
     Bounds m_bounds;
     int m_xlinepos = 0;
@@ -548,64 +547,48 @@ private:
     }
 
 public:
-    explicit FontBatchBuilder(const FontMetrics &fm, std::vector<FontVert3d> &output)
+    explicit FontBatchBuilder(const FontMetrics &fm, std::vector<FontInstanceData> &output)
         : m_fm{fm}
-        , m_iTexSize{fm.common.scaleW, fm.common.scaleH}
         , m_verts3d{output}
     {}
 
-    NODISCARD glm::vec2 getTexCoord(const glm::ivec2 &iTexCoord) const
+    void emitGlyphInstance(const bool isEmpty,
+                           const glm::ivec2 &iVertex00,
+                           const glm::ivec2 &iTexCoord00,
+                           const glm::ivec2 &iglyphSize)
     {
-        return glm::vec2(iTexCoord) / glm::vec2(m_iTexSize);
-    }
+        if (!isEmpty) {
+            m_bounds.include(iVertex00);
+            m_bounds.include(iVertex00 + iglyphSize);
+        }
 
-    // REVISIT: This could be done in the shader,
-    // at the cost of transmitting italics bit and rotation angle.
-    NODISCARD glm::vec2 transformVert(const glm::ivec2 &ipos) const
-    {
-        glm::vec2 pos(ipos);
+        if (m_noOutput) {
+            return;
+        }
 
+        uint16_t flags = 0;
         if (m_opts.wantItalics) {
-            pos.x += pos.y / 6.f;
+            flags |= FONT_FLAG_ITALICS;
         }
 
-        if (m_opts.rotation) {
-            pos = glm::vec2(m_opts.rotation.value() * glm::vec4(pos, 0, 1));
+        uint32_t color = m_opts.fgColor.getUint32();
+        if (m_opts.namedColor) {
+            flags |= FONT_FLAG_NAMED_COLOR;
+            color = static_cast<uint32_t>(m_opts.namedColor.value());
         }
-        return pos;
-    }
 
-    void emitGlyphQuad(const bool isEmpty,
-                       const glm::ivec2 &iVertex00,
-                       const glm::ivec2 &iTexCoord00,
-                       const glm::ivec2 &iglyphSize)
-    {
-        const auto emitWithOffset =
-            [this, isEmpty, &iVertex00, &iTexCoord00](const glm::ivec2 &pixelOffset) -> void {
-            const glm::ivec2 relativeVertPos = iVertex00 + pixelOffset;
-            if (!isEmpty) {
-                // side-effect: updates bounds; this must come before return
-                m_bounds.include(relativeVertPos);
-            }
-
-            if (m_noOutput) {
-                return;
-            }
-
-            const glm::vec2 tc = getTexCoord(iTexCoord00 + pixelOffset);
-            const glm::vec2 vert = transformVert(relativeVertPos);
-            m_verts3d.emplace_back(m_opts.pos, m_opts.fgColor, tc, vert);
-        };
-
-        const auto &x = iglyphSize.x;
-        const auto &y = iglyphSize.y;
-        // 3-2
-        // | |
-        // 0-1
-        emitWithOffset(glm::ivec2(0, 0));
-        emitWithOffset(glm::ivec2(x, 0));
-        emitWithOffset(glm::ivec2(x, y));
-        emitWithOffset(glm::ivec2(0, y));
+        m_verts3d.emplace_back(m_opts.pos,
+                               color,
+                               static_cast<int16_t>(iVertex00.x),
+                               static_cast<int16_t>(iVertex00.y),
+                               static_cast<int16_t>(iglyphSize.x),
+                               static_cast<int16_t>(iglyphSize.y),
+                               static_cast<int16_t>(iTexCoord00.x),
+                               static_cast<int16_t>(iTexCoord00.y),
+                               static_cast<int16_t>(iglyphSize.x),
+                               static_cast<int16_t>(iglyphSize.y),
+                               static_cast<int16_t>(m_opts.rotationDegrees),
+                               flags);
     }
 
     void emitGlyph(const FontMetrics::Glyph *const g, const FontMetrics::Kerning *const k)
@@ -619,7 +602,7 @@ public:
         }
         const auto iVertex00 = glm::ivec2(m_xlinepos + g->xoffset, g->yoffset);
         m_xlinepos += g->xadvance;
-        emitGlyphQuad(std::isspace(g->id), iVertex00, iTexCoord00, glyphSize);
+        emitGlyphInstance(std::isspace(g->id), iVertex00, iTexCoord00, glyphSize);
     }
 
     void call_foreach_glyph(const int wordOffset, const bool output)
@@ -644,25 +627,26 @@ public:
 
         // measurement, background color, and underline.
         {
-            const auto add = [this](const Color c, const glm::ivec2 &ivert, const glm::ivec2 &itc) {
-                const glm::vec2 tc = getTexCoord(itc);
-                const glm::vec2 vert = transformVert(ivert);
-                m_verts3d.emplace_back(m_opts.pos, c, tc, vert);
-            };
-
-            const auto quad = [&add](const Color c, const Rect &vert, const Rect &tc) {
-#define ADD(a, b) add(c, glm::ivec2{vert.a.x, vert.b.y}, glm::ivec2{tc.a.x, tc.b.y})
-                // note: lo and hi refer to members of vert and tc.
-                ADD(lo, lo);
-                ADD(hi, lo);
-                ADD(hi, hi);
-                ADD(lo, hi);
-#undef ADD
-            };
+            const auto emitSpecialInstance =
+                [this](uint32_t color, uint16_t flags, const Rect &vert, const Rect &tc) {
+                    if (m_noOutput) {
+                        return;
+                    }
+                    m_verts3d.emplace_back(m_opts.pos,
+                                           color,
+                                           static_cast<int16_t>(vert.lo.x),
+                                           static_cast<int16_t>(vert.lo.y),
+                                           static_cast<int16_t>(vert.width()),
+                                           static_cast<int16_t>(vert.height()),
+                                           static_cast<int16_t>(tc.lo.x),
+                                           static_cast<int16_t>(tc.lo.y),
+                                           static_cast<int16_t>(tc.width()),
+                                           static_cast<int16_t>(tc.height()),
+                                           static_cast<int16_t>(m_opts.rotationDegrees),
+                                           flags);
+                };
 
             const glm::ivec2 margin{m_fm.common.marginX, m_fm.common.marginY};
-            const auto &lo = m_bounds.minVertPos;
-            const auto &hi = m_bounds.maxVertPos;
 
             if (m_opts.wantAlignCenter) {
                 const auto halfWidth = m_xlinepos / 2;
@@ -675,11 +659,21 @@ public:
                 m_bounds.maxVertPos.x -= m_xlinepos;
             }
 
+            const auto &lo = m_bounds.minVertPos;
+            const auto &hi = m_bounds.maxVertPos;
+
             if (m_opts.optBgColor) {
                 if (const FontMetrics::Glyph *const background = m_fm.getBackground()) {
-                    quad(m_opts.optBgColor.value(),
-                         Rect{lo - margin, hi + margin},
-                         background->getRect());
+                    uint16_t flags = 0;
+                    uint32_t color = m_opts.optBgColor.value().getUint32();
+                    if (m_opts.namedBgColor) {
+                        flags |= FONT_FLAG_NAMED_COLOR;
+                        color = static_cast<uint32_t>(m_opts.namedBgColor.value());
+                    }
+                    emitSpecialInstance(color,
+                                        flags,
+                                        Rect{lo - margin, hi + margin},
+                                        background->getRect());
                 }
             }
 
@@ -687,9 +681,16 @@ public:
                 if (const FontMetrics::Glyph *const underline = m_fm.getUnderline()) {
                     const auto usize = underline->getSize();
                     const auto offset = underline->getOffset() + glm::ivec2{wordOffset, 0};
-                    quad(m_opts.fgColor,
-                         Rect{offset, offset + glm::ivec2{m_xlinepos, usize.y}},
-                         underline->getRect());
+                    uint16_t flags = 0;
+                    uint32_t color = m_opts.fgColor.getUint32();
+                    if (m_opts.namedColor) {
+                        flags |= FONT_FLAG_NAMED_COLOR;
+                        color = static_cast<uint32_t>(m_opts.namedColor.value());
+                    }
+                    emitSpecialInstance(color,
+                                        flags,
+                                        Rect{offset, offset + glm::ivec2{m_xlinepos, usize.y}},
+                                        underline->getRect());
                 }
             }
         }
@@ -812,7 +813,7 @@ glm::ivec2 GLFont::getScreenCenter() const
 
 void FontMetrics::getFontBatchRawData(const GLText *const text,
                                       const size_t count,
-                                      std::vector<FontVert3d> &output) const
+                                      std::vector<FontInstanceData> &output) const
 {
     if (count == 0) {
         return;
@@ -821,23 +822,23 @@ void FontMetrics::getFontBatchRawData(const GLText *const text,
     const auto before = output.size();
     const auto end = text + count;
 
-    const size_t expectedVerts = std::invoke([text, end]() -> size_t {
+    const size_t expectedInstances = std::invoke([text, end]() -> size_t {
         int numGlyphs = 0;
         for (const GLText *it = text; it != end; ++it) {
             numGlyphs += static_cast<int>(it->text.size()) + (it->bgcolor.has_value() ? 1 : 0)
                          + (it->fontFormatFlag.contains(FontFormatFlagEnum::UNDERLINE) ? 1 : 0);
         }
-        return 4 * static_cast<size_t>(numGlyphs);
+        return static_cast<size_t>(numGlyphs);
     });
 
-    output.reserve(before + expectedVerts);
+    output.reserve(before + expectedInstances);
 
     auto &fm = *this;
     FontBatchBuilder fontBatchBuilder{fm, output};
     for (const GLText *it = text; it != end; ++it) {
         fontBatchBuilder.addString(*it);
     }
-    assert(output.size() == before + expectedVerts);
+    assert(output.size() == before + expectedInstances);
 }
 
 void GLFont::render2dTextImmediate(const std::vector<GLText> &text)
@@ -861,7 +862,7 @@ void GLFont::render2dTextImmediate(const std::vector<GLText> &text)
     m_gl.setProjectionMatrix(oldProj);
 }
 
-void GLFont::render3dTextImmediate(const std::vector<FontVert3d> &rawVerts)
+void GLFont::render3dTextImmediate(const std::vector<FontInstanceData> &rawVerts)
 {
     if (rawVerts.empty()) {
         return;
@@ -880,14 +881,14 @@ void GLFont::render3dTextImmediate(const std::vector<GLText> &text)
     render3dTextImmediate(rawVerts);
 }
 
-std::vector<FontVert3d> GLFont::getFontMeshIntermediate(const std::vector<GLText> &text)
+std::vector<FontInstanceData> GLFont::getFontMeshIntermediate(const std::vector<GLText> &text)
 {
-    std::vector<FontVert3d> output;
+    std::vector<FontInstanceData> output;
     getFontMetrics().getFontBatchRawData(text.data(), text.size(), output);
     return output;
 }
 
-UniqueMesh GLFont::getFontMesh(const std::vector<FontVert3d> &rawVerts)
+UniqueMesh GLFont::getFontMesh(const std::vector<FontInstanceData> &rawVerts)
 {
     return m_gl.createFontMesh(m_texture, DrawModeEnum::QUADS, rawVerts);
 }

--- a/src/opengl/Font.h
+++ b/src/opengl/Font.h
@@ -29,19 +29,25 @@ struct NODISCARD GLText final
     std::optional<Color> bgcolor;
     FontFormatFlags fontFormatFlag;
     int rotationAngle = 0;
+    std::optional<NamedColorEnum> namedColor;
+    std::optional<NamedColorEnum> namedBgColor;
 
     explicit GLText(const glm::vec3 &pos_,
                     std::string moved_text,
                     const Color color_ = {},
                     std::optional<Color> bgcolor_ = {},
                     const FontFormatFlags fontFormatFlag_ = {},
-                    int rotationAngle_ = 0)
+                    int rotationAngle_ = 0,
+                    std::optional<NamedColorEnum> namedColor_ = std::nullopt,
+                    std::optional<NamedColorEnum> namedBgColor_ = std::nullopt)
         : pos{pos_}
         , text{std::move(moved_text)}
         , color{color_}
         , bgcolor{bgcolor_}
         , fontFormatFlag{fontFormatFlag_}
         , rotationAngle{rotationAngle_}
+        , namedColor{namedColor_}
+        , namedBgColor{namedBgColor_}
     {}
 };
 
@@ -92,14 +98,14 @@ public:
                             std::optional<Color> bgcolor = {});
     void render2dTextImmediate(const std::vector<GLText> &text);
     void render3dTextImmediate(const std::vector<GLText> &text);
-    void render3dTextImmediate(const std::vector<FontVert3d> &rawVerts);
+    void render3dTextImmediate(const std::vector<FontInstanceData> &rawVerts);
 
 public:
-    NODISCARD std::vector<FontVert3d> getFontMeshIntermediate(const std::vector<GLText> &text);
-    NODISCARD UniqueMesh getFontMesh(const std::vector<FontVert3d> &text);
+    NODISCARD std::vector<FontInstanceData> getFontMeshIntermediate(const std::vector<GLText> &text);
+    NODISCARD UniqueMesh getFontMesh(const std::vector<FontInstanceData> &text);
 };
 
 extern void getFontBatchRawData(const FontMetrics &fm,
                                 const GLText *text,
                                 size_t count,
-                                std::vector<FontVert3d> &output);
+                                std::vector<FontInstanceData> &output);

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -142,7 +142,7 @@ UniqueMesh OpenGL::createRoomQuadTexBatch(const std::vector<RoomQuadTexVert> &ba
 
 UniqueMesh OpenGL::createFontMesh(const SharedMMTexture &texture,
                                   const DrawModeEnum mode,
-                                  const std::vector<FontVert3d> &batch)
+                                  const std::vector<FontInstanceData> &batch)
 {
     return getFunctions().createFontMesh(texture, mode, batch);
 }
@@ -268,7 +268,7 @@ void OpenGL::initializeRenderer(const float devicePixelRatio)
     m_rendererInitialized = true;
 }
 
-void OpenGL::renderFont3d(const SharedMMTexture &texture, const std::vector<FontVert3d> &verts)
+void OpenGL::renderFont3d(const SharedMMTexture &texture, const std::vector<FontInstanceData> &verts)
 {
     getFunctions().renderFont3d(texture, verts);
 }

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -141,10 +141,9 @@ UniqueMesh OpenGL::createRoomQuadTexBatch(const std::vector<RoomQuadTexVert> &ba
 }
 
 UniqueMesh OpenGL::createFontMesh(const SharedMMTexture &texture,
-                                  const DrawModeEnum mode,
                                   const std::vector<FontInstanceData> &batch)
 {
-    return getFunctions().createFontMesh(texture, mode, batch);
+    return getFunctions().createFontMesh(texture, batch);
 }
 
 void OpenGL::clear(const Color color)

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -316,7 +316,8 @@ void OpenGL::initArrayFromFiles(const SharedMMTexture &array, const std::vector<
 
     const auto numLayers = static_cast<GLsizei>(input.size());
     for (GLsizei i = 0; i < numLayers; ++i) {
-        QImage image = QImage{input[static_cast<size_t>(i)]}.mirrored();
+        const QImage image = QImage{input[static_cast<size_t>(i)]}.mirrored().convertToFormat(
+            QImage::Format_RGBA8888);
         if (image.width() != qtex.width() || image.height() != qtex.height()) {
             std::ostringstream oss;
             oss << "Image is " << image.width() << "x" << image.height() << ", but expected "
@@ -324,18 +325,17 @@ void OpenGL::initArrayFromFiles(const SharedMMTexture &array, const std::vector<
             auto s = std::move(oss).str();
             MMLOG_ERROR() << s.c_str();
         }
-        const QImage swappedImage = std::move(image).rgbSwapped();
         gl.glTexSubImage3D(GL_TEXTURE_2D_ARRAY,
                            0,
                            0,
                            0,
                            i,
-                           swappedImage.width(),
-                           swappedImage.height(),
+                           image.width(),
+                           image.height(),
                            1,
                            GL_RGBA,
                            GL_UNSIGNED_BYTE,
-                           swappedImage.constBits());
+                           image.constBits());
     }
 
     gl.glGenerateMipmap(GL_TEXTURE_2D_ARRAY);
@@ -362,7 +362,7 @@ void OpenGL::initArrayFromImages(const SharedMMTexture &array,
         assert(ipow2 == layer.front().height());
 
         for (size_t level_num = 0; level_num < numLevels; ++level_num) {
-            const QImage &image = layer[level_num];
+            const QImage image = layer[level_num].convertToFormat(QImage::Format_RGBA8888);
             if (image.width() != (qtex.width() >> level_num)
                 || image.height() != (qtex.height() >> level_num)) {
                 std::ostringstream oss;
@@ -373,18 +373,17 @@ void OpenGL::initArrayFromImages(const SharedMMTexture &array,
                 MMLOG_ERROR() << s.c_str();
             }
 
-            const QImage swappedImage = std::move(image).rgbSwapped();
             gl.glTexSubImage3D(GL_TEXTURE_2D_ARRAY,
                                static_cast<GLint>(level_num),
                                0,
                                0,
                                static_cast<GLint>(z),
-                               swappedImage.width(),
-                               swappedImage.height(),
+                               image.width(),
+                               image.height(),
                                1,
                                GL_RGBA,
                                GL_UNSIGNED_BYTE,
-                               swappedImage.constBits());
+                               image.constBits());
         }
     }
 

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -89,6 +89,11 @@ public:
     NODISCARD UniqueMesh createColoredTexturedQuadBatch(const std::vector<ColoredTexVert> &verts,
                                                         MMTextureId texture);
 
+public:
+    NODISCARD UniqueMesh createRoomQuadTexBatch(const std::vector<RoomQuadTexVert> &verts,
+                                                MMTextureId texture);
+
+public:
     NODISCARD UniqueMesh createFontMesh(const SharedMMTexture &texture,
                                         DrawModeEnum mode,
                                         const std::vector<FontVert3d> &batch);
@@ -161,6 +166,9 @@ public:
 
 public:
     void cleanup();
+    NODISCARD GLRenderState getDefaultRenderState();
+    void bindNamedColorsBuffer();
+    void resetNamedColorsBuffer();
     void setTextureLookup(MMTextureId, SharedMMTexture);
 
 public:

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -95,7 +95,6 @@ public:
 
 public:
     NODISCARD UniqueMesh createFontMesh(const SharedMMTexture &texture,
-                                        DrawModeEnum mode,
                                         const std::vector<FontInstanceData> &batch);
 
 protected:

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -96,7 +96,7 @@ public:
 public:
     NODISCARD UniqueMesh createFontMesh(const SharedMMTexture &texture,
                                         DrawModeEnum mode,
-                                        const std::vector<FontVert3d> &batch);
+                                        const std::vector<FontInstanceData> &batch);
 
 protected:
     void renderPlain(DrawModeEnum type,
@@ -157,7 +157,7 @@ public:
     }
 
 public:
-    void renderFont3d(const SharedMMTexture &texture, const std::vector<FontVert3d> &verts);
+    void renderFont3d(const SharedMMTexture &texture, const std::vector<FontInstanceData> &verts);
 
 public:
     void clear(const Color color);

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -51,6 +51,29 @@ struct NODISCARD ColoredTexVert final
     {}
 };
 
+struct NODISCARD RoomQuadTexVert final
+{
+    // xyz = room coord, w = (colorId << 8 | tex_z)
+    // - colorId: packed into bits 8-15 (must be < MAX_NAMED_COLORS)
+    // - tex_z:   packed into bits 0-7  (must be < 256)
+    glm::ivec4 vertTexCol{};
+
+    explicit RoomQuadTexVert(const glm::ivec3 &vert, const int tex_z)
+        : RoomQuadTexVert{vert, tex_z, NamedColorEnum::DEFAULT}
+    {}
+
+    explicit RoomQuadTexVert(const glm::ivec3 &vert, const int tex_z, const NamedColorEnum color)
+        : vertTexCol{vert, (static_cast<uint8_t>(color) << 8) | tex_z}
+    {
+        if (IS_DEBUG_BUILD) {
+            constexpr auto max_texture_layers = 256;
+            const auto c = static_cast<uint8_t>(color);
+            assert(c == std::clamp<uint8_t>(c, 0, NUM_NAMED_COLORS - 1));
+            assert(tex_z == std::clamp(tex_z, 0, max_texture_layers - 1));
+        }
+    }
+};
+
 using ColoredTexVertVector = std::vector<ColoredTexVert>;
 
 struct NODISCARD ColorVert final
@@ -88,7 +111,14 @@ struct NODISCARD FontVert3d final
     {}
 };
 
-enum class NODISCARD DrawModeEnum { INVALID = 0, POINTS = 1, LINES = 2, TRIANGLES = 3, QUADS = 4 };
+enum class NODISCARD DrawModeEnum {
+    INVALID = 0,
+    POINTS = 1,
+    LINES = 2,
+    TRIANGLES = 3,
+    QUADS = 4,
+    INSTANCED_QUADS = 5
+};
 
 struct NODISCARD LineParams final
 {
@@ -344,6 +374,7 @@ public:
     DEFAULT_MOVES_DELETE_COPIES(UniqueMesh);
 
     void render(const GLRenderState &rs) const { deref(m_mesh).render(rs); }
+    NODISCARD explicit operator bool() const { return m_mesh != nullptr; }
 };
 
 struct NODISCARD UniqueMeshVector final

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -87,27 +87,45 @@ struct NODISCARD ColorVert final
     {}
 };
 
-// Similar to ColoredTexVert, except it has a base position in world coordinates.
+// Instance data for font rendering.
 // the font's vertex shader transforms the world position to screen space,
-// rounds to integer pixel offset, and then adds the vertex position in screen space.
-//
-// Rendering with the font shader requires passing uniforms for the world space
-// model-view-projection matrix and the output viewport.
-struct NODISCARD FontVert3d final
+// rounds to integer pixel offset, and then adds the (possibly rotated/italicized)
+// vertex offset in screen space.
+struct NODISCARD FontInstanceData final
 {
     glm::vec3 base{}; // world space
-    Color color;
-    glm::vec2 tex{};
-    glm::vec2 vert{}; // screen space
+    uint32_t color = 0;
+    int16_t offsetX = 0, offsetY = 0;
+    int16_t sizeW = 0, sizeH = 0;
+    int16_t uvX = 0, uvY = 0;
+    int16_t uvW = 0, uvH = 0;
+    int16_t rotation = 0;
+    uint16_t flags = 0;
 
-    explicit FontVert3d(const glm::vec3 &base_,
-                        const Color color_,
-                        const glm::vec2 &tex_,
-                        const glm::vec2 &vert_)
+    explicit FontInstanceData(const glm::vec3 &base_,
+                              uint32_t color_,
+                              int16_t offsetX_,
+                              int16_t offsetY_,
+                              int16_t sizeW_,
+                              int16_t sizeH_,
+                              int16_t uvX_,
+                              int16_t uvY_,
+                              int16_t uvW_,
+                              int16_t uvH_,
+                              int16_t rotation_,
+                              uint16_t flags_)
         : base{base_}
         , color{color_}
-        , tex{tex_}
-        , vert{vert_}
+        , offsetX{offsetX_}
+        , offsetY{offsetY_}
+        , sizeW{sizeW_}
+        , sizeH{sizeH_}
+        , uvX{uvX_}
+        , uvY{uvY_}
+        , uvW{uvW_}
+        , uvH{uvH_}
+        , rotation{rotation_}
+        , flags{flags_}
     {}
 };
 

--- a/src/opengl/legacy/AbstractShaderProgram.cpp
+++ b/src/opengl/legacy/AbstractShaderProgram.cpp
@@ -3,6 +3,8 @@
 
 #include "AbstractShaderProgram.h"
 
+#include "../../global/ConfigConsts.h"
+
 namespace Legacy {
 
 AbstractShaderProgram::AbstractShaderProgram(std::string dirName,

--- a/src/opengl/legacy/AbstractShaderProgram.cpp
+++ b/src/opengl/legacy/AbstractShaderProgram.cpp
@@ -90,6 +90,15 @@ void AbstractShaderProgram::setUniform1iv(const GLint location,
     deref(functions).glUniform1iv(location, count, value);
 }
 
+void AbstractShaderProgram::setUniform2iv(const GLint location,
+                                          const GLsizei count,
+                                          const GLint *const value)
+{
+    assert(m_isBound);
+    auto functions = m_functions.lock();
+    deref(functions).glUniform2iv(location, count, value);
+}
+
 void AbstractShaderProgram::setUniform1fv(const GLint location,
                                           const GLsizei count,
                                           const GLfloat *const value)
@@ -167,6 +176,12 @@ void AbstractShaderProgram::setViewport(const char *const name, const Viewport &
     const glm::ivec4 viewport{input_viewport.offset, input_viewport.size};
     const GLint location = getUniformLocation(name);
     setUniform4iv(location, 1, glm::value_ptr(viewport));
+}
+
+void AbstractShaderProgram::setIVec2(const char *const name, const glm::ivec2 &v)
+{
+    const GLint location = getUniformLocation(name);
+    setUniform2iv(location, 1, glm::value_ptr(v));
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/AbstractShaderProgram.h
+++ b/src/opengl/legacy/AbstractShaderProgram.h
@@ -72,6 +72,7 @@ public:
 
 public:
     void setUniform1iv(GLint location, GLsizei count, const GLint *value);
+    void setUniform2iv(GLint location, GLsizei count, const GLint *value);
     void setUniform1fv(GLint location, GLsizei count, const GLfloat *value);
     void setUniform4fv(GLint location, GLsizei count, const GLfloat *value);
     void setUniform4iv(GLint location, GLsizei count, const GLint *value);
@@ -89,6 +90,7 @@ public:
     void setMatrix(const char *name, const glm::mat4 &m);
     void setTexture(const char *name, int textureUnit);
     void setViewport(const char *name, const Viewport &input_viewport);
+    void setIVec2(const char *name, const glm::ivec2 &v);
 };
 
 } // namespace Legacy

--- a/src/opengl/legacy/FontMesh3d.cpp
+++ b/src/opengl/legacy/FontMesh3d.cpp
@@ -12,24 +12,20 @@ namespace Legacy {
 
 FontMesh3d::FontMesh3d(const SharedFunctions &functions,
                        const std::shared_ptr<FontShader> &sharedShader,
-                       SharedMMTexture texture,
+                       const MMTextureId textureId,
                        const DrawModeEnum mode,
                        const std::vector<FontInstanceData> &verts)
     : Base{functions, sharedShader, mode, verts}
-    , m_texture{std::move(texture)}
+    , m_textureId{textureId}
 {}
 
 FontMesh3d::~FontMesh3d() = default;
 
 GLRenderState FontMesh3d::virt_modifyRenderState(const GLRenderState &renderState) const
 {
-    const SharedMMTexture &shared = m_texture;
-    const MMTexture &tex = *shared;
-    const MMTextureId id = tex.getId();
-
     return renderState.withBlend(BlendModeEnum::TRANSPARENCY)
         .withDepthFunction(std::nullopt)
-        .withTexture0(id);
+        .withTexture0(m_textureId);
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/FontMesh3d.cpp
+++ b/src/opengl/legacy/FontMesh3d.cpp
@@ -14,7 +14,7 @@ FontMesh3d::FontMesh3d(const SharedFunctions &functions,
                        const std::shared_ptr<FontShader> &sharedShader,
                        SharedMMTexture texture,
                        const DrawModeEnum mode,
-                       const std::vector<FontVert3d> &verts)
+                       const std::vector<FontInstanceData> &verts)
     : Base{functions, sharedShader, mode, verts}
     , m_texture{std::move(texture)}
 {}

--- a/src/opengl/legacy/FontMesh3d.h
+++ b/src/opengl/legacy/FontMesh3d.h
@@ -118,12 +118,12 @@ class NODISCARD FontMesh3d final : public SimpleFont3dMesh<FontInstanceData>
 {
 private:
     using Base = SimpleFont3dMesh<FontInstanceData>;
-    SharedMMTexture m_texture;
+    MMTextureId m_textureId;
 
 public:
     explicit FontMesh3d(const SharedFunctions &functions,
                         const std::shared_ptr<FontShader> &sharedShader,
-                        SharedMMTexture texture,
+                        MMTextureId textureId,
                         DrawModeEnum mode,
                         const std::vector<FontInstanceData> &verts);
 

--- a/src/opengl/legacy/FunctionsES30.cpp
+++ b/src/opengl/legacy/FunctionsES30.cpp
@@ -25,6 +25,7 @@ std::optional<GLenum> FunctionsES30::virt_toGLenum(const DrawModeEnum mode)
 
     case DrawModeEnum::INVALID:
     case DrawModeEnum::QUADS:
+    case DrawModeEnum::INSTANCED_QUADS:
         break;
     }
 

--- a/src/opengl/legacy/FunctionsGL33.cpp
+++ b/src/opengl/legacy/FunctionsGL33.cpp
@@ -1,5 +1,6 @@
 #include "FunctionsGL33.h"
 
+#include "../../global/ConfigConsts.h"
 #include "../OpenGLConfig.h"
 
 #include <optional>
@@ -27,7 +28,10 @@ std::optional<GLenum> FunctionsGL33::virt_toGLenum(const DrawModeEnum mode)
     case DrawModeEnum::QUADS:
 #ifndef MMAPPER_NO_OPENGL
         return canRenderQuads() ? std::make_optional(GL_QUADS) : std::nullopt;
+#else
+        FALLTHROUGH;
 #endif
+    case DrawModeEnum::INSTANCED_QUADS:
     case DrawModeEnum::INVALID:
         break;
     }

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -271,16 +271,12 @@ void Functions::renderFont3d(const SharedMMTexture &texture,
 }
 
 UniqueMesh Functions::createFontMesh(const SharedMMTexture &texture,
-                                     const DrawModeEnum mode,
                                      const std::vector<FontInstanceData> &batch)
 {
-    const auto instancedMode = (mode == DrawModeEnum::QUADS) ? DrawModeEnum::INSTANCED_QUADS : mode;
+    const auto mode = DrawModeEnum::INSTANCED_QUADS;
     const auto &prog = getShaderPrograms().getFontShader();
-    return UniqueMesh{std::make_unique<Legacy::FontMesh3d>(shared_from_this(),
-                                                           prog,
-                                                           texture,
-                                                           instancedMode,
-                                                           batch)};
+    return UniqueMesh{
+        std::make_unique<Legacy::FontMesh3d>(shared_from_this(), prog, texture, mode, batch)};
 }
 
 Functions::Functions(Badge<Functions>)

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -275,8 +275,11 @@ UniqueMesh Functions::createFontMesh(const SharedMMTexture &texture,
 {
     const auto mode = DrawModeEnum::INSTANCED_QUADS;
     const auto &prog = getShaderPrograms().getFontShader();
-    return UniqueMesh{
-        std::make_unique<Legacy::FontMesh3d>(shared_from_this(), prog, texture, mode, batch)};
+    return UniqueMesh{std::make_unique<Legacy::FontMesh3d>(shared_from_this(),
+                                                           prog,
+                                                           texture->getId(),
+                                                           mode,
+                                                           batch)};
 }
 
 Functions::Functions(Badge<Functions>)

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -253,7 +253,8 @@ void Functions::renderColoredTextured(const DrawModeEnum mode,
                                                                  state);
 }
 
-void Functions::renderFont3d(const SharedMMTexture &texture, const std::vector<FontVert3d> &verts)
+void Functions::renderFont3d(const SharedMMTexture &texture,
+                             const std::vector<FontInstanceData> &verts)
 
 {
     const auto state = GLRenderState()
@@ -262,21 +263,24 @@ void Functions::renderFont3d(const SharedMMTexture &texture, const std::vector<F
                            .withTexture0(texture->getId());
 
     const auto &prog = getShaderPrograms().getFontShader();
-    renderImmediate<FontVert3d, Legacy::SimpleFont3dMesh>(shared_from_this(),
-                                                          DrawModeEnum::QUADS,
-                                                          verts,
-                                                          prog,
-                                                          state);
+    renderImmediate<FontInstanceData, Legacy::SimpleFont3dMesh>(shared_from_this(),
+                                                                DrawModeEnum::INSTANCED_QUADS,
+                                                                verts,
+                                                                prog,
+                                                                state);
 }
 
 UniqueMesh Functions::createFontMesh(const SharedMMTexture &texture,
                                      const DrawModeEnum mode,
-                                     const std::vector<FontVert3d> &batch)
+                                     const std::vector<FontInstanceData> &batch)
 {
-    assert(static_cast<size_t>(mode) >= VERTS_PER_TRI);
+    const auto instancedMode = (mode == DrawModeEnum::QUADS) ? DrawModeEnum::INSTANCED_QUADS : mode;
     const auto &prog = getShaderPrograms().getFontShader();
-    return UniqueMesh{
-        std::make_unique<Legacy::FontMesh3d>(shared_from_this(), prog, texture, mode, batch)};
+    return UniqueMesh{std::make_unique<Legacy::FontMesh3d>(shared_from_this(),
+                                                           prog,
+                                                           texture,
+                                                           instancedMode,
+                                                           batch)};
 }
 
 Functions::Functions(Badge<Functions>)

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -425,7 +425,6 @@ public:
 
 public:
     NODISCARD UniqueMesh createFontMesh(const SharedMMTexture &texture,
-                                        DrawModeEnum mode,
                                         const std::vector<FontInstanceData> &batch);
 
 public:

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -220,6 +220,7 @@ public:
     using Base::glTexSubImage3D;
     using Base::glUniform1fv;
     using Base::glUniform1iv;
+    using Base::glUniform2iv;
     using Base::glUniform4fv;
     using Base::glUniform4iv;
     using Base::glUniformBlockBinding;
@@ -425,7 +426,7 @@ public:
 public:
     NODISCARD UniqueMesh createFontMesh(const SharedMMTexture &texture,
                                         DrawModeEnum mode,
-                                        const std::vector<FontVert3d> &batch);
+                                        const std::vector<FontInstanceData> &batch);
 
 public:
     void renderPoints(const std::vector<ColorVert> &verts, const GLRenderState &state);
@@ -443,7 +444,7 @@ public:
     void renderColoredTextured(DrawModeEnum mode,
                                const std::vector<ColoredTexVert> &verts,
                                const GLRenderState &state);
-    void renderFont3d(const SharedMMTexture &texture, const std::vector<FontVert3d> &verts);
+    void renderFont3d(const SharedMMTexture &texture, const std::vector<FontInstanceData> &verts);
 
 public:
     void checkError();

--- a/src/opengl/legacy/ShaderUtils.cpp
+++ b/src/opengl/legacy/ShaderUtils.cpp
@@ -5,6 +5,7 @@
 
 #include "../../global/ConfigConsts.h"
 #include "../../global/Consts.h"
+#include "../../global/NamedColors.h"
 #include "../../global/PrintUtils.h"
 #include "../../global/TextUtils.h"
 
@@ -211,7 +212,12 @@ NODISCARD static GLuint compileShader(Functions &gl, const GLenum type, const So
     // NOTE: GLES 2.0 required `const char**` instead of `const char*const*`,
     // so Qt uses the least common denominator without the middle const;
     // that's the reason the `ptrs` array below is not `const`.
-    std::array<const char *, 3> ptrs = {gl.getShaderVersion(), "#line 1\n", source.source.c_str()};
+    std::string defineNamedColors = "#define MAX_NAMED_COLORS " + std::to_string(MAX_NAMED_COLORS)
+                                    + "\n";
+    std::array<const char *, 4> ptrs = {gl.getShaderVersion(),
+                                        defineNamedColors.c_str(),
+                                        "#line 1\n",
+                                        source.source.c_str()};
     gl.glShaderSource(shaderId, static_cast<GLsizei>(ptrs.size()), ptrs.data(), nullptr);
     gl.glCompileShader(shaderId);
     checkShaderInfo(gl, shaderId);
@@ -248,6 +254,7 @@ Program loadShaders(Functions &gl, const Source &vert, const Source &frag)
 
     gl.glLinkProgram(prog);
     checkProgramInfo(gl, prog);
+    gl.applyDefaultUniformBlockBindings(prog);
 
     for (const GLuint s : shaders) {
         if (is_valid(s)) {

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -31,8 +31,37 @@ AColorPlainShader::~AColorPlainShader() = default;
 UColorPlainShader::~UColorPlainShader() = default;
 AColorTexturedShader::~AColorTexturedShader() = default;
 UColorTexturedShader::~UColorTexturedShader() = default;
+
+RoomQuadTexShader::~RoomQuadTexShader() = default;
+
 FontShader::~FontShader() = default;
 PointShader::~PointShader() = default;
+
+void ShaderPrograms::early_init()
+{
+    std::ignore = getPlainAColorShader();
+    std::ignore = getPlainUColorShader();
+    std::ignore = getTexturedAColorShader();
+    std::ignore = getTexturedUColorShader();
+
+    std::ignore = getRoomQuadTexShader();
+
+    std::ignore = getFontShader();
+    std::ignore = getPointShader();
+}
+
+void ShaderPrograms::resetAll()
+{
+    m_aColorShader.reset();
+    m_uColorShader.reset();
+    m_aTexturedShader.reset();
+    m_uTexturedShader.reset();
+
+    m_roomQuadTexShader.reset();
+
+    m_font.reset();
+    m_point.reset();
+}
 
 // essentially a private member of ShaderPrograms
 template<typename T>
@@ -76,6 +105,11 @@ const std::shared_ptr<UColorPlainShader> &ShaderPrograms::getPlainUColorShader()
 const std::shared_ptr<AColorTexturedShader> &ShaderPrograms::getTexturedAColorShader()
 {
     return getInitialized<AColorTexturedShader>(m_aTexturedShader, getFunctions(), "tex/acolor");
+}
+
+const std::shared_ptr<RoomQuadTexShader> &ShaderPrograms::getRoomQuadTexShader()
+{
+    return getInitialized<RoomQuadTexShader>(m_roomQuadTexShader, getFunctions(), "room/tex/acolor");
 }
 
 const std::shared_ptr<UColorTexturedShader> &ShaderPrograms::getTexturedUColorShader()

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -3,6 +3,10 @@
 
 #include "Shaders.h"
 
+#include "../../display/Textures.h"
+#include "FunctionsES30.h"
+#include "FunctionsGL33.h"
+#include "Legacy.h"
 #include "ShaderUtils.h"
 
 #include <memory>
@@ -35,6 +39,24 @@ UColorTexturedShader::~UColorTexturedShader() = default;
 RoomQuadTexShader::~RoomQuadTexShader() = default;
 
 FontShader::~FontShader() = default;
+
+void FontShader::virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms)
+{
+    assert(uniforms.textures[0] != INVALID_MM_TEXTURE_ID);
+    auto shared_functions = m_functions.lock();
+    Functions &functions = deref(shared_functions);
+
+    setMatrix("uMVP3D", mvp);
+    setTexture("uFontTexture", 0);
+    setViewport("uPhysViewport", functions.getPhysicalViewport());
+
+    const auto &shared_tex = functions.getTexLookup().at(uniforms.textures[0]);
+    const MMTexture &tex = deref(shared_tex);
+    const QOpenGLTexture *qtex = tex.get();
+    if (qtex) {
+        setIVec2("uFontTexSize", glm::ivec2(qtex->width(), qtex->height()));
+    }
+}
 PointShader::~PointShader() = default;
 
 void ShaderPrograms::early_init()

--- a/src/opengl/legacy/Shaders.h
+++ b/src/opengl/legacy/Shaders.h
@@ -56,6 +56,24 @@ private:
     }
 };
 
+struct NODISCARD RoomQuadTexShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~RoomQuadTexShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms) final
+    {
+        assert(uniforms.textures[0] != INVALID_MM_TEXTURE_ID);
+
+        setColor("uColor", uniforms.color);
+        setMatrix("uMVP", mvp);
+        setTexture("uTexture", 0);
+    }
+};
+
 struct NODISCARD UColorTexturedShader final : public AbstractShaderProgram
 {
 public:
@@ -116,10 +134,17 @@ struct NODISCARD ShaderPrograms final
 {
 private:
     Functions &m_functions;
+
+private:
     std::shared_ptr<AColorPlainShader> m_aColorShader;
     std::shared_ptr<UColorPlainShader> m_uColorShader;
     std::shared_ptr<AColorTexturedShader> m_aTexturedShader;
     std::shared_ptr<UColorTexturedShader> m_uTexturedShader;
+
+private:
+    std::shared_ptr<RoomQuadTexShader> m_roomQuadTexShader;
+
+private:
     std::shared_ptr<FontShader> m_font;
     std::shared_ptr<PointShader> m_point;
 
@@ -134,15 +159,7 @@ private:
     NODISCARD Functions &getFunctions() { return m_functions; }
 
 public:
-    void resetAll()
-    {
-        m_aColorShader.reset();
-        m_uColorShader.reset();
-        m_aTexturedShader.reset();
-        m_uTexturedShader.reset();
-        m_font.reset();
-        m_point.reset();
-    }
+    void resetAll();
 
 public:
     // attribute color (aka "Colored")
@@ -153,8 +170,16 @@ public:
     NODISCARD const std::shared_ptr<AColorTexturedShader> &getTexturedAColorShader();
     // uniform color + textured (aka "Textured")
     NODISCARD const std::shared_ptr<UColorTexturedShader> &getTexturedUColorShader();
+
+public:
+    NODISCARD const std::shared_ptr<RoomQuadTexShader> &getRoomQuadTexShader();
+
+public:
     NODISCARD const std::shared_ptr<FontShader> &getFontShader();
     NODISCARD const std::shared_ptr<PointShader> &getPointShader();
+
+public:
+    void early_init();
 };
 
 } // namespace Legacy

--- a/src/opengl/legacy/Shaders.h
+++ b/src/opengl/legacy/Shaders.h
@@ -94,24 +94,13 @@ private:
 
 struct NODISCARD FontShader final : public AbstractShaderProgram
 {
-private:
-    using Base = AbstractShaderProgram;
-
 public:
-    using Base::AbstractShaderProgram;
+    using AbstractShaderProgram::AbstractShaderProgram;
 
     ~FontShader() final;
 
 private:
-    void virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms) final
-    {
-        assert(uniforms.textures[0] != INVALID_MM_TEXTURE_ID);
-        auto functions = Base::m_functions.lock();
-
-        setMatrix("uMVP3D", mvp);
-        setTexture("uFontTexture", 0);
-        setViewport("uPhysViewport", deref(functions).getPhysicalViewport());
-    }
+    void virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms) final;
 };
 
 struct NODISCARD PointShader final : public AbstractShaderProgram

--- a/src/opengl/legacy/SimpleMesh.cpp
+++ b/src/opengl/legacy/SimpleMesh.cpp
@@ -2,3 +2,58 @@
 // Copyright (C) 2019 The MMapper Authors
 
 #include "SimpleMesh.h"
+
+#include "../../global/ConfigConsts.h"
+
+void Legacy::drawRoomQuad(Functions &gl, const GLsizei numVerts)
+{
+    static constexpr size_t NUM_ELEMENTS = 4;
+    const SharedVbo shared = gl.getSharedVbos().get(SharedVboEnum::InstancedQuadIbo);
+    VBO &vbo = deref(shared);
+
+    if (!vbo) {
+        if (IS_DEBUG_BUILD) {
+            qDebug() << "allocating shared VBO for drawRoomQuad";
+        }
+
+        vbo.emplace(gl.shared_from_this());
+
+        // CCW order
+        const std::vector<uint8_t> indices{0, 1, 2, 3};
+        assert(indices.size() == NUM_ELEMENTS);
+
+        MAYBE_UNUSED const auto numIndices = gl.setIbo(vbo.get(),
+                                                       indices,
+                                                       BufferUsageEnum::STATIC_DRAW);
+        assert(numIndices == NUM_ELEMENTS);
+    }
+
+    struct NODISCARD IBOBinder final
+    {
+    private:
+        Functions &m_gl;
+
+    public:
+        IBOBinder(Functions &f, const VBO &vbo)
+            : m_gl(f)
+        {
+            if (IS_DEBUG_BUILD) {
+                GLint binding = -1;
+                m_gl.glGetIntegerv(GL_ELEMENT_ARRAY_BUFFER_BINDING, &binding);
+                assert(binding == 0);
+            }
+            m_gl.glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vbo.get());
+        }
+        ~IBOBinder() { m_gl.glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0); }
+        DELETE_CTORS_AND_ASSIGN_OPS(IBOBinder);
+    };
+
+    {
+        IBOBinder ibo_binder{gl, *shared};
+        gl.glDrawElementsInstanced(GL_TRIANGLE_FAN,
+                                   NUM_ELEMENTS,
+                                   GL_UNSIGNED_BYTE,
+                                   nullptr,
+                                   numVerts);
+    }
+}

--- a/src/opengl/legacy/SimpleMesh.cpp
+++ b/src/opengl/legacy/SimpleMesh.cpp
@@ -5,7 +5,7 @@
 
 #include "../../global/ConfigConsts.h"
 
-void Legacy::drawRoomQuad(Functions &gl, const GLsizei numVerts)
+void Legacy::drawInstancedQuadGeometry(Functions &gl, const GLsizei numVerts)
 {
     static constexpr size_t NUM_ELEMENTS = 4;
     const SharedVbo shared = gl.getSharedVbos().get(SharedVboEnum::InstancedQuadIbo);
@@ -13,7 +13,7 @@ void Legacy::drawRoomQuad(Functions &gl, const GLsizei numVerts)
 
     if (!vbo) {
         if (IS_DEBUG_BUILD) {
-            qDebug() << "allocating shared VBO for drawRoomQuad";
+            qDebug() << "allocating shared VBO for drawInstancedQuadGeometry";
         }
 
         vbo.emplace(gl.shared_from_this());

--- a/src/opengl/legacy/SimpleMesh.h
+++ b/src/opengl/legacy/SimpleMesh.h
@@ -17,6 +17,8 @@
 
 namespace Legacy {
 
+void drawRoomQuad(Functions &gl, GLsizei numVerts);
+
 template<typename VertexType_, typename ProgramType_>
 class NODISCARD SimpleMesh : public IRenderable
 {
@@ -108,7 +110,13 @@ private:
                    const BufferUsageEnum usage)
     {
         const auto numVerts = verts.size();
-        assert(mode == DrawModeEnum::INVALID || numVerts % static_cast<size_t>(mode) == 0);
+
+        static_assert(static_cast<size_t>(DrawModeEnum::POINTS) == 1);
+        static_assert(static_cast<size_t>(DrawModeEnum::LINES) == 2);
+        static_assert(static_cast<size_t>(DrawModeEnum::TRIANGLES) == 3);
+        static_assert(static_cast<size_t>(DrawModeEnum::QUADS) == 4);
+        assert(mode == DrawModeEnum::INVALID || mode == DrawModeEnum::INSTANCED_QUADS
+               || numVerts % static_cast<size_t>(mode) == 0);
 
         if (!m_vbo && numVerts != 0) {
             m_vbo.emplace(m_shared_functions);
@@ -179,11 +187,14 @@ private:
 
         auto attribUnbinder = bindAttribs();
 
-        if (const std::optional<GLenum> &optMode = m_functions.toGLenum(m_drawMode)) {
+        if (m_drawMode == DrawModeEnum::INSTANCED_QUADS) {
+            drawRoomQuad(m_functions, m_numVerts);
+        } else if (const std::optional<GLenum> &optMode = m_functions.toGLenum(m_drawMode)) {
             m_functions.glDrawArrays(optMode.value(), 0, m_numVerts);
         } else {
             assert(false);
         }
     }
 };
+
 } // namespace Legacy

--- a/src/opengl/legacy/SimpleMesh.h
+++ b/src/opengl/legacy/SimpleMesh.h
@@ -17,7 +17,7 @@
 
 namespace Legacy {
 
-void drawRoomQuad(Functions &gl, GLsizei numVerts);
+void drawInstancedQuadGeometry(Functions &gl, GLsizei numVerts);
 
 template<typename VertexType_, typename ProgramType_>
 class NODISCARD SimpleMesh : public IRenderable
@@ -188,7 +188,7 @@ private:
         auto attribUnbinder = bindAttribs();
 
         if (m_drawMode == DrawModeEnum::INSTANCED_QUADS) {
-            drawRoomQuad(m_functions, m_numVerts);
+            drawInstancedQuadGeometry(m_functions, m_numVerts);
         } else if (const std::optional<GLenum> &optMode = m_functions.toGLenum(m_drawMode)) {
             m_functions.glDrawArrays(optMode.value(), 0, m_numVerts);
         } else {

--- a/src/opengl/legacy/VBO.h
+++ b/src/opengl/legacy/VBO.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2019 The MMapper Authors
 
-#include "../../global/utils.h"
+#include "../../global/EnumIndexedArray.h"
 #include "Legacy.h"
 
 #include <memory>
@@ -57,6 +57,33 @@ public:
     }
 
     void resetAll() { base::clear(); }
+};
+
+class NODISCARD SharedVbos final
+    : private EnumIndexedArray<SharedVbo, SharedVboEnum, NUM_SHARED_VBOS>
+{
+private:
+    using base = EnumIndexedArray<SharedVbo, SharedVboEnum, NUM_SHARED_VBOS>;
+
+public:
+    SharedVbos() = default;
+
+public:
+    NODISCARD SharedVbo get(const SharedVboEnum buffer)
+    {
+        SharedVbo &shared = base::operator[](buffer);
+        if (shared == nullptr) {
+            shared = std::make_shared<VBO>();
+        }
+        return shared;
+    }
+
+    void reset(const SharedVboEnum buffer) { base::operator[](buffer).reset(); }
+
+    void resetAll()
+    {
+        base::for_each([](auto &shared) { shared.reset(); });
+    }
 };
 
 class NODISCARD Program final

--- a/src/resources/mmapper2.qrc
+++ b/src/resources/mmapper2.qrc
@@ -212,6 +212,8 @@
         <file>pixmaps/wall-west.png</file>
         <file>shaders/legacy/font/frag.glsl</file>
         <file>shaders/legacy/font/vert.glsl</file>
+        <file>shaders/legacy/room/tex/acolor/frag.glsl</file>
+        <file>shaders/legacy/room/tex/acolor/vert.glsl</file>
         <file>shaders/legacy/plain/acolor/frag.glsl</file>
         <file>shaders/legacy/plain/acolor/vert.glsl</file>
         <file>shaders/legacy/plain/ucolor/frag.glsl</file>

--- a/src/resources/shaders/legacy/font/vert.glsl
+++ b/src/resources/shaders/legacy/font/vert.glsl
@@ -3,11 +3,20 @@
 
 uniform mat4 uMVP3D;
 uniform ivec4 uPhysViewport;
+uniform ivec2 uFontTexSize;
 
-layout(location = 0) in vec3 aBase; // address in world space
-layout(location = 1) in vec4 aColor;
-layout(location = 2) in vec2 aTexCoord;
-layout(location = 3) in vec2 aVert; // offset in raw pixels
+uniform NamedColorsBlock {
+    vec4 uNamedColors[MAX_NAMED_COLORS];
+};
+
+layout(location = 0) in vec3 aBase;
+layout(location = 1) in uint aColor;
+layout(location = 2) in ivec4 aRect;   // offsetX, offsetY, sizeW, sizeH
+layout(location = 3) in ivec4 aUVRect; // uvX, uvY, uvW, uvH
+layout(location = 4) in ivec2 aParams; // rotation, flags
+
+const uint FLAG_ITALICS = 1u;
+const uint FLAG_NAMED_COLOR = 2u;
 
 out vec4 vColor;
 out vec2 vTexCoord;
@@ -41,10 +50,20 @@ vec2 convertScreen01toNdcClip(vec2 pos)
     return pos;
 }
 
-vec2 addPerVertexOffset(vec2 wordOriginNdc)
+vec4 unpackRGBA(uint c)
+{
+    return vec4(
+        float(c & 0xFFu) / 255.0,
+        float((c >> 8u) & 0xFFu) / 255.0,
+        float((c >> 16u) & 0xFFu) / 255.0,
+        float((c >> 24u) & 0xFFu) / 255.0
+    );
+}
+
+vec2 addPerVertexOffset(vec2 wordOriginNdc, vec2 glyphOffsetPixels)
 {
     vec2 wordOriginScreen = anti_flicker(convertNDCtoScreenSpace(wordOriginNdc));
-    return convertScreen01toNdcClip(wordOriginScreen + convertPhysPixelsToScreen01(aVert.xy));
+    return convertScreen01toNdcClip(wordOriginScreen + convertPhysPixelsToScreen01(glyphOffsetPixels));
 }
 
 // NOTE:
@@ -55,38 +74,53 @@ vec2 addPerVertexOffset(vec2 wordOriginNdc)
 //    (hint: 2 is outside the clip region [-1, 1])
 const vec4 ignored = vec4(2.0, 2.0, 2.0, 1.0);
 
-vec4 computePosition()
+void main()
 {
-#if 0 // REVISIT: add a maximum view distance?
-    if (length(aBase - uCenter) > uMaxViewDistance) {
-        return ignored;
+    uint flags = uint(aParams.y);
+    if ((flags & FLAG_NAMED_COLOR) != 0u) {
+        vColor = uNamedColors[aColor % uint(MAX_NAMED_COLORS)];
+    } else {
+        vColor = unpackRGBA(aColor);
     }
-#endif
+
+    const vec2[4] quad = vec2[4](vec2(0, 0), vec2(1, 0), vec2(1, 1), vec2(0, 1));
+    vec2 corner = quad[gl_VertexID];
+
+    vTexCoord = (vec2(aUVRect.xy) + corner * vec2(aUVRect.zw)) / vec2(uFontTexSize);
+
+    vec2 posPixels = vec2(aRect.xy) + corner * vec2(aRect.zw);
+
+    if ((flags & FLAG_ITALICS) != 0u) {
+        posPixels.x += posPixels.y / 6.0;
+    }
+
+    int rotation = int(aParams.x);
+    if (rotation != 0) {
+        float rad = radians(float(rotation));
+        float s = sin(rad);
+        float c = cos(rad);
+        posPixels = vec2(posPixels.x * c - posPixels.y * s, posPixels.x * s + posPixels.y * c);
+    }
 
     vec4 pos = uMVP3D * vec4(aBase, 1); /* 3D transform */
 
     // Ignore any text that falls far outside of the clip region.
     if (any(greaterThan(abs(pos.xyz), vec3(1.5 * abs(pos.w))))) {
-        return ignored;
+        gl_Position = ignored;
+        return;
     }
 
     // Also ignore anything that appears too close to the camera.
     if (abs(pos.w) < 1e-3) {
-        return ignored;
+        gl_Position = ignored;
+        return;
     }
 
     // convert from clip space to normalized device coordinates (NDC)
     pos /= pos.w;
 
-    pos.xy = addPerVertexOffset(pos.xy);
+    pos.xy = addPerVertexOffset(pos.xy, posPixels);
 
     // Note: We're not using the built-in MVP matrix.
-    return pos;
-}
-
-void main()
-{
-    vColor = aColor;
-    vTexCoord = aTexCoord;
-    gl_Position = computePosition();
+    gl_Position = pos;
 }

--- a/src/resources/shaders/legacy/font/vert.glsl
+++ b/src/resources/shaders/legacy/font/vert.glsl
@@ -79,8 +79,9 @@ void main()
     uint flags = uint(aParams.y);
 
     // Branchless color selection
-    vec4 namedCol = uNamedColors[aColor % uint(MAX_NAMED_COLORS)];
     vec4 unpackedCol = unpackRGBA(aColor);
+    vec4 namedCol = uNamedColors[(aColor & 0x00FFFFFFu) % uint(MAX_NAMED_COLORS)];
+    namedCol.a *= unpackedCol.a;
     vColor = mix(unpackedCol, namedCol, float((flags & FLAG_NAMED_COLOR) != 0u));
 
     const vec2[4] quad = vec2[4](vec2(0, 0), vec2(1, 0), vec2(1, 1), vec2(0, 1));

--- a/src/resources/shaders/legacy/room/tex/acolor/frag.glsl
+++ b/src/resources/shaders/legacy/room/tex/acolor/frag.glsl
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+uniform sampler2DArray uTexture;
+uniform vec4 uColor;
+
+in vec4 vColor;
+in vec3 vTexCoord;
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    vFragmentColor = vColor * uColor * texture(uTexture, vTexCoord);
+}

--- a/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+uniform mat4 uMVP;
+uniform NamedColorsBlock {
+    vec4 uNamedColors[MAX_NAMED_COLORS];
+};
+
+layout(location = 0) in ivec4 aVertTexCol;
+
+out vec4 vColor;
+out vec3 vTexCoord;
+
+void main()
+{
+    // ccw-order assumes it's a triangle fan (as opposed to a triangle strip)
+    const ivec3[4] ioffsets_ccw = ivec3[4](ivec3(0, 0, 0), ivec3(1, 0, 0), ivec3(1, 1, 0), ivec3(0, 1, 0));
+    ivec3 ioffset = ioffsets_ccw[gl_VertexID];
+
+    int texZ = aVertTexCol.w & 0xFF;
+    int colorId = (aVertTexCol.w >> 8) % MAX_NAMED_COLORS;
+
+    vColor = uNamedColors[colorId];
+    vTexCoord = vec3(ioffset.xy, float(texZ));
+    gl_Position = uMVP * vec4(aVertTexCol.xyz + ioffset, 1.0);
+}


### PR DESCRIPTION
This change refactors font rendering to use OpenGL instancing, aligning it with the room rendering architecture. Key improvements include reduced CPU overhead by moving transformations to the GPU, significantly lower VBO memory usage through instancing and data packing, and better maintainability by using shared patterns and naming conventions. It also introduces support for the global NamedColorsBlock in font shaders, fulfilling the requirement for Infomark colors.

---
*PR created automatically by Jules for task [8698413520678216920](https://jules.google.com/task/8698413520678216920) started by @nschimme*