### PR TITLE
Migrate MapCanvas to QOpenGLWindow with Smooth Dragging

### DIFF
--- a/src/display/MapCanvasData.cpp
+++ b/src/display/MapCanvasData.cpp
@@ -11,7 +11,9 @@
 
 #include <glm/gtc/epsilon.hpp>
 
+#include <QNativeGestureEvent>
 #include <QPointF>
+#include <QTouchEvent>
 
 const MMapper::Array<RoomTintEnum, NUM_ROOM_TINTS> &getAllRoomTints()
 {
@@ -58,6 +60,12 @@ std::optional<glm::vec3> MapCanvasViewport::project(const glm::vec3 &v) const
 // output: world coordinates.
 glm::vec3 MapCanvasViewport::unproject_raw(const glm::vec3 &mouse_depth) const
 {
+    return unproject_raw(mouse_depth, m_viewProj);
+}
+
+glm::vec3 MapCanvasViewport::unproject_raw(const glm::vec3 &mouse_depth,
+                                           const glm::mat4 &viewProj) const
+{
     const float depth = mouse_depth.z;
     assert(::isClamped(depth, 0.f, 1.f));
 
@@ -67,7 +75,7 @@ glm::vec3 MapCanvasViewport::unproject_raw(const glm::vec3 &mouse_depth) const
     const glm::vec3 screen{screen2d, depth};
     const auto ndc = screen * 2.f - 1.f;
 
-    const auto tmp = glm::inverse(m_viewProj) * glm::vec4(ndc, 1.f);
+    const auto tmp = glm::inverse(viewProj) * glm::vec4(ndc, 1.f);
     // clamp to avoid division by zero
     constexpr float limit = 1e-6f;
     const auto w = (std::abs(tmp.w) < limit) ? std::copysign(limit, tmp.w) : tmp.w;
@@ -80,11 +88,17 @@ glm::vec3 MapCanvasViewport::unproject_raw(const glm::vec3 &mouse_depth) const
 // because it could be
 glm::vec3 MapCanvasViewport::unproject_clamped(const glm::vec2 &mouse) const
 {
+    return unproject_clamped(mouse, m_viewProj);
+}
+
+glm::vec3 MapCanvasViewport::unproject_clamped(const glm::vec2 &mouse,
+                                               const glm::mat4 &viewProj) const
+{
     const auto flayer = static_cast<float>(m_currentLayer);
     const auto &x = mouse.x;
     const auto &y = mouse.y;
-    const auto a = unproject_raw(glm::vec3{x, y, 0.f}); // near
-    const auto b = unproject_raw(glm::vec3{x, y, 1.f}); // far
+    const auto a = unproject_raw(glm::vec3{x, y, 0.f}, viewProj); // near
+    const auto b = unproject_raw(glm::vec3{x, y, 1.f}, viewProj); // far
     const float t = (flayer - a.z) / (b.z - a.z);
     const auto result = glm::mix(a, b, std::clamp(t, 0.f, 1.f));
     return glm::vec3{glm::vec2{result}, flayer};
@@ -93,12 +107,29 @@ glm::vec3 MapCanvasViewport::unproject_clamped(const glm::vec2 &mouse) const
 glm::vec2 MapCanvasViewport::getMouseCoords(const QInputEvent *const event) const
 {
     if (const auto *const mouse = dynamic_cast<const QMouseEvent *>(event)) {
-        const auto x = static_cast<float>(mouse->pos().x());
-        const auto y = static_cast<float>(height() - mouse->pos().y());
+        const auto x = static_cast<float>(mouse->position().x());
+        const auto y = static_cast<float>(height() - mouse->position().y());
         return glm::vec2{x, y};
     } else if (const auto *const wheel = dynamic_cast<const QWheelEvent *>(event)) {
         const auto x = static_cast<float>(wheel->position().x());
         const auto y = static_cast<float>(height() - wheel->position().y());
+        return glm::vec2{x, y};
+    } else if (const auto *const gesture = dynamic_cast<const QNativeGestureEvent *>(event)) {
+        const auto x = static_cast<float>(gesture->position().x());
+        const auto y = static_cast<float>(height() - gesture->position().y());
+        return glm::vec2{x, y};
+    } else if (const auto *const touch = dynamic_cast<const QTouchEvent *>(event)) {
+        const auto &points = touch->points();
+        if (points.isEmpty()) {
+            throw std::invalid_argument("no touch points");
+        }
+        QPointF centroid(0, 0);
+        for (const auto &p : points) {
+            centroid += p.position();
+        }
+        centroid /= static_cast<qreal>(points.size());
+        const auto x = static_cast<float>(centroid.x());
+        const auto y = static_cast<float>(height() - centroid.y());
         return glm::vec2{x, y};
     } else {
         throw std::invalid_argument("event");
@@ -109,7 +140,16 @@ glm::vec2 MapCanvasViewport::getMouseCoords(const QInputEvent *const event) cons
 // output is the world space intersection with the current layer
 std::optional<glm::vec3> MapCanvasViewport::unproject(const QInputEvent *const event) const
 {
-    const auto xy = getMouseCoords(event);
+    try {
+        const auto xy = getMouseCoords(event);
+        return unproject(xy);
+    } catch (const std::invalid_argument &) {
+        return std::nullopt;
+    }
+}
+
+std::optional<glm::vec3> MapCanvasViewport::unproject(const glm::vec2 &xy) const
+{
     // We don't actually know the depth we're trying to unproject;
     // technically we're solving for a ray, so we should unproject
     // two different depths and find where the ray intersects the

--- a/src/display/MapCanvasData.cpp
+++ b/src/display/MapCanvasData.cpp
@@ -170,7 +170,17 @@ std::optional<glm::vec3> MapCanvasViewport::unproject(const glm::vec2 &xy) const
 
 std::optional<MouseSel> MapCanvasViewport::getUnprojectedMouseSel(const QInputEvent *const event) const
 {
-    const auto opt_v = unproject(event);
+    try {
+        const auto xy = getMouseCoords(event);
+        return getUnprojectedMouseSel(xy);
+    } catch (const std::invalid_argument &) {
+        return std::nullopt;
+    }
+}
+
+std::optional<MouseSel> MapCanvasViewport::getUnprojectedMouseSel(const glm::vec2 &xy) const
+{
+    const auto opt_v = unproject(xy);
     if (!opt_v.has_value()) {
         return std::nullopt;
     }

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -48,8 +48,6 @@ public:
 
 private:
     float m_scaleFactor = 1.f;
-    // pinch gesture
-    float m_pinchFactor = 1.f;
 
 private:
     NODISCARD static float clamp(float x)
@@ -63,21 +61,10 @@ public:
 
 public:
     NODISCARD float getRaw() const { return clamp(m_scaleFactor); }
-    NODISCARD float getTotal() const { return clamp(m_scaleFactor * m_pinchFactor); }
+    NODISCARD float getTotal() const { return clamp(m_scaleFactor); }
 
 public:
     void set(const float scale) { m_scaleFactor = clamp(scale); }
-    void setPinch(const float pinch)
-    {
-        // Don't bother to clamp this, since the total is clamped.
-        m_pinchFactor = pinch;
-    }
-    void endPinch()
-    {
-        const float total = getTotal();
-        m_scaleFactor = total;
-        m_pinchFactor = 1.f;
-    }
     void reset() { *this = ScaleFactor(); }
 
 public:

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -20,7 +20,7 @@
 #include <unordered_map>
 
 #include <QOpenGLTexture>
-#include <QWidget>
+#include <QWindow>
 #include <QtGui/QMatrix4x4>
 #include <QtGui/QMouseEvent>
 #include <QtGui/qopengl.h>
@@ -100,7 +100,7 @@ public:
 struct NODISCARD MapCanvasViewport
 {
 private:
-    QWidget &m_sizeWidget;
+    QWindow &m_window;
 
 public:
     glm::mat4 m_viewProj{1.f};
@@ -109,25 +109,27 @@ public:
     int m_currentLayer = 0;
 
 public:
-    explicit MapCanvasViewport(QWidget &sizeWidget)
-        : m_sizeWidget{sizeWidget}
+    explicit MapCanvasViewport(QWindow &window)
+        : m_window{window}
     {}
 
 public:
-    NODISCARD auto width() const { return m_sizeWidget.width(); }
-    NODISCARD auto height() const { return m_sizeWidget.height(); }
+    NODISCARD auto width() const { return m_window.width(); }
+    NODISCARD auto height() const { return m_window.height(); }
     NODISCARD Viewport getViewport() const
     {
-        const auto &r = m_sizeWidget.rect();
-        return Viewport{glm::ivec2{r.x(), r.y()}, glm::ivec2{r.width(), r.height()}};
+        return Viewport{glm::ivec2{0, 0}, glm::ivec2{m_window.width(), m_window.height()}};
     }
     NODISCARD float getTotalScaleFactor() const { return m_scaleFactor.getTotal(); }
 
 public:
     NODISCARD std::optional<glm::vec3> project(const glm::vec3 &) const;
     NODISCARD glm::vec3 unproject_raw(const glm::vec3 &) const;
+    NODISCARD glm::vec3 unproject_raw(const glm::vec3 &, const glm::mat4 &) const;
     NODISCARD glm::vec3 unproject_clamped(const glm::vec2 &) const;
+    NODISCARD glm::vec3 unproject_clamped(const glm::vec2 &, const glm::mat4 &) const;
     NODISCARD std::optional<glm::vec3> unproject(const QInputEvent *event) const;
+    NODISCARD std::optional<glm::vec3> unproject(const glm::vec2 &xy) const;
     NODISCARD std::optional<MouseSel> getUnprojectedMouseSel(const QInputEvent *event) const;
     NODISCARD glm::vec2 getMouseCoords(const QInputEvent *event) const;
 };

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -118,6 +118,7 @@ public:
     NODISCARD std::optional<glm::vec3> unproject(const QInputEvent *event) const;
     NODISCARD std::optional<glm::vec3> unproject(const glm::vec2 &xy) const;
     NODISCARD std::optional<MouseSel> getUnprojectedMouseSel(const QInputEvent *event) const;
+    NODISCARD std::optional<MouseSel> getUnprojectedMouseSel(const glm::vec2 &xy) const;
     NODISCARD glm::vec2 getMouseCoords(const QInputEvent *event) const;
 };
 

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -1207,3 +1207,4 @@ void MapCanvas::userPressedEscape(bool /*pressed*/)
         break;
     }
 }
+// Trigger CI retry

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -297,17 +297,18 @@ void MapCanvas::touchEvent(QTouchEvent *const event)
         const auto &p1 = points[0];
         const auto &p2 = points[1];
 
-        const float currentDistance
-            = glm::distance(glm::vec2(static_cast<float>(p1.position().x()),
-                                      static_cast<float>(p1.position().y())),
-                            glm::vec2(static_cast<float>(p2.position().x()),
-                                      static_cast<float>(p2.position().y())));
+        const float currentDistance = glm::distance(glm::vec2(static_cast<float>(p1.position().x()),
+                                                              static_cast<float>(p1.position().y())),
+                                                    glm::vec2(static_cast<float>(p2.position().x()),
+                                                              static_cast<float>(
+                                                                  p2.position().y())));
 
         if (event->type() == QEvent::TouchBegin || p1.state() == QEventPoint::Pressed
             || p2.state() == QEventPoint::Pressed) {
             m_moveBackup = getUnprojectedMouseSel(event);
             if (hasBackup()) {
-                m_moveBackup->pos = Coordinate2f{currentDistance, 0.f}; // use pos.x for initial distance
+                m_moveBackup->pos = Coordinate2f{currentDistance,
+                                                 0.f}; // use pos.x for initial distance
             }
         }
 
@@ -1025,7 +1026,6 @@ void MapCanvas::mouseReleaseEvent(QMouseEvent *const event)
     m_altPressed = false;
     m_ctrlPressed = false;
 }
-
 
 void MapCanvas::startMoving(const MouseSel &startPos)
 {

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -160,6 +160,10 @@ private:
     };
     std::optional<DragState> m_dragState;
 
+    float m_initialPinchDistance = 0.f;
+    float m_lastPinchFactor = 1.f;
+    float m_lastMagnification = 1.f;
+
 public:
     explicit MapCanvas(MapData &mapData,
                        PrespammedPath &prespammedPath,
@@ -235,6 +239,8 @@ private:
                                            int currentLayer);
     void setMvp(const glm::mat4 &viewProj);
     void setViewportAndMvp(int width, int height);
+
+    void zoomAt(float factor, const glm::vec2 &mousePos);
 
     NODISCARD BatchedInfomarksMeshes getInfomarksMeshes();
     void drawInfomark(InfomarksBatch &batch,

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -30,7 +30,7 @@
 #include <QColor>
 #include <QMatrix4x4>
 #include <QOpenGLDebugMessage>
-#include <QOpenGLWidget>
+#include <QOpenGLWindow>
 #include <QtCore>
 
 class CharacterBatch;
@@ -47,7 +47,7 @@ class QWheelEvent;
 class QWidget;
 class RoomSelFakeGL;
 
-class NODISCARD_QOBJECT MapCanvas final : public QOpenGLWidget,
+class NODISCARD_QOBJECT MapCanvas final : public QOpenGLWindow,
                                           private MapCanvasViewport,
                                           private MapCanvasInputState
 {
@@ -152,11 +152,19 @@ private:
     };
     std::optional<AltDragState> m_altDragState;
 
+    struct DragState
+    {
+        glm::vec3 startWorldPos;
+        glm::vec2 startScroll;
+        glm::mat4 startViewProj;
+    };
+    std::optional<DragState> m_dragState;
+
 public:
     explicit MapCanvas(MapData &mapData,
                        PrespammedPath &prespammedPath,
                        Mmapper2Group &groupManager,
-                       QWidget *parent);
+                       QWindow *parent = nullptr);
     ~MapCanvas() final;
 
 public:
@@ -168,9 +176,6 @@ private:
     void cleanupOpenGL();
 
 public:
-    NODISCARD QSize minimumSizeHint() const override;
-    NODISCARD QSize sizeHint() const override;
-
     using MapCanvasViewport::getTotalScaleFactor;
     void setZoom(float zoom)
     {
@@ -180,12 +185,14 @@ public:
     NODISCARD float getRawZoom() const { return m_scaleFactor.getRaw(); }
 
 public:
-    NODISCARD auto width() const { return QOpenGLWidget::width(); }
-    NODISCARD auto height() const { return QOpenGLWidget::height(); }
-    NODISCARD auto rect() const { return QOpenGLWidget::rect(); }
+    NODISCARD auto width() const { return QOpenGLWindow::width(); }
+    NODISCARD auto height() const { return QOpenGLWindow::height(); }
+    NODISCARD QRect rect() const { return QRect(0, 0, width(), height()); }
 
 private:
     void onMovement();
+    void startMoving(const MouseSel &startPos);
+    void stopMoving();
 
 private:
     void reportGLVersion();
@@ -202,6 +209,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
+    void touchEvent(QTouchEvent *event) override;
     bool event(QEvent *e) override;
 
 private:
@@ -287,6 +295,9 @@ signals:
 
     void sig_setCurrentRoom(RoomId id, bool update);
     void sig_zoomChanged(float);
+
+    void sig_showTooltip(const QString &text, const QPoint &pos);
+    void sig_customContextMenuRequested(const QPoint &pos);
 
 public slots:
     void slot_onForcedPositionChange();

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -48,7 +48,7 @@
 
 #include <QMessageBox>
 #include <QMessageLogContext>
-#include <QOpenGLWidget>
+#include <QOpenGLWindow>
 #include <QtCore>
 #include <QtGui/qopengl.h>
 #include <QtGui>
@@ -96,15 +96,15 @@ void setShowPerfStats(const bool show)
 class NODISCARD MakeCurrentRaii final
 {
 private:
-    QOpenGLWidget &m_glWidget;
+    QOpenGLWindow &m_glWindow;
 
 public:
-    explicit MakeCurrentRaii(QOpenGLWidget &widget)
-        : m_glWidget{widget}
+    explicit MakeCurrentRaii(QOpenGLWindow &window)
+        : m_glWindow{window}
     {
-        m_glWidget.makeCurrent();
+        m_glWindow.makeCurrent();
     }
-    ~MakeCurrentRaii() { m_glWidget.doneCurrent(); }
+    ~MakeCurrentRaii() { m_glWindow.doneCurrent(); }
 
     DELETE_CTORS_AND_ASSIGN_OPS(MakeCurrentRaii);
 };
@@ -215,7 +215,7 @@ void MapCanvas::initializeGL()
     } catch (const std::exception &) {
         hide();
         doneCurrent();
-        QMessageBox::critical(this,
+        QMessageBox::critical(nullptr,
                               "Unable to initialize OpenGL",
                               "Upgrade your video card drivers");
         if constexpr (CURRENT_PLATFORM == PlatformEnum::Windows) {
@@ -859,7 +859,7 @@ void MapCanvas::paintGL()
     const auto &afterBatches = optAfterBatches.value();
     const auto afterPaint = Clock::now();
     const bool calledFinish = std::invoke([this]() -> bool {
-        if (auto *const ctxt = QOpenGLWidget::context()) {
+        if (auto *const ctxt = QOpenGLWindow::context()) {
             if (auto *const func = ctxt->functions()) {
                 func->glFinish();
                 return true;

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -45,7 +45,7 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
 
     m_gridLayout->addWidget(m_horizontalScrollBar, 1, 0, 1, 1);
 
-    m_canvas = mmqt::makeQPointer<MapCanvas>(mapData, pp, gm);
+    m_canvas = new MapCanvas(mapData, pp, gm);
     m_canvas->setMinimumSize(QSize(1280 / 4, 720 / 4));
     m_canvas->resize(QSize(1280, 720));
 

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -25,25 +25,25 @@ class QResizeEvent;
 MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QWidget *const parent)
     : QWidget(parent)
 {
-    m_gridLayout = std::make_unique<QGridLayout>(this);
+    m_gridLayout = mmqt::makeQPointer<QGridLayout>(this);
     m_gridLayout->setSpacing(0);
     m_gridLayout->setContentsMargins(0, 0, 0, 0);
 
-    m_verticalScrollBar = std::make_unique<QScrollBar>(this);
+    m_verticalScrollBar = mmqt::makeQPointer<QScrollBar>(this);
     m_verticalScrollBar->setOrientation(Qt::Vertical);
     m_verticalScrollBar->setRange(0, 0);
     m_verticalScrollBar->hide();
     m_verticalScrollBar->setSingleStep(MapCanvas::SCROLL_SCALE);
 
-    m_gridLayout->addWidget(m_verticalScrollBar.get(), 0, 1, 1, 1);
+    m_gridLayout->addWidget(m_verticalScrollBar, 0, 1, 1, 1);
 
-    m_horizontalScrollBar = std::make_unique<QScrollBar>(this);
+    m_horizontalScrollBar = mmqt::makeQPointer<QScrollBar>(this);
     m_horizontalScrollBar->setOrientation(Qt::Horizontal);
     m_horizontalScrollBar->setRange(0, 0);
     m_horizontalScrollBar->hide();
     m_horizontalScrollBar->setSingleStep(MapCanvas::SCROLL_SCALE);
 
-    m_gridLayout->addWidget(m_horizontalScrollBar.get(), 1, 0, 1, 1);
+    m_gridLayout->addWidget(m_horizontalScrollBar, 1, 0, 1, 1);
 
     m_canvas = new MapCanvas(mapData, pp, gm);
     m_canvas->setMinimumSize(QSize(1280 / 4, 720 / 4));
@@ -96,16 +96,16 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
     auto splashPixmap = createSplashPixmap(size(), devicePixelRatioF());
 
     // Now set pixmap with painted text
-    m_splashLabel = std::make_unique<QLabel>(this);
+    m_splashLabel = mmqt::makeQPointer<QLabel>(this);
     m_splashLabel->setPixmap(splashPixmap);
     m_splashLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     m_splashLabel->setGeometry(rect());
-    m_gridLayout->addWidget(m_splashLabel.get(), 0, 0, 1, 1, Qt::AlignCenter);
+    m_gridLayout->addWidget(m_splashLabel, 0, 0, 1, 1, Qt::AlignCenter);
     m_splashLabel->show();
 
     // from map window to canvas
     {
-        connect(m_horizontalScrollBar.get(),
+        connect(m_horizontalScrollBar,
                 &QScrollBar::valueChanged,
                 m_canvas,
                 [this](const int x) -> void {
@@ -113,7 +113,7 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
                     m_canvas->slot_setHorizontalScroll(val);
                 });
 
-        connect(m_verticalScrollBar.get(),
+        connect(m_verticalScrollBar,
                 &QScrollBar::valueChanged,
                 m_canvas,
                 [this](const int y) -> void {
@@ -139,7 +139,7 @@ void MapWindow::hideSplashImage()
 {
     if (m_splashLabel) {
         m_splashLabel->hide();
-        m_splashLabel.release();
+        m_splashLabel->deleteLater();
     }
 }
 
@@ -201,13 +201,13 @@ void MapWindow::slot_continuousScroll(const int hStep, const int input_vStep)
         if (scrollTimer->isActive()) {
             scrollTimer->stop();
         }
-        scrollTimer.reset();
+        delete scrollTimer;
     }
 
     // start
     if ((scrollTimer == nullptr) && (hStep != 0 || vStep != 0)) {
-        scrollTimer = std::make_unique<QTimer>(this);
-        connect(scrollTimer.get(), &QTimer::timeout, this, &MapWindow::slot_scrollTimerTimeout);
+        scrollTimer = mmqt::makeQPointer<QTimer>(this);
+        connect(scrollTimer, &QTimer::timeout, this, &MapWindow::slot_scrollTimerTimeout);
         scrollTimer->start(100);
     }
 }

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -7,6 +7,7 @@
 #include "mapwindow.h"
 
 #include "../display/Filenames.h"
+#include "../global/MakeQPointer.h"
 #include "../global/SignalBlocker.h"
 #include "../global/Version.h"
 #include "mapcanvas.h"
@@ -49,6 +50,9 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
     m_canvas->resize(QSize(1280, 720));
 
     m_canvasContainer = QWidget::createWindowContainer(m_canvas, this);
+    assert(m_canvasContainer);
+    assert(m_canvasContainer->parent() == this);
+
     m_gridLayout->addWidget(m_canvasContainer, 0, 0, 1, 1);
     setMinimumSize(m_canvas->minimumSize());
 

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -45,7 +45,7 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
 
     m_gridLayout->addWidget(m_horizontalScrollBar, 1, 0, 1, 1);
 
-    m_canvas = new MapCanvas(mapData, pp, gm);
+    m_canvas = mmqt::makeQPointer<MapCanvas>(mapData, pp, gm);
     m_canvas->setMinimumSize(QSize(1280 / 4, 720 / 4));
     m_canvas->resize(QSize(1280, 720));
 
@@ -201,7 +201,7 @@ void MapWindow::slot_continuousScroll(const int hStep, const int input_vStep)
         if (scrollTimer->isActive()) {
             scrollTimer->stop();
         }
-        delete scrollTimer;
+        scrollTimer->deleteLater();
     }
 
     // start
@@ -231,8 +231,12 @@ void MapWindow::slot_graphicsSettingsChanged()
 
 void MapWindow::slot_centerOnWorldPos(const glm::vec2 &worldPos)
 {
+    const SignalBlocker block_horz{*m_horizontalScrollBar};
+    const SignalBlocker block_vert{*m_verticalScrollBar};
+
     const auto scrollPos = m_knownMapSize.worldToScroll(worldPos);
-    centerOnScrollPos(scrollPos);
+    m_horizontalScrollBar->setValue(scrollPos.x);
+    m_verticalScrollBar->setValue(scrollPos.y);
 }
 
 void MapWindow::centerOnScrollPos(const glm::ivec2 &scrollPos)

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -13,6 +13,7 @@
 #include <QLabel>
 #include <QPixmap>
 #include <QPoint>
+#include <QPointer>
 #include <QSize>
 #include <QString>
 #include <QWidget>
@@ -43,8 +44,8 @@ protected:
     std::unique_ptr<QGridLayout> m_gridLayout;
     std::unique_ptr<QScrollBar> m_horizontalScrollBar;
     std::unique_ptr<QScrollBar> m_verticalScrollBar;
-    MapCanvas *m_canvas;
-    QWidget *m_canvasContainer;
+    QPointer<MapCanvas> m_canvas;
+    QPointer<QWidget> m_canvasContainer;
     std::unique_ptr<QLabel> m_splashLabel;
 
 private:

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -37,16 +37,16 @@ class NODISCARD_QOBJECT MapWindow final : public QWidget
     Q_OBJECT
 
 protected:
-    std::unique_ptr<QTimer> scrollTimer;
+    QPointer<QTimer> scrollTimer;
     int m_verticalScrollStep = 0;
     int m_horizontalScrollStep = 0;
 
-    std::unique_ptr<QGridLayout> m_gridLayout;
-    std::unique_ptr<QScrollBar> m_horizontalScrollBar;
-    std::unique_ptr<QScrollBar> m_verticalScrollBar;
+    QPointer<QGridLayout> m_gridLayout;
+    QPointer<QScrollBar> m_horizontalScrollBar;
+    QPointer<QScrollBar> m_verticalScrollBar;
     QPointer<MapCanvas> m_canvas;
     QPointer<QWidget> m_canvasContainer;
-    std::unique_ptr<QLabel> m_splashLabel;
+    QPointer<QLabel> m_splashLabel;
 
 private:
     struct NODISCARD KnownMapSize final

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -43,7 +43,8 @@ protected:
     std::unique_ptr<QGridLayout> m_gridLayout;
     std::unique_ptr<QScrollBar> m_horizontalScrollBar;
     std::unique_ptr<QScrollBar> m_verticalScrollBar;
-    std::unique_ptr<MapCanvas> m_canvas;
+    MapCanvas *m_canvas;
+    QWidget *m_canvasContainer;
     std::unique_ptr<QLabel> m_splashLabel;
 
 private:
@@ -91,4 +92,7 @@ public slots:
     void slot_scrollTimerTimeout();
     void slot_graphicsSettingsChanged();
     void slot_zoomChanged(const float zoom) { emit sig_zoomChanged(zoom); }
+    void slot_showTooltip(const QString &text, const QPoint &pos);
+
+    void setCanvasEnabled(bool enabled);
 };

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -465,7 +465,7 @@ void MainWindow::wireConnections()
             &MapCanvas::sig_newInfomarkSelection,
             this,
             &MainWindow::slot_newInfomarkSelection);
-    connect(canvas, &QWidget::customContextMenuRequested, this, &MainWindow::slot_showContextMenu);
+    connect(canvas, &MapCanvas::sig_customContextMenuRequested, this, &MainWindow::slot_showContextMenu);
 
     // Group
     connect(m_groupManager, &Mmapper2Group::sig_log, this, &MainWindow::slot_log);
@@ -1313,7 +1313,6 @@ void MainWindow::slot_setShowMenuBar()
     m_dockDialogGroup->setMouseTracking(!showMenuBar);
     m_dockDialogLog->setMouseTracking(!showMenuBar);
     m_dockDialogRoom->setMouseTracking(!showMenuBar);
-    getCanvas()->setMouseTracking(!showMenuBar);
 
     if (showMenuBar) {
         menuBar()->show();
@@ -1322,14 +1321,12 @@ void MainWindow::slot_setShowMenuBar()
         m_dockDialogGroup->removeEventFilter(this);
         m_dockDialogLog->removeEventFilter(this);
         m_dockDialogRoom->removeEventFilter(this);
-        getCanvas()->removeEventFilter(this);
     } else {
         m_dockDialogAdventure->installEventFilter(this);
         m_dockDialogClient->installEventFilter(this);
         m_dockDialogGroup->installEventFilter(this);
         m_dockDialogLog->installEventFilter(this);
         m_dockDialogRoom->installEventFilter(this);
-        getCanvas()->installEventFilter(this);
     }
 }
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -465,7 +465,10 @@ void MainWindow::wireConnections()
             &MapCanvas::sig_newInfomarkSelection,
             this,
             &MainWindow::slot_newInfomarkSelection);
-    connect(canvas, &MapCanvas::sig_customContextMenuRequested, this, &MainWindow::slot_showContextMenu);
+    connect(canvas,
+            &MapCanvas::sig_customContextMenuRequested,
+            this,
+            &MainWindow::slot_showContextMenu);
 
     // Group
     connect(m_groupManager, &Mmapper2Group::sig_log, this, &MainWindow::slot_log);

--- a/src/mainwindow/utils.cpp
+++ b/src/mainwindow/utils.cpp
@@ -9,12 +9,12 @@
 CanvasDisabler::CanvasDisabler(MapWindow &in_window)
     : window{in_window}
 {
-    window.getCanvas()->setEnabled(false);
+    window.setCanvasEnabled(false);
 }
 
 CanvasDisabler::~CanvasDisabler()
 {
-    window.getCanvas()->setEnabled(true);
+    window.setCanvasEnabled(true);
     window.hideSplashImage();
 }
 


### PR DESCRIPTION
This change modernizes the map rendering pipeline by migrating `MapCanvas` from `QOpenGLWidget` to `QOpenGLWindow`. To maintain UI compatibility, it is embedded into `MapWindow` via `createWindowContainer`.

Key improvements and constraints:
1. **Continuous Dragging**: The map now follows the cursor smoothly during MOVE mode using a captured projection matrix and world coordinates.
2. **UX Preservation**: The original discrete zoom steps and touch gesture "feel" were intentionally preserved. Pinch-zoom is manually handled via `QTouchEvent` as `QOpenGLWindow` doesn't support the legacy gesture API automatically.
3. **Architecture**: Dragging state management was consolidated into `startMoving()` and `stopMoving()` methods for better maintainability.
4. **UI Integration**: New signals `sig_showTooltip` and `sig_customContextMenuRequested` were added to allow the `QOpenGLWindow` to interact with the `QWidget`-based main application UI.

---
*PR created automatically by Jules for task [15752247612279573398](https://jules.google.com/task/15752247612279573398) started by @nschimme*