### PR TITLE
Migrate MapCanvas to QOpenGLWindow and Refactor MapWindow

### DIFF
--- a/src/display/Connections.cpp
+++ b/src/display/Connections.cpp
@@ -710,9 +710,11 @@ void MapCanvas::paintNearbyConnectionPoints()
 
     // FIXME: This doesn't show dots for red connections.
     if (input.m_connectionSelection != nullptr
-        && (input.m_connectionSelection->isFirstValid() || input.m_connectionSelection->isSecondValid())) {
-        const CD valid = input.m_connectionSelection->isFirstValid() ? input.m_connectionSelection->getFirst()
-                                                               : input.m_connectionSelection->getSecond();
+        && (input.m_connectionSelection->isFirstValid()
+            || input.m_connectionSelection->isSecondValid())) {
+        const CD valid = input.m_connectionSelection->isFirstValid()
+                             ? input.m_connectionSelection->getFirst()
+                             : input.m_connectionSelection->getSecond();
         const Coordinate &c = valid.room.getPosition();
         const glm::vec3 &pos = c.to_vec3();
         points.emplace_back(Colors::cyan, pos + getConnectionOffset(valid.direction));

--- a/src/display/Infomarks.cpp
+++ b/src/display/Infomarks.cpp
@@ -348,26 +348,27 @@ void MapCanvas::paintSelectedInfomarks()
                 batch.drawPoint(point);
             };
 
-            const auto drawSelectionPoints = [this, &drawPoint, &input](const InfomarkHandle &marker) {
-                const auto &pos1 = marker.getPosition1();
-                if (pos1.z != m_currentLayer) {
-                    return;
-                }
+            const auto drawSelectionPoints =
+                [this, &drawPoint, &input](const InfomarkHandle &marker) {
+                    const auto &pos1 = marker.getPosition1();
+                    if (pos1.z != m_currentLayer) {
+                        return;
+                    }
 
-                const auto color = (input.m_infoMarkSelection != nullptr
-                                    && input.m_infoMarkSelection->contains(marker.getId()))
-                                       ? Colors::yellow
-                                       : Colors::cyan;
+                    const auto color = (input.m_infoMarkSelection != nullptr
+                                        && input.m_infoMarkSelection->contains(marker.getId()))
+                                           ? Colors::yellow
+                                           : Colors::cyan;
 
-                drawPoint(pos1, color);
-                if (marker.getType() == InfomarkTypeEnum::TEXT) {
-                    return;
-                }
+                    drawPoint(pos1, color);
+                    if (marker.getType() == InfomarkTypeEnum::TEXT) {
+                        return;
+                    }
 
-                const Coordinate &pos2 = marker.getPosition2();
-                assert(pos2.z == m_currentLayer);
-                drawPoint(pos2, color);
-            };
+                    const Coordinate &pos2 = marker.getPosition2();
+                    assert(pos2.z == m_currentLayer);
+                    drawPoint(pos2, color);
+                };
 
             const auto &map = m_data.getCurrentMap();
             const InfomarkDb &db = map.getInfomarkDb();

--- a/src/display/MapCanvasData.cpp
+++ b/src/display/MapCanvasData.cpp
@@ -109,8 +109,8 @@ glm::vec3 MapCanvasViewport::unproject_clamped(const glm::vec2 &mouse) const
 glm::vec2 MapCanvasViewport::getMouseCoords(const QInputEvent *const event) const
 {
     if (const auto *const mouse = dynamic_cast<const QMouseEvent *>(event)) {
-        const auto x = static_cast<float>(mouse->pos().x());
-        const auto y = static_cast<float>(height() - mouse->pos().y());
+        const auto x = static_cast<float>(mouse->position().x());
+        const auto y = static_cast<float>(height() - mouse->position().y());
         return glm::vec2{x, y};
     } else if (const auto *const wheel = dynamic_cast<const QWheelEvent *>(event)) {
         const auto x = static_cast<float>(wheel->position().x());

--- a/src/display/MapCanvasData.cpp
+++ b/src/display/MapCanvasData.cpp
@@ -12,6 +12,7 @@
 #include <glm/gtc/epsilon.hpp>
 
 #include <QPointF>
+#include <QWindow>
 
 const MMapper::Array<RoomTintEnum, NUM_ROOM_TINTS> &getAllRoomTints()
 {
@@ -25,6 +26,21 @@ MapCanvasInputState::MapCanvasInputState(PrespammedPath &prespammedPath)
 {}
 
 MapCanvasInputState::~MapCanvasInputState() = default;
+
+int MapCanvasViewport::width() const
+{
+    return m_window.width();
+}
+
+int MapCanvasViewport::height() const
+{
+    return m_window.height();
+}
+
+Viewport MapCanvasViewport::getViewport() const
+{
+    return Viewport{glm::ivec2{0, 0}, glm::ivec2{m_window.width(), m_window.height()}};
+}
 
 // world space to screen space (logical pixels)
 std::optional<glm::vec3> MapCanvasViewport::project(const glm::vec3 &v) const

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -20,13 +20,13 @@
 #include <unordered_map>
 
 #include <QOpenGLTexture>
-#include <QWidget>
 #include <QtGui/QMatrix4x4>
 #include <QtGui/QMouseEvent>
 #include <QtGui/qopengl.h>
 #include <QtGui>
 
 class ConnectionSelection;
+class QWindow;
 class MapData;
 class PrespammedPath;
 class InfomarkSelection;
@@ -100,7 +100,7 @@ public:
 struct NODISCARD MapCanvasViewport
 {
 private:
-    QWidget &m_sizeWidget;
+    QWindow &m_window;
 
 public:
     glm::mat4 m_viewProj{1.f};
@@ -109,18 +109,14 @@ public:
     int m_currentLayer = 0;
 
 public:
-    explicit MapCanvasViewport(QWidget &sizeWidget)
-        : m_sizeWidget{sizeWidget}
+    explicit MapCanvasViewport(QWindow &window)
+        : m_window{window}
     {}
 
 public:
-    NODISCARD auto width() const { return m_sizeWidget.width(); }
-    NODISCARD auto height() const { return m_sizeWidget.height(); }
-    NODISCARD Viewport getViewport() const
-    {
-        const auto &r = m_sizeWidget.rect();
-        return Viewport{glm::ivec2{r.x(), r.y()}, glm::ivec2{r.width(), r.height()}};
-    }
+    NODISCARD int width() const;
+    NODISCARD int height() const;
+    NODISCARD Viewport getViewport() const;
     NODISCARD float getTotalScaleFactor() const { return m_scaleFactor.getTotal(); }
 
 public:
@@ -185,7 +181,7 @@ struct NODISCARD MapCanvasInputState
     };
 
     std::optional<RoomSelMove> m_roomSelectionMove;
-    NODISCARD bool hasRoomSelectionMove() { return m_roomSelectionMove.has_value(); }
+    NODISCARD bool hasRoomSelectionMove() const { return m_roomSelectionMove.has_value(); }
 
     std::shared_ptr<InfomarkSelection> m_infoMarkSelection;
 
@@ -202,7 +198,7 @@ struct NODISCARD MapCanvasInputState
 
 public:
     explicit MapCanvasInputState(PrespammedPath &prespammedPath);
-    ~MapCanvasInputState();
+    virtual ~MapCanvasInputState();
 
 public:
     NODISCARD static MouseSel getMouseSel(const std::optional<MouseSel> &x)

--- a/src/display/RoomSelections.cpp
+++ b/src/display/RoomSelections.cpp
@@ -124,8 +124,9 @@ void MapCanvas::paintSelectedRoom(RoomSelFakeGL &gl, const RawRoom &room)
     // This fake GL uses resetMatrix() before this function.
     gl.resetMatrix();
 
+    auto &input = getInputState();
     const float marginPixels = MapScreen::DEFAULT_MARGIN_PIXELS;
-    const bool isMoving = hasRoomSelectionMove();
+    const bool isMoving = input.hasRoomSelectionMove();
 
     if (!isMoving && !m_mapScreen.isRoomVisible(roomPos, marginPixels / 2.f)) {
         const glm::vec3 roomCenter = roomPos.to_vec3() + glm::vec3{0.5f, 0.5f, 0.f};
@@ -157,22 +158,23 @@ void MapCanvas::paintSelectedRoom(RoomSelFakeGL &gl, const RawRoom &room)
 
     if (isMoving) {
         gl.resetMatrix();
-        const auto &relativeOffset = m_roomSelectionMove->pos;
+        const auto &relativeOffset = input.m_roomSelectionMove->pos;
         gl.glTranslatef(x + relativeOffset.x, y + relativeOffset.y, z);
-        gl.drawColoredQuad(m_roomSelectionMove->wrongPlace ? RoomSelFakeGL::SelTypeEnum::MoveBad
+        gl.drawColoredQuad(input.m_roomSelectionMove->wrongPlace ? RoomSelFakeGL::SelTypeEnum::MoveBad
                                                            : RoomSelFakeGL::SelTypeEnum::MoveGood);
     }
 }
 
 void MapCanvas::paintSelectedRooms()
 {
-    if (!m_roomSelection || m_roomSelection->empty()) {
+    auto &input = getInputState();
+    if (!input.m_roomSelection || input.m_roomSelection->empty()) {
         return;
     }
 
     RoomSelFakeGL gl;
 
-    for (const RoomId id : deref(m_roomSelection)) {
+    for (const RoomId id : deref(input.m_roomSelection)) {
         if (const auto room = m_data.findRoomHandle(id)) {
             gl.resetMatrix();
             paintSelectedRoom(gl, room.getRaw());

--- a/src/display/RoomSelections.cpp
+++ b/src/display/RoomSelections.cpp
@@ -160,8 +160,9 @@ void MapCanvas::paintSelectedRoom(RoomSelFakeGL &gl, const RawRoom &room)
         gl.resetMatrix();
         const auto &relativeOffset = input.m_roomSelectionMove->pos;
         gl.glTranslatef(x + relativeOffset.x, y + relativeOffset.y, z);
-        gl.drawColoredQuad(input.m_roomSelectionMove->wrongPlace ? RoomSelFakeGL::SelTypeEnum::MoveBad
-                                                           : RoomSelFakeGL::SelTypeEnum::MoveGood);
+        gl.drawColoredQuad(input.m_roomSelectionMove->wrongPlace
+                               ? RoomSelFakeGL::SelTypeEnum::MoveBad
+                               : RoomSelFakeGL::SelTypeEnum::MoveGood);
     }
 }
 

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -53,9 +53,7 @@ NODISCARD static NonOwningPointer &primaryMapCanvas()
     return primary;
 }
 
-MapCanvas::MapCanvas(MapData &mapData,
-                     PrespammedPath &prespammedPath,
-                     Mmapper2Group &groupManager)
+MapCanvas::MapCanvas(MapData &mapData, PrespammedPath &prespammedPath, Mmapper2Group &groupManager)
     : QOpenGLWindow{}
     , MapCanvasViewport{static_cast<QWindow &>(*this)}
     , m_mapScreen{*this}

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -55,25 +55,20 @@ NODISCARD static NonOwningPointer &primaryMapCanvas()
 
 MapCanvas::MapCanvas(MapData &mapData,
                      PrespammedPath &prespammedPath,
-                     Mmapper2Group &groupManager,
-                     QWidget *const parent)
-    : QOpenGLWidget{parent}
-    , MapCanvasViewport{static_cast<QWidget &>(*this)}
-    , MapCanvasInputState{prespammedPath}
-    , m_mapScreen{static_cast<MapCanvasViewport &>(*this)}
+                     Mmapper2Group &groupManager)
+    : QOpenGLWindow{}
+    , MapCanvasViewport{static_cast<QWindow &>(*this)}
+    , m_mapScreen{*this}
     , m_opengl{}
     , m_glFont{m_opengl}
     , m_data{mapData}
+    , m_prespammedPath{prespammedPath}
     , m_groupManager{groupManager}
 {
     NonOwningPointer &pmc = primaryMapCanvas();
     if (pmc == nullptr) {
         pmc = this;
     }
-
-    setCursor(Qt::OpenHandCursor);
-    grabGesture(Qt::PinchGesture);
-    setContextMenuPolicy(Qt::CustomContextMenu);
 }
 
 MapCanvas::~MapCanvas()
@@ -109,52 +104,14 @@ void MapCanvas::slot_layerReset()
     layerChanged();
 }
 
-void MapCanvas::slot_setCanvasMouseMode(const CanvasMouseModeEnum mode)
-{
-    // FIXME: This probably isn't what you actually want here,
-    // since it clears selections when re-choosing the same mode,
-    // or when changing to a compatible mode.
-    //
-    // e.g. RAYPICK_ROOMS vs SELECT_CONNECTIONS,
-    // or if you're trying to use MOVE to pan to reach more rooms
-    // (granted, the latter isn't "necessary" because you can use
-    // scrollbars or use the new zoom-recenter feature).
-    slot_clearAllSelections();
-
-    switch (mode) {
-    case CanvasMouseModeEnum::MOVE:
-        setCursor(Qt::OpenHandCursor);
-        break;
-
-    default:
-    case CanvasMouseModeEnum::NONE:
-    case CanvasMouseModeEnum::RAYPICK_ROOMS:
-    case CanvasMouseModeEnum::SELECT_CONNECTIONS:
-    case CanvasMouseModeEnum::CREATE_INFOMARKS:
-        setCursor(Qt::CrossCursor);
-        break;
-
-    case CanvasMouseModeEnum::SELECT_ROOMS:
-    case CanvasMouseModeEnum::CREATE_ROOMS:
-    case CanvasMouseModeEnum::CREATE_CONNECTIONS:
-    case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
-    case CanvasMouseModeEnum::SELECT_INFOMARKS:
-        setCursor(Qt::ArrowCursor);
-        break;
-    }
-
-    m_canvasMouseMode = mode;
-    m_selectedArea = false;
-    selectionChanged();
-}
-
 void MapCanvas::slot_setRoomSelection(const SigRoomSelection &selection)
 {
+    auto &input = getInputState();
     if (!selection.isValid()) {
-        m_roomSelection.reset();
+        input.m_roomSelection.reset();
     } else {
-        m_roomSelection = selection.getShared();
-        auto &sel = deref(m_roomSelection);
+        input.m_roomSelection = selection.getShared();
+        auto &sel = deref(input.m_roomSelection);
         auto &map = m_data;
         sel.removeMissing(map);
 
@@ -176,117 +133,27 @@ void MapCanvas::slot_setRoomSelection(const SigRoomSelection &selection)
 
 void MapCanvas::slot_setConnectionSelection(const std::shared_ptr<ConnectionSelection> &selection)
 {
-    m_connectionSelection = selection;
+    getInputState().m_connectionSelection = selection;
     emit sig_newConnectionSelection(selection.get());
     selectionChanged();
 }
 
 void MapCanvas::slot_setInfomarkSelection(const std::shared_ptr<InfomarkSelection> &selection)
 {
-    if (m_canvasMouseMode == CanvasMouseModeEnum::CREATE_INFOMARKS) {
-        m_infoMarkSelection = selection;
+    auto &input = getInputState();
+    if (input.m_canvasMouseMode == CanvasMouseModeEnum::CREATE_INFOMARKS) {
+        input.m_infoMarkSelection = selection;
 
     } else if (selection == nullptr || selection->empty()) {
-        m_infoMarkSelection = nullptr;
+        input.m_infoMarkSelection = nullptr;
 
     } else {
         qDebug() << "Updated selection with" << selection->size() << "infomarks";
-        m_infoMarkSelection = selection;
+        input.m_infoMarkSelection = selection;
     }
 
-    emit sig_newInfomarkSelection(m_infoMarkSelection.get());
+    emit sig_newInfomarkSelection(input.m_infoMarkSelection.get());
     selectionChanged();
-}
-
-NODISCARD static uint32_t operator&(const Qt::KeyboardModifiers left, const Qt::Modifier right)
-{
-    return static_cast<uint32_t>(left) & static_cast<uint32_t>(right);
-}
-
-void MapCanvas::wheelEvent(QWheelEvent *const event)
-{
-    const bool hasCtrl = (event->modifiers() & Qt::CTRL) != 0u;
-
-    switch (m_canvasMouseMode) {
-    case CanvasMouseModeEnum::MOVE:
-    case CanvasMouseModeEnum::SELECT_INFOMARKS:
-    case CanvasMouseModeEnum::CREATE_INFOMARKS:
-    case CanvasMouseModeEnum::RAYPICK_ROOMS:
-    case CanvasMouseModeEnum::SELECT_ROOMS:
-    case CanvasMouseModeEnum::SELECT_CONNECTIONS:
-    case CanvasMouseModeEnum::CREATE_ROOMS:
-    case CanvasMouseModeEnum::CREATE_CONNECTIONS:
-    case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
-        if (hasCtrl) {
-            if (event->angleDelta().y() > 100) {
-                slot_layerDown();
-            } else if (event->angleDelta().y() < -100) {
-                slot_layerUp();
-            }
-        } else {
-            const auto zoomAndMaybeRecenter = [this, event](const int numSteps) -> bool {
-                assert(numSteps != 0);
-                const auto optCenter = getUnprojectedMouseSel(event);
-
-                // NOTE: Do a regular zoom if the projection failed.
-                if (!optCenter) {
-                    m_scaleFactor.logStep(numSteps);
-                    return false; // failed to recenter
-                }
-
-                // Our goal is to keep the point under the mouse constant,
-                // so we'll do the usual trick: translate to the origin,
-                // scale/rotate, then translate back. However, the amount
-                // we translate will differ because zoom changes our height.
-                const auto newCenter = optCenter->to_vec3();
-                const auto oldCenter = m_mapScreen.getCenter();
-
-                // 1. recenter to mouse location
-
-                const auto delta1 = glm::ivec2(glm::vec2(newCenter - oldCenter)
-                                               * static_cast<float>(SCROLL_SCALE));
-
-                emit sig_mapMove(delta1.x, delta1.y);
-
-                // 2. zoom in
-                m_scaleFactor.logStep(numSteps);
-
-                // 3. adjust viewport for new projection
-                setViewportAndMvp(width(), height());
-
-                // 4. subtract the offset to same mouse coordinate;
-                // This probably shouldn't ever fail, but let's make it conditional
-                // (worst case: we're left centered on what we clicked on,
-                // which will create infuriating overshoots if it ever happens)
-                if (const auto &optCenter2 = getUnprojectedMouseSel(event)) {
-                    const auto delta2 = glm::ivec2(glm::vec2(optCenter2->to_vec3() - newCenter)
-                                                   * static_cast<float>(SCROLL_SCALE));
-
-                    emit sig_mapMove(-delta2.x, -delta2.y);
-
-                    // NOTE: caller is expected to call update() after this function,
-                    // so we don't have to update the viewport.
-                }
-
-                return true;
-            };
-
-            // Change the zoom level
-            const int numSteps = event->angleDelta().y() / 120;
-            if (numSteps != 0) {
-                zoomAndMaybeRecenter(numSteps);
-                zoomChanged();
-                update();
-            }
-        }
-        break;
-
-    case CanvasMouseModeEnum::NONE:
-    default:
-        break;
-    }
-
-    event->accept();
 }
 
 void MapCanvas::slot_onForcedPositionChange()
@@ -294,55 +161,14 @@ void MapCanvas::slot_onForcedPositionChange()
     slot_requestUpdate();
 }
 
-bool MapCanvas::event(QEvent *const event)
-{
-    auto tryHandlePinchZoom = [this, event]() -> bool {
-        if (event->type() != QEvent::Gesture) {
-            return false;
-        }
-
-        const auto *const gestureEvent = dynamic_cast<QGestureEvent *>(event);
-        if (gestureEvent == nullptr) {
-            return false;
-        }
-
-        // Zoom in / out
-        QGesture *const gesture = gestureEvent->gesture(Qt::PinchGesture);
-        const auto *const pinch = dynamic_cast<QPinchGesture *>(gesture);
-        if (pinch == nullptr) {
-            return false;
-        }
-
-        const QPinchGesture::ChangeFlags changeFlags = pinch->changeFlags();
-        if (changeFlags & QPinchGesture::ScaleFactorChanged) {
-            const auto pinchFactor = static_cast<float>(pinch->totalScaleFactor());
-            m_scaleFactor.setPinch(pinchFactor);
-            if ((false)) {
-                zoomChanged(); // Don't call this here, because it's not true yet.
-            }
-        }
-        if (pinch->state() == Qt::GestureFinished) {
-            m_scaleFactor.endPinch();
-            zoomChanged(); // might not have actually changed
-        }
-        update();
-        return true;
-    };
-
-    if (tryHandlePinchZoom()) {
-        return true;
-    }
-
-    return QOpenGLWidget::event(event);
-}
-
 void MapCanvas::slot_createRoom()
 {
-    if (!hasSel1()) {
+    auto &input = getInputState();
+    if (!input.hasSel1()) {
         return;
     }
 
-    const Coordinate c = getSel1().getCoordinate();
+    const Coordinate c = input.getSel1().getCoordinate();
     if (const auto &existing = m_data.findRoomHandle(c)) {
         return;
     }
@@ -406,606 +232,6 @@ std::shared_ptr<InfomarkSelection> MapCanvas::getInfomarkSelection(const MouseSe
     const auto lo = getScaled(minCoord);
 
     return InfomarkSelection::alloc(m_data, lo, hi);
-}
-
-void MapCanvas::mousePressEvent(QMouseEvent *const event)
-{
-    const bool hasLeftButton = (event->buttons() & Qt::LeftButton) != 0u;
-    const bool hasRightButton = (event->buttons() & Qt::RightButton) != 0u;
-    const bool hasCtrl = (event->modifiers() & Qt::CTRL) != 0u;
-    MAYBE_UNUSED const bool hasAlt = (event->modifiers() & Qt::ALT) != 0u;
-
-    if (hasLeftButton && hasAlt) {
-        m_altDragState.emplace(AltDragState{event->pos(), cursor()});
-        setCursor(Qt::ClosedHandCursor);
-        event->accept();
-        return;
-    }
-
-    m_sel1 = m_sel2 = getUnprojectedMouseSel(event);
-    m_mouseLeftPressed = hasLeftButton;
-    m_mouseRightPressed = hasRightButton;
-
-    if (event->button() == Qt::ForwardButton) {
-        slot_layerUp();
-        return event->accept();
-    } else if (event->button() == Qt::BackButton) {
-        slot_layerDown();
-        return event->accept();
-    } else if (!m_mouseLeftPressed && m_mouseRightPressed) {
-        if (m_canvasMouseMode == CanvasMouseModeEnum::MOVE && hasSel1()) {
-            // Select the room under the cursor
-            m_roomSelection = RoomSelection::createSelection(
-                m_data.findAllRooms(getSel1().getCoordinate()));
-            slot_setRoomSelection(SigRoomSelection{m_roomSelection});
-
-            // Select infomarks under the cursor.
-            slot_setInfomarkSelection(getInfomarkSelection(getSel1()));
-
-            selectionChanged();
-        }
-        m_mouseRightPressed = false;
-        event->accept();
-        return;
-    }
-
-    switch (m_canvasMouseMode) {
-    case CanvasMouseModeEnum::CREATE_INFOMARKS:
-        infomarksChanged();
-        break;
-    case CanvasMouseModeEnum::SELECT_INFOMARKS:
-        // Select infomarks
-        if (hasLeftButton && hasSel1()) {
-            auto tmpSel = getInfomarkSelection(getSel1());
-            if (m_infoMarkSelection != nullptr && !tmpSel->empty()
-                && m_infoMarkSelection->contains(tmpSel->front().getId())) {
-                m_infoMarkSelectionMove.reset();   // dtor, if necessary
-                m_infoMarkSelectionMove.emplace(); // ctor
-            } else {
-                m_selectedArea = false;
-                m_infoMarkSelectionMove.reset();
-            }
-        }
-        selectionChanged();
-        break;
-    case CanvasMouseModeEnum::MOVE:
-        if (hasLeftButton && hasSel1()) {
-            setCursor(Qt::ClosedHandCursor);
-            startMoving(m_sel1.value());
-        }
-        break;
-
-    case CanvasMouseModeEnum::RAYPICK_ROOMS:
-        if (hasLeftButton) {
-            const auto xy = getMouseCoords(event);
-            const auto near = unproject_raw(glm::vec3{xy, 0.f});
-            const auto far = unproject_raw(glm::vec3{xy, 1.f});
-
-            // Note: this rounding assumes we're looking down.
-            // We're looking for integer z-planes that cross between
-            // the hi and lo points.
-            const auto hiz = static_cast<int>(std::floor(near.z));
-            const auto loz = static_cast<int>(std::ceil(far.z));
-            if (hiz <= loz) {
-                break;
-            }
-
-            const auto inv_denom = 1.f / (far.z - near.z);
-
-            // REVISIT: This loop might feel laggy.
-            // Consider clamping the bounds of what we know we're currently displaying (including XY).
-            // (If you're looking almost parallel to the world, then the ray could pass through the
-            // visible region but still be within the visible Z-range.)
-            RoomIdSet tmpSel;
-            for (int z = hiz; z >= loz; --z) {
-                const float t = (static_cast<float>(z) - near.z) * inv_denom;
-                assert(isClamped(t, 0.f, 1.f));
-                const auto pos = glm::mix(near, far, t);
-                assert(static_cast<int>(std::lround(pos.z)) == z);
-                const Coordinate c2 = MouseSel{Coordinate2f{pos.x, pos.y}, z}.getCoordinate();
-                if (const auto r = m_data.findRoomHandle(c2)) {
-                    tmpSel.insert(r.getId());
-                }
-            }
-
-            if (!tmpSel.empty()) {
-                slot_setRoomSelection(
-                    SigRoomSelection(RoomSelection::createSelection(std::move(tmpSel))));
-            }
-
-            selectionChanged();
-        }
-        break;
-
-    case CanvasMouseModeEnum::SELECT_ROOMS:
-        // Cancel
-        if (hasRightButton) {
-            m_selectedArea = false;
-            slot_clearRoomSelection();
-        }
-        // Select rooms
-        if (hasLeftButton && hasSel1()) {
-            if (!hasCtrl) {
-                const auto pRoom = m_data.findRoomHandle(getSel1().getCoordinate());
-                if (pRoom.exists() && m_roomSelection != nullptr
-                    && m_roomSelection->contains(pRoom.getId())) {
-                    m_roomSelectionMove.emplace(RoomSelMove{});
-                } else {
-                    m_roomSelectionMove.reset();
-                    m_selectedArea = false;
-                    slot_clearRoomSelection();
-                }
-            } else {
-                m_ctrlPressed = true;
-            }
-        }
-        selectionChanged();
-        break;
-
-    case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
-    case CanvasMouseModeEnum::CREATE_CONNECTIONS:
-        // Select connection
-        if (hasLeftButton && hasSel1()) {
-            m_connectionSelection = ConnectionSelection::alloc(m_data, getSel1());
-            if (!m_connectionSelection->isFirstValid()) {
-                m_connectionSelection = nullptr;
-            }
-            emit sig_newConnectionSelection(nullptr);
-        }
-        // Cancel
-        if (hasRightButton) {
-            slot_clearConnectionSelection();
-        }
-        selectionChanged();
-        break;
-
-    case CanvasMouseModeEnum::SELECT_CONNECTIONS:
-        if (hasLeftButton && hasSel1()) {
-            m_connectionSelection = ConnectionSelection::alloc(m_data, getSel1());
-            if (!m_connectionSelection->isFirstValid()) {
-                m_connectionSelection = nullptr;
-            } else {
-                const auto &r1 = m_connectionSelection->getFirst().room;
-                const ExitDirEnum dir1 = m_connectionSelection->getFirst().direction;
-
-                if (r1.getExit(dir1).outIsEmpty()) {
-                    m_connectionSelection = nullptr;
-                }
-            }
-            emit sig_newConnectionSelection(nullptr);
-        }
-        // Cancel
-        if (hasRightButton) {
-            slot_clearConnectionSelection();
-        }
-        selectionChanged();
-        break;
-
-    case CanvasMouseModeEnum::CREATE_ROOMS:
-        slot_createRoom();
-        break;
-
-    case CanvasMouseModeEnum::NONE:
-    default:
-        break;
-    }
-}
-
-void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
-{
-    if (m_altDragState.has_value()) {
-        // The user released the Alt key mid-drag.
-        if (!((event->modifiers() & Qt::ALT) != 0u)) {
-            setCursor(m_altDragState->originalCursor);
-            m_altDragState.reset();
-            // Don't accept the event; let the underlying widgets handle it.
-            return;
-        }
-
-        auto &conf = setConfig().canvas.advanced;
-        auto &dragState = m_altDragState.value();
-        bool angleChanged = false;
-
-        const auto pos = event->pos();
-        const auto delta = pos - dragState.lastPos;
-        dragState.lastPos = pos;
-
-        // Camera rotation sensitivity: 3 degree per pixel
-        constexpr float SENSITIVITY = 0.3f;
-
-        // Horizontal movement adjusts yaw (horizontalAngle)
-        const int dx = delta.x();
-        if (dx != 0) {
-            conf.horizontalAngle.set(conf.horizontalAngle.get()
-                                     + static_cast<int>(static_cast<float>(dx) * SENSITIVITY));
-            angleChanged = true;
-        }
-
-        // Vertical movement adjusts pitch (verticalAngle), if auto-tilt is off
-        if (!conf.autoTilt.get()) {
-            const int dy = delta.y();
-            if (dy != 0) {
-                // Negated to match intuitive up/down dragging
-                conf.verticalAngle.set(conf.verticalAngle.get()
-                                       + static_cast<int>(static_cast<float>(-dy) * SENSITIVITY));
-                angleChanged = true;
-            }
-        }
-
-        if (angleChanged) {
-            graphicsSettingsChanged();
-        }
-        event->accept();
-        return;
-    }
-
-    const bool hasLeftButton = (event->buttons() & Qt::LeftButton) != 0u;
-
-    if (m_canvasMouseMode != CanvasMouseModeEnum::MOVE) {
-        // NOTE: Y is opposite of what you might expect here.
-        const int vScroll = std::invoke([this, event]() -> int {
-            const int h = height();
-            const int MARGIN = std::min(100, h / 4);
-            const auto y = event->position().y();
-            if (y < MARGIN) {
-                return SCROLL_SCALE;
-            } else if (y > h - MARGIN) {
-                return -SCROLL_SCALE;
-            } else {
-                return 0;
-            }
-        });
-        const int hScroll = std::invoke([this, event]() -> int {
-            const int w = width();
-            const int MARGIN = std::min(100, w / 4);
-            const auto x = event->position().x();
-            if (x < MARGIN) {
-                return -SCROLL_SCALE;
-            } else if (x > w - MARGIN) {
-                return SCROLL_SCALE;
-            } else {
-                return 0;
-            }
-        });
-
-        emit sig_continuousScroll(hScroll, vScroll);
-    }
-
-    m_sel2 = getUnprojectedMouseSel(event);
-
-    switch (m_canvasMouseMode) {
-    case CanvasMouseModeEnum::SELECT_INFOMARKS:
-        if (hasLeftButton && hasSel1() && hasSel2()) {
-            if (hasInfomarkSelectionMove()) {
-                m_infoMarkSelectionMove->pos = getSel2().pos - getSel1().pos;
-                setCursor(Qt::ClosedHandCursor);
-
-            } else {
-                m_selectedArea = true;
-            }
-        }
-        selectionChanged();
-        break;
-    case CanvasMouseModeEnum::CREATE_INFOMARKS:
-        if (hasLeftButton) {
-            m_selectedArea = true;
-        }
-        // REVISIT: It doesn't look like anything actually changed here?
-        infomarksChanged();
-        break;
-    case CanvasMouseModeEnum::MOVE:
-        if (hasLeftButton && m_mouseLeftPressed && hasSel2() && hasBackup()) {
-            const Coordinate2i delta
-                = ((getSel2().pos - getBackup().pos) * static_cast<float>(SCROLL_SCALE)).truncate();
-            if (delta.x != 0 || delta.y != 0) {
-                // negated because dragging to right is scrolling to the left.
-                emit sig_mapMove(-delta.x, -delta.y);
-            }
-        }
-        break;
-
-    case CanvasMouseModeEnum::RAYPICK_ROOMS:
-        break;
-
-    case CanvasMouseModeEnum::SELECT_ROOMS:
-        if (hasLeftButton) {
-            if (hasRoomSelectionMove() && hasSel1() && hasSel2()) {
-                auto &map = this->m_data;
-                auto isMovable = [&map](RoomSelection &sel, const Coordinate &offset) -> bool {
-                    sel.removeMissing(map);
-                    return map.getCurrentMap().wouldAllowRelativeMove(sel.getRoomIds(), offset);
-                };
-
-                const auto diff = getSel2().pos.truncate() - getSel1().pos.truncate();
-                const auto wrongPlace = !isMovable(deref(m_roomSelection), Coordinate{diff, 0});
-                m_roomSelectionMove->pos = diff;
-                m_roomSelectionMove->wrongPlace = wrongPlace;
-
-                setCursor(wrongPlace ? Qt::ForbiddenCursor : Qt::ClosedHandCursor);
-            } else {
-                m_selectedArea = true;
-            }
-        }
-        selectionChanged();
-        break;
-
-    case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
-    case CanvasMouseModeEnum::CREATE_CONNECTIONS:
-        if (hasLeftButton && hasSel2()) {
-            if (m_connectionSelection != nullptr) {
-                m_connectionSelection->setSecond(getSel2());
-
-                if (m_connectionSelection->isValid() && !m_connectionSelection->isCompleteNew()) {
-                    m_connectionSelection->removeSecond();
-                }
-
-                selectionChanged();
-            }
-        } else {
-            slot_requestUpdate();
-        }
-        break;
-
-    case CanvasMouseModeEnum::SELECT_CONNECTIONS:
-        if (hasLeftButton && hasSel2()) {
-            if (m_connectionSelection != nullptr) {
-                m_connectionSelection->setSecond(getSel2());
-
-                if (!m_connectionSelection->isCompleteExisting()) {
-                    m_connectionSelection->removeSecond();
-                }
-
-                selectionChanged();
-            }
-        }
-        break;
-
-    case CanvasMouseModeEnum::CREATE_ROOMS:
-    case CanvasMouseModeEnum::NONE:
-    default:
-        break;
-    }
-}
-
-void MapCanvas::mouseReleaseEvent(QMouseEvent *const event)
-{
-    if (m_altDragState.has_value()) {
-        setCursor(m_altDragState->originalCursor);
-        m_altDragState.reset();
-        event->accept();
-        return;
-    }
-
-    emit sig_continuousScroll(0, 0);
-    m_sel2 = getUnprojectedMouseSel(event);
-
-    if (m_mouseRightPressed) {
-        m_mouseRightPressed = false;
-    }
-
-    switch (m_canvasMouseMode) {
-    case CanvasMouseModeEnum::SELECT_INFOMARKS:
-        setCursor(Qt::ArrowCursor);
-        if (m_mouseLeftPressed) {
-            m_mouseLeftPressed = false;
-            if (hasInfomarkSelectionMove()) {
-                const auto pos_copy = m_infoMarkSelectionMove->pos;
-                m_infoMarkSelectionMove.reset();
-                if (m_infoMarkSelection != nullptr) {
-                    const auto offset = Coordinate{(pos_copy * INFOMARK_SCALE).truncate(), 0};
-
-                    // Update infomark location
-                    const InfomarkSelection &sel = deref(m_infoMarkSelection);
-                    sel.applyOffset(offset);
-                    infomarksChanged();
-                }
-            } else if (hasSel1() && hasSel2()) {
-                // Add infomarks to selection
-                const auto c1 = getSel1().getScaledCoordinate(INFOMARK_SCALE);
-                const auto c2 = getSel2().getScaledCoordinate(INFOMARK_SCALE);
-                auto tmpSel = InfomarkSelection::alloc(m_data, c1, c2);
-                if (tmpSel && tmpSel->size() == 1) {
-                    const InfomarkHandle &firstMark = tmpSel->front();
-                    const Coordinate &pos = firstMark.getPosition1();
-                    QString ctemp = QString("Selected Info Mark: [%1] (at %2,%3,%4)")
-                                        .arg(firstMark.getText().toQString())
-                                        .arg(pos.x)
-                                        .arg(pos.y)
-                                        .arg(pos.z);
-                    log(ctemp);
-                }
-                slot_setInfomarkSelection(tmpSel);
-            }
-            m_selectedArea = false;
-        }
-        selectionChanged();
-        break;
-
-    case CanvasMouseModeEnum::CREATE_INFOMARKS:
-        if (m_mouseLeftPressed && hasSel1() && hasSel2()) {
-            m_mouseLeftPressed = false;
-            const auto c1 = getSel1().getScaledCoordinate(INFOMARK_SCALE);
-            const auto c2 = getSel2().getScaledCoordinate(INFOMARK_SCALE);
-            // REVISIT: this previously searched for all the marks in c1, c2,
-            // and then immediately cleared the selection.
-            // Why??? Now it just allocates an empty selection.
-            auto tmpSel = InfomarkSelection::allocEmpty(m_data, c1, c2);
-            slot_setInfomarkSelection(tmpSel);
-        }
-        infomarksChanged();
-        break;
-
-    case CanvasMouseModeEnum::MOVE:
-        stopMoving();
-        setCursor(Qt::OpenHandCursor);
-        if (m_mouseLeftPressed) {
-            m_mouseLeftPressed = false;
-        }
-        // Display a room info tooltip if there was no mouse movement
-        if (hasSel1() && hasSel2() && getSel1().to_vec3() == getSel2().to_vec3()) {
-            if (const auto room = m_data.findRoomHandle(getSel1().getCoordinate())) {
-                // Tooltip doesn't support ANSI, and there's no way to add formatted text.
-                auto message = mmqt::previewRoom(room,
-                                                 mmqt::StripAnsiEnum::Yes,
-                                                 mmqt::PreviewStyleEnum::ForDisplay);
-
-                QToolTip::showText(mapToGlobal(event->position().toPoint()),
-                                   message,
-                                   this,
-                                   rect(),
-                                   5000);
-            }
-        }
-        break;
-
-    case CanvasMouseModeEnum::RAYPICK_ROOMS:
-        break;
-
-    case CanvasMouseModeEnum::SELECT_ROOMS:
-        setCursor(Qt::ArrowCursor);
-
-        // This seems very unusual.
-        if (m_ctrlPressed && m_altPressed) {
-            break;
-        }
-
-        if (m_mouseLeftPressed) {
-            m_mouseLeftPressed = false;
-
-            if (m_roomSelectionMove.has_value()) {
-                const auto pos = m_roomSelectionMove->pos;
-                const bool wrongPlace = m_roomSelectionMove->wrongPlace;
-                m_roomSelectionMove.reset();
-                if (!wrongPlace && (m_roomSelection != nullptr)) {
-                    const Coordinate moverel{pos, 0};
-                    m_data.applySingleChange(Change{
-                        room_change_types::MoveRelative2{m_roomSelection->getRoomIds(), moverel}});
-                }
-
-            } else {
-                if (hasSel1() && hasSel2()) {
-                    const Coordinate &c1 = getSel1().getCoordinate();
-                    const Coordinate &c2 = getSel2().getCoordinate();
-                    if (m_roomSelection == nullptr) {
-                        // add rooms to default selections
-                        m_roomSelection = RoomSelection::createSelection(
-                            m_data.findAllRooms(c1, c2));
-                    } else {
-                        auto &sel = deref(m_roomSelection);
-                        sel.removeMissing(m_data);
-                        // add or remove rooms to/from default selection
-                        const auto tmpSel = m_data.findAllRooms(c1, c2);
-                        for (const RoomId key : tmpSel) {
-                            if (sel.contains(key)) {
-                                sel.erase(key);
-                            } else {
-                                sel.insert(key);
-                            }
-                        }
-                    }
-                }
-
-                if (m_roomSelection != nullptr && !m_roomSelection->empty()) {
-                    slot_setRoomSelection(SigRoomSelection{m_roomSelection});
-                }
-            }
-            m_selectedArea = false;
-        }
-        selectionChanged();
-        break;
-
-    case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
-    case CanvasMouseModeEnum::CREATE_CONNECTIONS:
-        if (m_mouseLeftPressed && hasSel1() && hasSel2()) {
-            m_mouseLeftPressed = false;
-
-            if (m_connectionSelection == nullptr) {
-                m_connectionSelection = ConnectionSelection::alloc(m_data, getSel1());
-            }
-            m_connectionSelection->setSecond(getSel2());
-
-            if (!m_connectionSelection->isValid()) {
-                m_connectionSelection = nullptr;
-            } else {
-                const auto first = m_connectionSelection->getFirst();
-                const auto second = m_connectionSelection->getSecond();
-                const auto &r1 = first.room;
-                const auto &r2 = second.room;
-
-                if (r1.exists() && r2.exists()) {
-                    const ExitDirEnum dir1 = first.direction;
-                    const ExitDirEnum dir2 = second.direction;
-
-                    const RoomId id1 = r1.getId();
-                    const RoomId id2 = r2.getId();
-
-                    const bool isCompleteNew = m_connectionSelection->isCompleteNew();
-                    m_connectionSelection = nullptr;
-
-                    if (isCompleteNew) {
-                        const WaysEnum ways = (m_canvasMouseMode
-                                               != CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS)
-                                                  ? WaysEnum::TwoWay
-                                                  : WaysEnum::OneWay;
-                        const exit_change_types::ModifyExitConnection change{ChangeTypeEnum::Add,
-                                                                             id1,
-                                                                             dir1,
-                                                                             id2,
-                                                                             ways};
-                        m_data.applySingleChange(Change{change});
-                    }
-                    m_connectionSelection = ConnectionSelection::alloc(m_data);
-                    m_connectionSelection->setFirst(id1, dir1);
-                    m_connectionSelection->setSecond(id2, dir2);
-                    slot_mapChanged();
-                }
-            }
-
-            slot_setConnectionSelection(m_connectionSelection);
-        }
-        selectionChanged();
-        break;
-
-    case CanvasMouseModeEnum::SELECT_CONNECTIONS:
-        if (m_mouseLeftPressed && (m_connectionSelection != nullptr || hasSel1()) && hasSel2()) {
-            m_mouseLeftPressed = false;
-
-            if (m_connectionSelection == nullptr && hasSel1()) {
-                m_connectionSelection = ConnectionSelection::alloc(m_data, getSel1());
-            }
-            m_connectionSelection->setSecond(getSel2());
-
-            if (!m_connectionSelection->isValid() || !m_connectionSelection->isCompleteExisting()) {
-                m_connectionSelection = nullptr;
-            }
-            slot_setConnectionSelection(m_connectionSelection);
-        }
-        selectionChanged();
-        break;
-
-    case CanvasMouseModeEnum::CREATE_ROOMS:
-        if (m_mouseLeftPressed) {
-            m_mouseLeftPressed = false;
-        }
-        break;
-
-    case CanvasMouseModeEnum::NONE:
-    default:
-        break;
-    }
-
-    m_altPressed = false;
-    m_ctrlPressed = false;
-}
-
-QSize MapCanvas::minimumSizeHint() const
-{
-    return {sizeHint().width() / 4, sizeHint().height() / 4};
-}
-
-QSize MapCanvas::sizeHint() const
-{
-    return {1280, 720};
 }
 
 void MapCanvas::slot_setScroll(const glm::vec2 &worldPos)
@@ -1143,11 +369,17 @@ void MapCanvas::graphicsSettingsChanged()
     update();
 }
 
+void MapCanvas::zoomChanged()
+{
+    emit sig_zoomChanged(getRawZoom());
+}
+
 void MapCanvas::userPressedEscape(bool /*pressed*/)
 {
     // TODO: encapsulate the states so we can easily cancel anything that's in use.
+    auto &input = getInputState();
 
-    switch (m_canvasMouseMode) {
+    switch (input.m_canvasMouseMode) {
     case CanvasMouseModeEnum::NONE:
     case CanvasMouseModeEnum::CREATE_ROOMS:
         break;
@@ -1160,8 +392,8 @@ void MapCanvas::userPressedEscape(bool /*pressed*/)
 
     case CanvasMouseModeEnum::RAYPICK_ROOMS:
     case CanvasMouseModeEnum::SELECT_ROOMS:
-        m_selectedArea = false;
-        m_roomSelectionMove.reset();
+        input.m_selectedArea = false;
+        input.m_roomSelectionMove.reset();
         slot_clearRoomSelection(); // calls selectionChanged();
         break;
 
@@ -1170,8 +402,13 @@ void MapCanvas::userPressedEscape(bool /*pressed*/)
         FALLTHROUGH;
     case CanvasMouseModeEnum::SELECT_INFOMARKS:
     case CanvasMouseModeEnum::CREATE_INFOMARKS:
-        m_infoMarkSelectionMove.reset();
+        input.m_infoMarkSelectionMove.reset();
         slot_clearInfomarkSelection(); // calls selectionChanged();
         break;
     }
+}
+
+void MapCanvas::log(const QString &msg)
+{
+    emit sig_log("MapCanvas", msg);
 }

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -154,6 +154,28 @@ void MapCanvas::slot_setInfomarkSelection(const std::shared_ptr<InfomarkSelectio
     selectionChanged();
 }
 
+void MapCanvas::slot_clearRoomSelection()
+{
+    slot_setRoomSelection(SigRoomSelection{});
+}
+
+void MapCanvas::slot_clearConnectionSelection()
+{
+    slot_setConnectionSelection(nullptr);
+}
+
+void MapCanvas::slot_clearInfomarkSelection()
+{
+    slot_setInfomarkSelection(nullptr);
+}
+
+void MapCanvas::slot_clearAllSelections()
+{
+    slot_clearRoomSelection();
+    slot_clearConnectionSelection();
+    slot_clearInfomarkSelection();
+}
+
 void MapCanvas::slot_onForcedPositionChange()
 {
     slot_requestUpdate();

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -299,16 +299,10 @@ public slots:
     void slot_setConnectionSelection(const std::shared_ptr<ConnectionSelection> &);
     void slot_setInfomarkSelection(const std::shared_ptr<InfomarkSelection> &);
 
-    void slot_clearRoomSelection() { slot_setRoomSelection(SigRoomSelection{}); }
-    void slot_clearConnectionSelection() { slot_setConnectionSelection(nullptr); }
-    void slot_clearInfomarkSelection() { slot_setInfomarkSelection(nullptr); }
-
-    void slot_clearAllSelections()
-    {
-        slot_clearRoomSelection();
-        slot_clearConnectionSelection();
-        slot_clearInfomarkSelection();
-    }
+    void slot_clearRoomSelection();
+    void slot_clearConnectionSelection();
+    void slot_clearInfomarkSelection();
+    void slot_clearAllSelections();
 
     void slot_dataLoaded();
     void slot_moveMarker(RoomId id);

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -30,7 +30,7 @@
 #include <QColor>
 #include <QMatrix4x4>
 #include <QOpenGLDebugMessage>
-#include <QOpenGLWidget>
+#include <QOpenGLWindow>
 #include <QtCore>
 
 class CharacterBatch;
@@ -47,9 +47,8 @@ class QWheelEvent;
 class QWidget;
 class RoomSelFakeGL;
 
-class NODISCARD_QOBJECT MapCanvas final : public QOpenGLWidget,
-                                          private MapCanvasViewport,
-                                          private MapCanvasInputState
+class NODISCARD_QOBJECT MapCanvas final : public QOpenGLWindow,
+                                          public MapCanvasViewport
 {
     Q_OBJECT
 
@@ -139,28 +138,30 @@ private:
     Batches m_batches;
     MapCanvasTextures m_textures;
     MapData &m_data;
+    PrespammedPath &m_prespammedPath;
     Mmapper2Group &m_groupManager;
+    MapCanvasInputState *m_inputState = nullptr;
     Diff m_diff;
     FrameRateController m_frameRateController;
     std::unique_ptr<QOpenGLDebugLogger> m_logger;
     Signal2Lifetime m_lifetime;
 
-    struct AltDragState
-    {
-        QPoint lastPos;
-        QCursor originalCursor;
-    };
-    std::optional<AltDragState> m_altDragState;
-
 public:
     explicit MapCanvas(MapData &mapData,
                        PrespammedPath &prespammedPath,
-                       Mmapper2Group &groupManager,
-                       QWidget *parent);
+                       Mmapper2Group &groupManager);
     ~MapCanvas() final;
 
 public:
     NODISCARD static MapCanvas *getPrimary();
+
+public:
+    void setInputState(MapCanvasInputState *inputState) { m_inputState = inputState; }
+    NODISCARD MapCanvasInputState &getInputState() { return deref(m_inputState); }
+    NODISCARD const MapCanvasInputState &getInputState() const { return deref(m_inputState); }
+
+    NODISCARD auto &getMapScreen() { return m_mapScreen; }
+    NODISCARD const auto &getMapScreen() const { return m_mapScreen; }
 
 private:
     NODISCARD inline auto &getOpenGL() { return m_opengl; }
@@ -168,9 +169,6 @@ private:
     void cleanupOpenGL();
 
 public:
-    NODISCARD QSize minimumSizeHint() const override;
-    NODISCARD QSize sizeHint() const override;
-
     using MapCanvasViewport::getTotalScaleFactor;
     void setZoom(float zoom)
     {
@@ -180,9 +178,8 @@ public:
     NODISCARD float getRawZoom() const { return m_scaleFactor.getRaw(); }
 
 public:
-    NODISCARD auto width() const { return QOpenGLWidget::width(); }
-    NODISCARD auto height() const { return QOpenGLWidget::height(); }
-    NODISCARD auto rect() const { return QOpenGLWidget::rect(); }
+    using MapCanvasViewport::width;
+    using MapCanvasViewport::height;
 
 private:
     void onMovement();
@@ -198,11 +195,6 @@ protected:
     void drawGroupCharacters(CharacterBatch &characterBatch);
 
     void resizeGL(int width, int height) override;
-    void mousePressEvent(QMouseEvent *event) override;
-    void mouseReleaseEvent(QMouseEvent *event) override;
-    void mouseMoveEvent(QMouseEvent *event) override;
-    void wheelEvent(QWheelEvent *event) override;
-    bool event(QEvent *e) override;
 
 private:
     void setAnimating(bool value);
@@ -216,6 +208,7 @@ private:
     void updateTextures();
     void updateMultisampling();
 
+public:
     NODISCARD std::shared_ptr<InfomarkSelection> getInfomarkSelection(const MouseSel &sel);
     NODISCARD static glm::mat4 getViewProj_old(const glm::vec2 &scrollPos,
                                                const glm::ivec2 &size,
@@ -264,19 +257,17 @@ public:
     void screenChanged();
     void selectionChanged();
     void graphicsSettingsChanged();
-    void zoomChanged() { emit sig_zoomChanged(getRawZoom()); }
+    void zoomChanged();
 
 public:
     void userPressedEscape(bool);
 
 private:
-    void log(const QString &msg) { emit sig_log("MapCanvas", msg); }
+    void log(const QString &msg);
 
 signals:
     void sig_onCenter(const glm::vec2 &worldCoord);
-    void sig_mapMove(int dx, int dy);
     void sig_setScrollBars(const Coordinate &min, const Coordinate &max);
-    void sig_continuousScroll(int, int);
 
     void sig_log(const QString &, const QString &);
 
@@ -291,8 +282,6 @@ signals:
 public slots:
     void slot_onForcedPositionChange();
     void slot_createRoom();
-
-    void slot_setCanvasMouseMode(CanvasMouseModeEnum mode);
 
     void slot_setScroll(const glm::vec2 &worldPos);
     // void setScroll(const glm::ivec2 &) = delete; // moc tries to call the wrong one if you define this

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -47,8 +47,7 @@ class QWheelEvent;
 class QWidget;
 class RoomSelFakeGL;
 
-class NODISCARD_QOBJECT MapCanvas final : public QOpenGLWindow,
-                                          public MapCanvasViewport
+class NODISCARD_QOBJECT MapCanvas final : public QOpenGLWindow, public MapCanvasViewport
 {
     Q_OBJECT
 
@@ -178,8 +177,8 @@ public:
     NODISCARD float getRawZoom() const { return m_scaleFactor.getRaw(); }
 
 public:
-    using MapCanvasViewport::width;
     using MapCanvasViewport::height;
+    using MapCanvasViewport::width;
 
 private:
     void onMovement();

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -6,22 +6,33 @@
 
 #include "mapwindow.h"
 
+#include "../configuration/configuration.h"
 #include "../display/Filenames.h"
+#include "../display/InfomarkSelection.h"
+#include "../display/MapCanvasData.h"
+#include "../display/connectionselection.h"
 #include "../global/SignalBlocker.h"
 #include "../global/Version.h"
+#include "../mapdata/mapdata.h"
 #include "mapcanvas.h"
 
 #include <memory>
 
+#include <QGestureEvent>
 #include <QGridLayout>
 #include <QLabel>
+#include <QMouseEvent>
 #include <QPixmap>
 #include <QScrollBar>
+#include <QToolTip>
+#include <QWheelEvent>
 
 class QResizeEvent;
 
 MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QWidget *const parent)
     : QWidget(parent)
+    , MapCanvasInputState(pp)
+    , m_data(mapData)
 {
     m_gridLayout = std::make_unique<QGridLayout>(this);
     m_gridLayout->setSpacing(0);
@@ -43,11 +54,23 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
 
     m_gridLayout->addWidget(m_horizontalScrollBar.get(), 1, 0, 1, 1);
 
-    m_canvas = std::make_unique<MapCanvas>(mapData, pp, gm, this);
-    MapCanvas *const canvas = m_canvas.get();
+    m_canvas = new MapCanvas(mapData, pp, gm);
+    m_canvas->setInputState(this);
+    MapCanvas *const canvas = m_canvas;
 
-    m_gridLayout->addWidget(canvas, 0, 0, 1, 1);
-    setMinimumSize(canvas->minimumSizeHint());
+    m_canvasContainer = QWidget::createWindowContainer(m_canvas, this);
+    m_canvasContainer->setCursor(Qt::OpenHandCursor);
+    m_canvasContainer->grabGesture(Qt::PinchGesture);
+    m_canvasContainer->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_canvasContainer->installEventFilter(this);
+
+    connect(m_canvasContainer,
+            &QWidget::customContextMenuRequested,
+            this,
+            &MapWindow::sig_customContextMenuRequested);
+
+    m_gridLayout->addWidget(m_canvasContainer, 0, 0, 1, 1);
+    setMinimumSize(1280 / 4, 720 / 4);
 
     // Splash setup
     auto createSplashPixmap = [](const QSize &targetLogicalSize, qreal dpr) -> QPixmap {
@@ -121,9 +144,19 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
     {
         connect(canvas, &MapCanvas::sig_onCenter, this, &MapWindow::slot_centerOnWorldPos);
         connect(canvas, &MapCanvas::sig_setScrollBars, this, &MapWindow::slot_setScrollBars);
-        connect(canvas, &MapCanvas::sig_continuousScroll, this, &MapWindow::slot_continuousScroll);
-        connect(canvas, &MapCanvas::sig_mapMove, this, &MapWindow::slot_mapMove);
-        connect(canvas, &MapCanvas::sig_zoomChanged, this, &MapWindow::slot_zoomChanged);
+        connect(canvas, &MapCanvas::sig_log, this, &MapWindow::sig_log);
+    }
+
+    // relay signals from canvas to window
+    {
+        connect(canvas, &MapCanvas::sig_onCenter, this, &MapWindow::sig_onCenter);
+        connect(canvas, &MapCanvas::sig_setScrollBars, this, &MapWindow::sig_setScrollBars);
+        connect(canvas, &MapCanvas::sig_selectionChanged, this, &MapWindow::sig_selectionChanged);
+        connect(canvas, &MapCanvas::sig_newRoomSelection, this, &MapWindow::sig_newRoomSelection);
+        connect(canvas, &MapCanvas::sig_newConnectionSelection, this, &MapWindow::sig_newConnectionSelection);
+        connect(canvas, &MapCanvas::sig_newInfomarkSelection, this, &MapWindow::sig_newInfomarkSelection);
+        connect(canvas, &MapCanvas::sig_setCurrentRoom, this, &MapWindow::sig_setCurrentRoom);
+        connect(canvas, &MapCanvas::sig_zoomChanged, this, &MapWindow::sig_zoomChanged);
     }
 }
 
@@ -131,7 +164,7 @@ void MapWindow::hideSplashImage()
 {
     if (m_splashLabel) {
         m_splashLabel->hide();
-        m_splashLabel.release();
+        m_splashLabel.reset();
     }
 }
 
@@ -267,9 +300,9 @@ void MapWindow::updateScrollBars()
     }
 }
 
-MapCanvas *MapWindow::getCanvas() const
+MapCanvas *MapWindow::getMapCanvas() const
 {
-    return m_canvas.get();
+    return m_canvas;
 }
 
 void MapWindow::setZoom(const float zoom)
@@ -297,4 +330,768 @@ glm::ivec2 MapWindow::KnownMapSize::worldToScroll(const glm::vec2 &worldPos_in) 
     worldPos.y = static_cast<float>(size().y) - worldPos.y; // negate Y
     const glm::ivec2 scrollPos{worldPos * static_cast<float>(MapCanvas::SCROLL_SCALE)};
     return scrollPos;
+}
+
+bool MapWindow::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == m_canvasContainer) {
+        switch (event->type()) {
+        case QEvent::MouseButtonPress:
+            handleMousePress(static_cast<QMouseEvent *>(event));
+            return true;
+        case QEvent::MouseButtonRelease:
+            handleMouseRelease(static_cast<QMouseEvent *>(event));
+            return true;
+        case QEvent::MouseMove:
+            handleMouseMove(static_cast<QMouseEvent *>(event));
+            return true;
+        case QEvent::Wheel:
+            handleWheel(static_cast<QWheelEvent *>(event));
+            return true;
+        case QEvent::Gesture:
+            handleGesture(static_cast<QGestureEvent *>(event));
+            return true;
+        default:
+            break;
+        }
+    }
+    return QWidget::eventFilter(watched, event);
+}
+
+void MapWindow::handleMousePress(QMouseEvent *const event)
+{
+    const bool hasLeftButton = (event->buttons() & Qt::LeftButton) != 0u;
+    const bool hasRightButton = (event->buttons() & Qt::RightButton) != 0u;
+    const bool hasCtrl = (event->modifiers() & Qt::CTRL) != 0u;
+    const bool hasAlt = (event->modifiers() & Qt::ALT) != 0u;
+
+    if (hasLeftButton && hasAlt) {
+        m_altDragState.emplace(AltDragState{event->pos(), m_canvasContainer->cursor()});
+        m_canvasContainer->setCursor(Qt::ClosedHandCursor);
+        event->accept();
+        return;
+    }
+
+    m_sel1 = m_sel2 = m_canvas->getUnprojectedMouseSel(event);
+    m_mouseLeftPressed = hasLeftButton;
+    m_mouseRightPressed = hasRightButton;
+
+    if (event->button() == Qt::ForwardButton) {
+        m_canvas->slot_layerUp();
+        return event->accept();
+    } else if (event->button() == Qt::BackButton) {
+        m_canvas->slot_layerDown();
+        return event->accept();
+    } else if (!m_mouseLeftPressed && m_mouseRightPressed) {
+        if (m_canvasMouseMode == CanvasMouseModeEnum::MOVE && hasSel1()) {
+            // Select the room under the cursor
+            slot_setRoomSelection(SigRoomSelection{RoomSelection::createSelection(
+                m_data.findAllRooms(getSel1().getCoordinate()))});
+
+            // Select infomarks under the cursor.
+            slot_setInfomarkSelection(m_canvas->getInfomarkSelection(getSel1()));
+        }
+        m_mouseRightPressed = false;
+        event->accept();
+        return;
+    }
+
+    switch (m_canvasMouseMode) {
+    case CanvasMouseModeEnum::CREATE_INFOMARKS:
+        m_canvas->infomarksChanged();
+        break;
+    case CanvasMouseModeEnum::SELECT_INFOMARKS:
+        // Select infomarks
+        if (hasLeftButton && hasSel1()) {
+            auto tmpSel = m_canvas->getInfomarkSelection(getSel1());
+            if (m_infoMarkSelection != nullptr && !tmpSel->empty()
+                && m_infoMarkSelection->contains(tmpSel->front().getId())) {
+                m_infoMarkSelectionMove.reset();   // dtor, if necessary
+                m_infoMarkSelectionMove.emplace(); // ctor
+            } else {
+                m_selectedArea = false;
+                m_infoMarkSelectionMove.reset();
+            }
+        }
+        m_canvas->selectionChanged();
+        break;
+    case CanvasMouseModeEnum::MOVE:
+        if (hasLeftButton && hasSel1()) {
+            m_canvasContainer->setCursor(Qt::ClosedHandCursor);
+            startMoving(m_sel1.value());
+        }
+        break;
+
+    case CanvasMouseModeEnum::RAYPICK_ROOMS:
+        if (hasLeftButton) {
+            const auto xy = m_canvas->getMouseCoords(event);
+            const auto near = m_canvas->unproject_raw(glm::vec3{xy, 0.f});
+            const auto far = m_canvas->unproject_raw(glm::vec3{xy, 1.f});
+
+            const auto hiz = static_cast<int>(std::floor(near.z));
+            const auto loz = static_cast<int>(std::ceil(far.z));
+            if (hiz <= loz) {
+                break;
+            }
+
+            const auto inv_denom = 1.f / (far.z - near.z);
+
+            RoomIdSet tmpSel;
+            for (int z = hiz; z >= loz; --z) {
+                const float t = (static_cast<float>(z) - near.z) * inv_denom;
+                assert(isClamped(t, 0.f, 1.f));
+                const auto pos = glm::mix(near, far, t);
+                assert(static_cast<int>(std::lround(pos.z)) == z);
+                const Coordinate c2 = MouseSel{Coordinate2f{pos.x, pos.y}, z}.getCoordinate();
+                if (const auto r = m_data.findRoomHandle(c2)) {
+                    tmpSel.insert(r.getId());
+                }
+            }
+
+            if (!tmpSel.empty()) {
+                slot_setRoomSelection(
+                    SigRoomSelection(RoomSelection::createSelection(std::move(tmpSel))));
+            }
+        }
+        break;
+
+    case CanvasMouseModeEnum::SELECT_ROOMS:
+        // Cancel
+        if (hasRightButton) {
+            m_selectedArea = false;
+            slot_clearRoomSelection();
+        }
+        // Select rooms
+        if (hasLeftButton && hasSel1()) {
+            if (!hasCtrl) {
+                const auto pRoom = m_data.findRoomHandle(getSel1().getCoordinate());
+                if (pRoom.exists() && m_roomSelection != nullptr
+                    && m_roomSelection->contains(pRoom.getId())) {
+                    m_roomSelectionMove.emplace(RoomSelMove{});
+                } else {
+                    m_roomSelectionMove.reset();
+                    m_selectedArea = false;
+                    slot_clearRoomSelection();
+                }
+            } else {
+                m_ctrlPressed = true;
+            }
+        }
+        m_canvas->selectionChanged();
+        break;
+
+    case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
+    case CanvasMouseModeEnum::CREATE_CONNECTIONS:
+        // Select connection
+        if (hasLeftButton && hasSel1()) {
+            m_connectionSelection = ConnectionSelection::alloc(m_data, getSel1());
+            if (!m_connectionSelection->isFirstValid()) {
+                m_connectionSelection = nullptr;
+            }
+            emit sig_newConnectionSelection(nullptr);
+        }
+        // Cancel
+        if (hasRightButton) {
+            slot_clearConnectionSelection();
+        }
+        m_canvas->selectionChanged();
+        break;
+
+    case CanvasMouseModeEnum::SELECT_CONNECTIONS:
+        if (hasLeftButton && hasSel1()) {
+            m_connectionSelection = ConnectionSelection::alloc(m_data, getSel1());
+            if (!m_connectionSelection->isFirstValid()) {
+                m_connectionSelection = nullptr;
+            } else {
+                const auto &r1 = m_connectionSelection->getFirst().room;
+                const ExitDirEnum dir1 = m_connectionSelection->getFirst().direction;
+
+                if (r1.getExit(dir1).outIsEmpty()) {
+                    m_connectionSelection = nullptr;
+                }
+            }
+            emit sig_newConnectionSelection(nullptr);
+        }
+        // Cancel
+        if (hasRightButton) {
+            slot_clearConnectionSelection();
+        }
+        m_canvas->selectionChanged();
+        break;
+
+    case CanvasMouseModeEnum::CREATE_ROOMS:
+        slot_createRoom();
+        break;
+
+    case CanvasMouseModeEnum::NONE:
+    default:
+        break;
+    }
+}
+
+void MapWindow::handleMouseRelease(QMouseEvent *const event)
+{
+    if (m_altDragState.has_value()) {
+        m_canvasContainer->setCursor(m_altDragState->originalCursor);
+        m_altDragState.reset();
+        event->accept();
+        return;
+    }
+
+    emit sig_continuousScroll(0, 0);
+    m_sel2 = m_canvas->getUnprojectedMouseSel(event);
+
+    if (m_mouseRightPressed) {
+        m_mouseRightPressed = false;
+    }
+
+    switch (m_canvasMouseMode) {
+    case CanvasMouseModeEnum::SELECT_INFOMARKS:
+        m_canvasContainer->setCursor(Qt::ArrowCursor);
+        if (m_mouseLeftPressed) {
+            m_mouseLeftPressed = false;
+            if (hasInfomarkSelectionMove()) {
+                const auto pos_copy = m_infoMarkSelectionMove->pos;
+                m_infoMarkSelectionMove.reset();
+                if (m_infoMarkSelection != nullptr) {
+                    const auto offset = Coordinate{(pos_copy * INFOMARK_SCALE).truncate(), 0};
+
+                    // Update infomark location
+                    const InfomarkSelection &sel = deref(m_infoMarkSelection);
+                    sel.applyOffset(offset);
+                    m_canvas->infomarksChanged();
+                }
+            } else if (hasSel1() && hasSel2()) {
+                // Add infomarks to selection
+                const auto c1 = getSel1().getScaledCoordinate(INFOMARK_SCALE);
+                const auto c2 = getSel2().getScaledCoordinate(INFOMARK_SCALE);
+                auto tmpSel = InfomarkSelection::alloc(m_data, c1, c2);
+                if (tmpSel && tmpSel->size() == 1) {
+                    const InfomarkHandle &firstMark = tmpSel->front();
+                    const Coordinate &pos = firstMark.getPosition1();
+                    QString ctemp = QString("Selected Info Mark: [%1] (at %2,%3,%4)")
+                                        .arg(firstMark.getText().toQString())
+                                        .arg(pos.x)
+                                        .arg(pos.y)
+                                        .arg(pos.z);
+                    emit sig_log("MapCanvas", ctemp);
+                }
+                slot_setInfomarkSelection(tmpSel);
+            }
+            m_selectedArea = false;
+        }
+        m_canvas->selectionChanged();
+        break;
+
+    case CanvasMouseModeEnum::CREATE_INFOMARKS:
+        if (m_mouseLeftPressed && hasSel1() && hasSel2()) {
+            m_mouseLeftPressed = false;
+            const auto c1 = getSel1().getScaledCoordinate(INFOMARK_SCALE);
+            const auto c2 = getSel2().getScaledCoordinate(INFOMARK_SCALE);
+            auto tmpSel = InfomarkSelection::allocEmpty(m_data, c1, c2);
+            slot_setInfomarkSelection(tmpSel);
+        }
+        m_canvas->infomarksChanged();
+        break;
+
+    case CanvasMouseModeEnum::MOVE:
+        stopMoving();
+        m_canvasContainer->setCursor(Qt::OpenHandCursor);
+        if (m_mouseLeftPressed) {
+            m_mouseLeftPressed = false;
+        }
+        // Display a room info tooltip if there was no mouse movement
+        if (hasSel1() && hasSel2() && getSel1().to_vec3() == getSel2().to_vec3()) {
+            if (const auto room = m_data.findRoomHandle(getSel1().getCoordinate())) {
+                // Tooltip doesn't support ANSI, and there's no way to add formatted text.
+                auto message = mmqt::previewRoom(room,
+                                                 mmqt::StripAnsiEnum::Yes,
+                                                 mmqt::PreviewStyleEnum::ForDisplay);
+
+                QToolTip::showText(m_canvasContainer->mapToGlobal(event->position().toPoint()),
+                                   message,
+                                   m_canvasContainer,
+                                   m_canvasContainer->rect(),
+                                   5000);
+            }
+        }
+        break;
+
+    case CanvasMouseModeEnum::RAYPICK_ROOMS:
+        break;
+
+    case CanvasMouseModeEnum::SELECT_ROOMS:
+        m_canvasContainer->setCursor(Qt::ArrowCursor);
+
+        if (m_ctrlPressed && m_altPressed) {
+            break;
+        }
+
+        if (m_mouseLeftPressed) {
+            m_mouseLeftPressed = false;
+
+            if (m_roomSelectionMove.has_value()) {
+                const auto pos = m_roomSelectionMove->pos;
+                const bool wrongPlace = m_roomSelectionMove->wrongPlace;
+                m_roomSelectionMove.reset();
+                if (!wrongPlace && (m_roomSelection != nullptr)) {
+                    const Coordinate moverel{pos, 0};
+                    m_data.applySingleChange(Change{
+                        room_change_types::MoveRelative2{m_roomSelection->getRoomIds(), moverel}});
+                }
+
+            } else {
+                if (hasSel1() && hasSel2()) {
+                    const Coordinate &c1 = getSel1().getCoordinate();
+                    const Coordinate &c2 = getSel2().getCoordinate();
+                    if (m_roomSelection == nullptr) {
+                        // add rooms to default selections
+                        m_roomSelection = RoomSelection::createSelection(
+                            m_data.findAllRooms(c1, c2));
+                    } else {
+                        auto &sel = deref(m_roomSelection);
+                        sel.removeMissing(m_data);
+                        // add or remove rooms to/from default selection
+                        const auto tmpSel = m_data.findAllRooms(c1, c2);
+                        for (const RoomId key : tmpSel) {
+                            if (sel.contains(key)) {
+                                sel.erase(key);
+                            } else {
+                                sel.insert(key);
+                            }
+                        }
+                    }
+                }
+
+                if (m_roomSelection != nullptr && !m_roomSelection->empty()) {
+                    slot_setRoomSelection(SigRoomSelection{m_roomSelection});
+                }
+            }
+            m_selectedArea = false;
+        }
+        m_canvas->selectionChanged();
+        break;
+
+    case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
+    case CanvasMouseModeEnum::CREATE_CONNECTIONS:
+        if (m_mouseLeftPressed && hasSel1() && hasSel2()) {
+            m_mouseLeftPressed = false;
+
+            if (m_connectionSelection == nullptr) {
+                m_connectionSelection = ConnectionSelection::alloc(m_data, getSel1());
+            }
+            m_connectionSelection->setSecond(getSel2());
+
+            if (!m_connectionSelection->isValid()) {
+                m_connectionSelection = nullptr;
+            } else {
+                const auto first = m_connectionSelection->getFirst();
+                const auto second = m_connectionSelection->getSecond();
+                const auto &r1 = first.room;
+                const auto &r2 = second.room;
+
+                if (r1.exists() && r2.exists()) {
+                    const ExitDirEnum dir1 = first.direction;
+                    const ExitDirEnum dir2 = second.direction;
+
+                    const RoomId id1 = r1.getId();
+                    const RoomId id2 = r2.getId();
+
+                    const bool isCompleteNew = m_connectionSelection->isCompleteNew();
+                    m_connectionSelection = nullptr;
+
+                    if (isCompleteNew) {
+                        const WaysEnum ways = (m_canvasMouseMode
+                                               != CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS)
+                                                  ? WaysEnum::TwoWay
+                                                  : WaysEnum::OneWay;
+                        const exit_change_types::ModifyExitConnection change{ChangeTypeEnum::Add,
+                                                                             id1,
+                                                                             dir1,
+                                                                             id2,
+                                                                             ways};
+                        m_data.applySingleChange(Change{change});
+                    }
+                    m_connectionSelection = ConnectionSelection::alloc(m_data);
+                    m_connectionSelection->setFirst(id1, dir1);
+                    m_connectionSelection->setSecond(id2, dir2);
+                    m_canvas->slot_mapChanged();
+                }
+            }
+
+            slot_setConnectionSelection(m_connectionSelection);
+        }
+        m_canvas->selectionChanged();
+        break;
+
+    case CanvasMouseModeEnum::SELECT_CONNECTIONS:
+        if (m_mouseLeftPressed && (m_connectionSelection != nullptr || hasSel1()) && hasSel2()) {
+            m_mouseLeftPressed = false;
+
+            if (m_connectionSelection == nullptr && hasSel1()) {
+                m_connectionSelection = ConnectionSelection::alloc(m_data, getSel1());
+            }
+            m_connectionSelection->setSecond(getSel2());
+
+            if (!m_connectionSelection->isValid() || !m_connectionSelection->isCompleteExisting()) {
+                m_connectionSelection = nullptr;
+            }
+            slot_setConnectionSelection(m_connectionSelection);
+        }
+        m_canvas->selectionChanged();
+        break;
+
+    case CanvasMouseModeEnum::CREATE_ROOMS:
+        if (m_mouseLeftPressed) {
+            m_mouseLeftPressed = false;
+        }
+        break;
+
+    case CanvasMouseModeEnum::NONE:
+    default:
+        break;
+    }
+
+    m_altPressed = false;
+    m_ctrlPressed = false;
+}
+
+void MapWindow::handleMouseMove(QMouseEvent *const event)
+{
+    if (m_altDragState.has_value()) {
+        // The user released the Alt key mid-drag.
+        if (!((event->modifiers() & Qt::ALT) != 0u)) {
+            m_canvasContainer->setCursor(m_altDragState->originalCursor);
+            m_altDragState.reset();
+            return;
+        }
+
+        auto &conf = setConfig().canvas.advanced;
+        auto &dragState = m_altDragState.value();
+        bool angleChanged = false;
+
+        const auto pos = event->pos();
+        const auto delta = pos - dragState.lastPos;
+        dragState.lastPos = pos;
+
+        // Camera rotation sensitivity: 3 degree per pixel
+        constexpr float SENSITIVITY = 0.3f;
+
+        // Horizontal movement adjusts yaw (horizontalAngle)
+        const int dx = delta.x();
+        if (dx != 0) {
+            conf.horizontalAngle.set(conf.horizontalAngle.get()
+                                     + static_cast<int>(static_cast<float>(dx) * SENSITIVITY));
+            angleChanged = true;
+        }
+
+        // Vertical movement adjusts pitch (verticalAngle), if auto-tilt is off
+        if (!conf.autoTilt.get()) {
+            const int dy = delta.y();
+            if (dy != 0) {
+                // Negated to match intuitive up/down dragging
+                conf.verticalAngle.set(conf.verticalAngle.get()
+                                       + static_cast<int>(static_cast<float>(-dy) * SENSITIVITY));
+                angleChanged = true;
+            }
+        }
+
+        if (angleChanged) {
+            m_canvas->graphicsSettingsChanged();
+        }
+        event->accept();
+        return;
+    }
+
+    const bool hasLeftButton = (event->buttons() & Qt::LeftButton) != 0u;
+
+    if (m_canvasMouseMode != CanvasMouseModeEnum::MOVE) {
+        // NOTE: Y is opposite of what you might expect here.
+        const int vScroll = std::invoke([this, event]() -> int {
+            const int h = m_canvasContainer->height();
+            const int MARGIN = std::min(100, h / 4);
+            const auto y = event->position().y();
+            if (y < MARGIN) {
+                return MapCanvas::SCROLL_SCALE;
+            } else if (y > h - MARGIN) {
+                return -MapCanvas::SCROLL_SCALE;
+            } else {
+                return 0;
+            }
+        });
+        const int hScroll = std::invoke([this, event]() -> int {
+            const int w = m_canvasContainer->width();
+            const int MARGIN = std::min(100, w / 4);
+            const auto x = event->position().x();
+            if (x < MARGIN) {
+                return -MapCanvas::SCROLL_SCALE;
+            } else if (x > w - MARGIN) {
+                return MapCanvas::SCROLL_SCALE;
+            } else {
+                return 0;
+            }
+        });
+
+        emit sig_continuousScroll(hScroll, vScroll);
+        slot_continuousScroll(hScroll, vScroll);
+    }
+
+    m_sel2 = m_canvas->getUnprojectedMouseSel(event);
+
+    switch (m_canvasMouseMode) {
+    case CanvasMouseModeEnum::SELECT_INFOMARKS:
+        if (hasLeftButton && hasSel1() && hasSel2()) {
+            if (hasInfomarkSelectionMove()) {
+                m_infoMarkSelectionMove->pos = getSel2().pos - getSel1().pos;
+                m_canvasContainer->setCursor(Qt::ClosedHandCursor);
+
+            } else {
+                m_selectedArea = true;
+            }
+        }
+        m_canvas->selectionChanged();
+        break;
+    case CanvasMouseModeEnum::CREATE_INFOMARKS:
+        if (hasLeftButton) {
+            m_selectedArea = true;
+        }
+        m_canvas->infomarksChanged();
+        break;
+    case CanvasMouseModeEnum::MOVE:
+        if (hasLeftButton && m_mouseLeftPressed && hasSel2() && hasBackup()) {
+            const Coordinate2i delta
+                = ((getSel2().pos - getBackup().pos) * static_cast<float>(MapCanvas::SCROLL_SCALE))
+                      .truncate();
+            if (delta.x != 0 || delta.y != 0) {
+                // negated because dragging to right is scrolling to the left.
+                emit sig_mapMove(-delta.x, -delta.y);
+                slot_mapMove(-delta.x, -delta.y);
+            }
+        }
+        break;
+
+    case CanvasMouseModeEnum::RAYPICK_ROOMS:
+        break;
+
+    case CanvasMouseModeEnum::SELECT_ROOMS:
+        if (hasLeftButton) {
+            if (hasRoomSelectionMove() && hasSel1() && hasSel2()) {
+                auto &map = this->m_data;
+                auto isMovable = [&map](RoomSelection &sel, const Coordinate &offset) -> bool {
+                    sel.removeMissing(map);
+                    return map.getCurrentMap().wouldAllowRelativeMove(sel.getRoomIds(), offset);
+                };
+
+                const auto diff = getSel2().pos.truncate() - getSel1().pos.truncate();
+                const auto wrongPlace = !isMovable(deref(m_roomSelection), Coordinate{diff, 0});
+                m_roomSelectionMove->pos = diff;
+                m_roomSelectionMove->wrongPlace = wrongPlace;
+
+                m_canvasContainer->setCursor(wrongPlace ? Qt::ForbiddenCursor : Qt::ClosedHandCursor);
+            } else {
+                m_selectedArea = true;
+            }
+        }
+        m_canvas->selectionChanged();
+        break;
+
+    case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
+    case CanvasMouseModeEnum::CREATE_CONNECTIONS:
+        if (hasLeftButton && hasSel2()) {
+            if (m_connectionSelection != nullptr) {
+                m_connectionSelection->setSecond(getSel2());
+
+                if (m_connectionSelection->isValid() && !m_connectionSelection->isCompleteNew()) {
+                    m_connectionSelection->removeSecond();
+                }
+
+                m_canvas->selectionChanged();
+            }
+        } else {
+            m_canvas->slot_requestUpdate();
+        }
+        break;
+
+    case CanvasMouseModeEnum::SELECT_CONNECTIONS:
+        if (hasLeftButton && hasSel2()) {
+            if (m_connectionSelection != nullptr) {
+                m_connectionSelection->setSecond(getSel2());
+
+                if (!m_connectionSelection->isCompleteExisting()) {
+                    m_connectionSelection->removeSecond();
+                }
+
+                m_canvas->selectionChanged();
+            }
+        }
+        break;
+
+    case CanvasMouseModeEnum::CREATE_ROOMS:
+    case CanvasMouseModeEnum::NONE:
+    default:
+        break;
+    }
+}
+
+void MapWindow::handleWheel(QWheelEvent *const event)
+{
+    const bool hasCtrl = (event->modifiers() & Qt::CTRL) != 0u;
+
+    switch (m_canvasMouseMode) {
+    case CanvasMouseModeEnum::MOVE:
+    case CanvasMouseModeEnum::SELECT_INFOMARKS:
+    case CanvasMouseModeEnum::CREATE_INFOMARKS:
+    case CanvasMouseModeEnum::RAYPICK_ROOMS:
+    case CanvasMouseModeEnum::SELECT_ROOMS:
+    case CanvasMouseModeEnum::SELECT_CONNECTIONS:
+    case CanvasMouseModeEnum::CREATE_ROOMS:
+    case CanvasMouseModeEnum::CREATE_CONNECTIONS:
+    case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
+        if (hasCtrl) {
+            if (event->angleDelta().y() > 100) {
+                m_canvas->slot_layerDown();
+            } else if (event->angleDelta().y() < -100) {
+                m_canvas->slot_layerUp();
+            }
+        } else {
+            const auto zoomAndMaybeRecenter = [this, event](const int numSteps) -> bool {
+                assert(numSteps != 0);
+                const auto optCenter = m_canvas->getUnprojectedMouseSel(event);
+
+                if (!optCenter) {
+                    m_canvas->m_scaleFactor.logStep(numSteps);
+                    return false;
+                }
+
+                const auto newCenter = optCenter->to_vec3();
+                const auto oldCenter = m_canvas->getMapScreen().getCenter();
+
+                const auto delta1 = glm::ivec2(glm::vec2(newCenter - oldCenter)
+                                               * static_cast<float>(MapCanvas::SCROLL_SCALE));
+
+                emit sig_mapMove(delta1.x, delta1.y);
+                slot_mapMove(delta1.x, delta1.y);
+
+                m_canvas->m_scaleFactor.logStep(numSteps);
+
+                m_canvas->setViewportAndMvp(m_canvas->width(), m_canvas->height());
+
+                if (const auto &optCenter2 = m_canvas->getUnprojectedMouseSel(event)) {
+                    const auto delta2 = glm::ivec2(glm::vec2(optCenter2->to_vec3() - newCenter)
+                                                   * static_cast<float>(MapCanvas::SCROLL_SCALE));
+
+                    emit sig_mapMove(-delta2.x, -delta2.y);
+                    slot_mapMove(-delta2.x, -delta2.y);
+                }
+
+                return true;
+            };
+
+            const int numSteps = event->angleDelta().y() / 120;
+            if (numSteps != 0) {
+                zoomAndMaybeRecenter(numSteps);
+                zoomChanged();
+                m_canvas->update();
+            }
+        }
+        break;
+
+    case CanvasMouseModeEnum::NONE:
+    default:
+        break;
+    }
+
+    event->accept();
+}
+
+void MapWindow::handleGesture(QGestureEvent *const event)
+{
+    // Zoom in / out
+    QGesture *const gesture = event->gesture(Qt::PinchGesture);
+    const auto *const pinch = dynamic_cast<QPinchGesture *>(gesture);
+    if (pinch == nullptr) {
+        return;
+    }
+
+    const QPinchGesture::ChangeFlags changeFlags = pinch->changeFlags();
+    if (changeFlags & QPinchGesture::ScaleFactorChanged) {
+        const auto pinchFactor = static_cast<float>(pinch->totalScaleFactor());
+        m_canvas->m_scaleFactor.setPinch(pinchFactor);
+    }
+    if (pinch->state() == Qt::GestureFinished) {
+        m_canvas->m_scaleFactor.endPinch();
+        zoomChanged();
+    }
+    m_canvas->update();
+    event->accept();
+}
+
+
+void MapWindow::slot_createRoom()
+{
+    if (!hasSel1()) {
+        return;
+    }
+
+    const Coordinate c = getSel1().getCoordinate();
+    if (const auto &existing = m_data.findRoomHandle(c)) {
+        return;
+    }
+
+    if (m_data.createEmptyRoom(Coordinate{c.x, c.y, m_canvas->m_currentLayer})) {
+        // success
+    } else {
+        // failed!
+    }
+}
+
+void MapWindow::slot_setCanvasMouseMode(const CanvasMouseModeEnum mode)
+{
+    m_canvas->slot_clearAllSelections();
+
+    switch (mode) {
+    case CanvasMouseModeEnum::MOVE:
+        m_canvasContainer->setCursor(Qt::OpenHandCursor);
+        break;
+
+    default:
+    case CanvasMouseModeEnum::NONE:
+    case CanvasMouseModeEnum::RAYPICK_ROOMS:
+    case CanvasMouseModeEnum::SELECT_CONNECTIONS:
+    case CanvasMouseModeEnum::CREATE_INFOMARKS:
+        m_canvasContainer->setCursor(Qt::CrossCursor);
+        break;
+
+    case CanvasMouseModeEnum::SELECT_ROOMS:
+    case CanvasMouseModeEnum::CREATE_ROOMS:
+    case CanvasMouseModeEnum::CREATE_CONNECTIONS:
+    case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
+    case CanvasMouseModeEnum::SELECT_INFOMARKS:
+        m_canvasContainer->setCursor(Qt::ArrowCursor);
+        break;
+    }
+
+    m_canvasMouseMode = mode;
+    m_selectedArea = false;
+    m_canvas->selectionChanged();
+}
+
+void MapWindow::slot_setRoomSelection(const SigRoomSelection &selection)
+{
+    m_canvas->slot_setRoomSelection(selection);
+}
+
+void MapWindow::slot_setConnectionSelection(const std::shared_ptr<ConnectionSelection> &selection)
+{
+    m_canvas->slot_setConnectionSelection(selection);
+}
+
+void MapWindow::slot_setInfomarkSelection(const std::shared_ptr<InfomarkSelection> &selection)
+{
+    m_canvas->slot_setInfomarkSelection(selection);
+}
+
+void MapWindow::zoomChanged()
+{
+    emit sig_zoomChanged(m_canvas->getRawZoom());
 }

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -27,6 +27,11 @@
 #include <QToolTip>
 #include <QWheelEvent>
 
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#undef near // Bad dog, Microsoft; bad dog!!!
+#undef far  // Bad dog, Microsoft; bad dog!!!
+#endif
+
 class QResizeEvent;
 
 MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QWidget *const parent)
@@ -448,7 +453,7 @@ void MapWindow::handleMousePress(QMouseEvent *const event)
                 assert(isClamped(t, 0.f, 1.f));
                 const auto pos = glm::mix(nearPos, farPos, t);
                 assert(static_cast<int>(std::lround(pos.z)) == z);
-                const Coordinate c2 = MouseSel{Coordinate2f{pos.x, pos.y}, z}.getCoordinate();
+                const Coordinate c2 = MouseSel(Coordinate2f(pos.x, pos.y), z).getCoordinate();
                 if (const auto r = m_data.findRoomHandle(c2)) {
                     tmpSel.insert(r.getId());
                 }

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -373,8 +373,8 @@ void MapWindow::handleMousePress(QMouseEvent *const event)
 {
     const bool hasLeftButton = (event->buttons() & Qt::LeftButton) != 0u;
     const bool hasRightButton = (event->buttons() & Qt::RightButton) != 0u;
-    const bool hasCtrl = (event->modifiers() & Qt::CTRL) != 0u;
-    const bool hasAlt = (event->modifiers() & Qt::ALT) != 0u;
+    const bool hasCtrl = (event->modifiers() & Qt::ControlModifier) != 0u;
+    const bool hasAlt = (event->modifiers() & Qt::AltModifier) != 0u;
 
     if (hasLeftButton && hasAlt) {
         m_altDragState.emplace(AltDragState{event->pos(), m_canvasContainer->cursor()});
@@ -771,7 +771,7 @@ void MapWindow::handleMouseMove(QMouseEvent *const event)
 {
     if (m_altDragState.has_value()) {
         // The user released the Alt key mid-drag.
-        if (!((event->modifiers() & Qt::ALT) != 0u)) {
+        if (!((event->modifiers() & Qt::AltModifier) != 0u)) {
             m_canvasContainer->setCursor(m_altDragState->originalCursor);
             m_altDragState.reset();
             return;
@@ -947,7 +947,7 @@ void MapWindow::handleMouseMove(QMouseEvent *const event)
 
 void MapWindow::handleWheel(QWheelEvent *const event)
 {
-    const bool hasCtrl = (event->modifiers() & Qt::CTRL) != 0u;
+    const bool hasCtrl = (event->modifiers() & Qt::ControlModifier) != 0u;
 
     switch (m_canvasMouseMode) {
     case CanvasMouseModeEnum::MOVE:

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -95,6 +95,7 @@ private:
     NODISCARD std::shared_ptr<InfomarkSelection> getInfomarkSelection(const MouseSel &sel);
 
 public:
+    void setMouseTracking(bool enable);
     void updateScrollBars();
     void setZoom(float zoom);
     NODISCARD float getZoom() const;
@@ -140,16 +141,10 @@ public slots:
     void slot_setConnectionSelection(const std::shared_ptr<ConnectionSelection> &);
     void slot_setInfomarkSelection(const std::shared_ptr<InfomarkSelection> &);
 
-    void slot_clearRoomSelection() { slot_setRoomSelection(SigRoomSelection{}); }
-    void slot_clearConnectionSelection() { slot_setConnectionSelection(nullptr); }
-    void slot_clearInfomarkSelection() { slot_setInfomarkSelection(nullptr); }
-
-    void slot_clearAllSelections()
-    {
-        slot_clearRoomSelection();
-        slot_clearConnectionSelection();
-        slot_clearInfomarkSelection();
-    }
+    void slot_clearRoomSelection();
+    void slot_clearConnectionSelection();
+    void slot_clearInfomarkSelection();
+    void slot_clearAllSelections();
 
     void slot_createRoom();
 };

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -6,10 +6,12 @@
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
 #include "../map/coordinate.h"
+#include "MapCanvasData.h"
 #include "mapcanvas.h"
 
 #include <memory>
 
+#include <QGestureEvent>
 #include <QLabel>
 #include <QPixmap>
 #include <QPoint>
@@ -31,7 +33,7 @@ class QResizeEvent;
 class QScrollBar;
 class QTimer;
 
-class NODISCARD_QOBJECT MapWindow final : public QWidget
+class NODISCARD_QOBJECT MapWindow final : public QWidget, public MapCanvasInputState
 {
     Q_OBJECT
 
@@ -43,8 +45,18 @@ protected:
     std::unique_ptr<QGridLayout> m_gridLayout;
     std::unique_ptr<QScrollBar> m_horizontalScrollBar;
     std::unique_ptr<QScrollBar> m_verticalScrollBar;
-    std::unique_ptr<MapCanvas> m_canvas;
+    MapCanvas *m_canvas = nullptr;
+    QWidget *m_canvasContainer = nullptr;
     std::unique_ptr<QLabel> m_splashLabel;
+
+    struct AltDragState
+    {
+        QPoint lastPos;
+        QCursor originalCursor;
+    };
+    std::optional<AltDragState> m_altDragState;
+
+    MapData &m_data;
 
 private:
     struct NODISCARD KnownMapSize final
@@ -68,7 +80,19 @@ public:
     void keyReleaseEvent(QKeyEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
 
-    NODISCARD MapCanvas *getCanvas() const;
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+    NODISCARD MapCanvas *getMapCanvas() const;
+    NODISCARD QWidget *getCanvas() const { return m_canvasContainer; }
+
+private:
+    void handleMousePress(QMouseEvent *event);
+    void handleMouseRelease(QMouseEvent *event);
+    void handleMouseMove(QMouseEvent *event);
+    void handleWheel(QWheelEvent *event);
+    void handleGesture(QGestureEvent *event);
+
+    NODISCARD std::shared_ptr<InfomarkSelection> getInfomarkSelection(const MouseSel &sel);
 
 public:
     void updateScrollBars();
@@ -79,9 +103,27 @@ public:
 private:
     void centerOnScrollPos(const glm::ivec2 &scrollPos);
 
+public:
+    void zoomChanged();
+
 signals:
+    void sig_onCenter(const glm::vec2 &worldCoord);
+    void sig_mapMove(int dx, int dy);
+    void sig_setScrollBars(const Coordinate &min, const Coordinate &max);
+    void sig_continuousScroll(int, int);
+
+    void sig_log(const QString &, const QString &);
+
+    void sig_selectionChanged();
+    void sig_newRoomSelection(const SigRoomSelection &);
+    void sig_newConnectionSelection(ConnectionSelection *);
+    void sig_newInfomarkSelection(InfomarkSelection *);
+
+    void sig_setCurrentRoom(RoomId id, bool update);
+    void sig_zoomChanged(float);
+
     void sig_setScroll(const glm::vec2 &worldPos);
-    void sig_zoomChanged(float zoom);
+    void sig_customContextMenuRequested(const QPoint &pos);
 
 public slots:
     void slot_setScrollBars(const Coordinate &, const Coordinate &);
@@ -91,4 +133,23 @@ public slots:
     void slot_scrollTimerTimeout();
     void slot_graphicsSettingsChanged();
     void slot_zoomChanged(const float zoom) { emit sig_zoomChanged(zoom); }
+
+    void slot_setCanvasMouseMode(CanvasMouseModeEnum mode);
+
+    void slot_setRoomSelection(const SigRoomSelection &);
+    void slot_setConnectionSelection(const std::shared_ptr<ConnectionSelection> &);
+    void slot_setInfomarkSelection(const std::shared_ptr<InfomarkSelection> &);
+
+    void slot_clearRoomSelection() { slot_setRoomSelection(SigRoomSelection{}); }
+    void slot_clearConnectionSelection() { slot_setConnectionSelection(nullptr); }
+    void slot_clearInfomarkSelection() { slot_setInfomarkSelection(nullptr); }
+
+    void slot_clearAllSelections()
+    {
+        slot_clearRoomSelection();
+        slot_clearConnectionSelection();
+        slot_clearInfomarkSelection();
+    }
+
+    void slot_createRoom();
 };

--- a/src/mainwindow/mainwindow-async.cpp
+++ b/src/mainwindow/mainwindow-async.cpp
@@ -774,7 +774,7 @@ void MainWindow::slot_merge()
             auto pStorage = getLoadOrMergeMapStorage(pc, source);
             connect(pStorage.get(), &AbstractMapStorage::sig_log, this, &MainWindow::slot_log);
 
-            getCanvas()->slot_clearAllSelections();
+            getMapCanvas()->slot_clearAllSelections();
             m_asyncTask.begin(std::make_unique<AsyncMerge>(std::move(pc),
                                                            *this,
                                                            source->getFileName(),

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -398,7 +398,10 @@ void MainWindow::wireConnections()
             &PathMachine::slot_releaseAllPaths);
 
     MapCanvas *const canvas = getMapCanvas();
-    connect(m_mapData, &MapFrontend::sig_clearingMap, m_mapWindow, &MapWindow::slot_clearAllSelections);
+    connect(m_mapData,
+            &MapFrontend::sig_clearingMap,
+            m_mapWindow,
+            &MapWindow::slot_clearAllSelections);
 
     connect(m_pathMachine,
             &Mmapper2PathMachine::sig_playerMoved,
@@ -466,7 +469,10 @@ void MainWindow::wireConnections()
             &MapWindow::sig_newInfomarkSelection,
             this,
             &MainWindow::slot_newInfomarkSelection);
-    connect(m_mapWindow, &MapWindow::sig_customContextMenuRequested, this, &MainWindow::slot_showContextMenu);
+    connect(m_mapWindow,
+            &MapWindow::sig_customContextMenuRequested,
+            this,
+            &MainWindow::slot_showContextMenu);
 
     // Group
     connect(m_groupManager, &Mmapper2Group::sig_log, this, &MainWindow::slot_log);

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1319,7 +1319,7 @@ void MainWindow::slot_setShowMenuBar()
     m_dockDialogGroup->setMouseTracking(!showMenuBar);
     m_dockDialogLog->setMouseTracking(!showMenuBar);
     m_dockDialogRoom->setMouseTracking(!showMenuBar);
-    m_mapWindow->getCanvas()->setMouseTracking(!showMenuBar);
+    m_mapWindow->setMouseTracking(!showMenuBar);
 
     if (showMenuBar) {
         menuBar()->show();

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -292,8 +292,7 @@ MainWindow::MainWindow()
     showScrollBarsAct->setChecked(getConfig().general.showScrollBars);
     slot_setShowScrollBars();
 
-    if constexpr (CURRENT_PLATFORM == PlatformEnum::Mac) {
-    } else {
+    if constexpr (CURRENT_PLATFORM != PlatformEnum::Mac) {
         showMenuBarAct->setChecked(getConfig().general.showMenuBar);
         slot_setShowMenuBar();
     }
@@ -2073,6 +2072,11 @@ void MainWindow::keyReleaseEvent(QKeyEvent *event)
 MapCanvas *MainWindow::getMapCanvas() const
 {
     return m_mapWindow->getMapCanvas();
+}
+
+QWidget *MainWindow::getCanvas() const
+{
+    return static_cast<QWidget *>(m_mapWindow);
 }
 
 void MainWindow::mapChanged() const

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -367,7 +367,7 @@ private:
     NODISCARD ProgressDialogLifetime createNewProgressDialog(const QString &text, bool allow_cancel);
     void endProgressDialog();
     NODISCARD MapCanvas *getMapCanvas() const;
-    NODISCARD QWidget *getCanvas() const { return (QWidget *) m_mapWindow; }
+    NODISCARD QWidget *getCanvas() const { return static_cast<QWidget *>(m_mapWindow); }
     void mapChanged() const;
     void setCanvasMouseMode(CanvasMouseModeEnum mode);
     void setMapModified(bool);

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -367,7 +367,7 @@ private:
     NODISCARD ProgressDialogLifetime createNewProgressDialog(const QString &text, bool allow_cancel);
     void endProgressDialog();
     NODISCARD MapCanvas *getMapCanvas() const;
-    NODISCARD QWidget *getCanvas() const { return static_cast<QWidget *>(m_mapWindow); }
+    NODISCARD QWidget *getCanvas() const;
     void mapChanged() const;
     void setCanvasMouseMode(CanvasMouseModeEnum mode);
     void setMapModified(bool);

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -366,7 +366,8 @@ private:
     };
     NODISCARD ProgressDialogLifetime createNewProgressDialog(const QString &text, bool allow_cancel);
     void endProgressDialog();
-    NODISCARD MapCanvas *getCanvas() const;
+    NODISCARD MapCanvas *getMapCanvas() const;
+    NODISCARD QWidget *getCanvas() const { return (QWidget *)m_mapWindow; }
     void mapChanged() const;
     void setCanvasMouseMode(CanvasMouseModeEnum mode);
     void setMapModified(bool);

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -367,7 +367,7 @@ private:
     NODISCARD ProgressDialogLifetime createNewProgressDialog(const QString &text, bool allow_cancel);
     void endProgressDialog();
     NODISCARD MapCanvas *getMapCanvas() const;
-    NODISCARD QWidget *getCanvas() const { return (QWidget *)m_mapWindow; }
+    NODISCARD QWidget *getCanvas() const { return (QWidget *) m_mapWindow; }
     void mapChanged() const;
     void setCanvasMouseMode(CanvasMouseModeEnum mode);
     void setMapModified(bool);


### PR DESCRIPTION
This task involved a major architectural refactoring of the map display component. By migrating from `QOpenGLWidget` to `QOpenGLWindow`, we decouple the core OpenGL rendering logic from the widget system, which is a modern Qt design pattern. 

Key improvements:
- **Decoupling**: `MapCanvas` now focuses solely on rendering, while `MapWindow` handles user interaction and integration with the QWidget-based UI.
- **State Management**: Shared rendering and input state is explicitly managed via helper classes, improving maintainability.
- **Ownership**: Resolved a critical ownership issue where `QWidget::createWindowContainer` and `std::unique_ptr` would compete for the window's lifecycle.
- **Signal Flow**: Updated the application to route map-related events through `MapWindow`, providing a cleaner interface for `MainWindow`.
- **DPI Support**: Maintained robust support for High-DPI screens by ensuring correct scaling within the OpenGL pipeline.

---
*PR created automatically by Jules for task [14050028203067024947](https://jules.google.com/task/14050028203067024947) started by @nschimme*