### PR TITLE
Refactor input handling and improve pointer robustness

### DIFF
--- a/src/display/MapCanvasData.cpp
+++ b/src/display/MapCanvasData.cpp
@@ -104,7 +104,7 @@ glm::vec3 MapCanvasViewport::unproject_clamped(const glm::vec2 &mouse,
     return glm::vec3{glm::vec2{result}, flayer};
 }
 
-glm::vec2 MapCanvasViewport::getMouseCoords(const QInputEvent *const event) const
+std::optional<glm::vec2> MapCanvasViewport::getMouseCoords(const QInputEvent *const event) const
 {
     if (const auto *const mouse = dynamic_cast<const QMouseEvent *>(event)) {
         const auto x = static_cast<float>(mouse->position().x());
@@ -121,7 +121,7 @@ glm::vec2 MapCanvasViewport::getMouseCoords(const QInputEvent *const event) cons
     } else if (const auto *const touch = dynamic_cast<const QTouchEvent *>(event)) {
         const auto &points = touch->points();
         if (points.isEmpty()) {
-            throw std::invalid_argument("no touch points");
+            return std::nullopt;
         }
         QPointF centroid(0, 0);
         for (const auto &p : points) {
@@ -132,7 +132,7 @@ glm::vec2 MapCanvasViewport::getMouseCoords(const QInputEvent *const event) cons
         const auto y = static_cast<float>(height() - centroid.y());
         return glm::vec2{x, y};
     } else {
-        throw std::invalid_argument("event");
+        return std::nullopt;
     }
 }
 
@@ -140,12 +140,11 @@ glm::vec2 MapCanvasViewport::getMouseCoords(const QInputEvent *const event) cons
 // output is the world space intersection with the current layer
 std::optional<glm::vec3> MapCanvasViewport::unproject(const QInputEvent *const event) const
 {
-    try {
-        const auto xy = getMouseCoords(event);
-        return unproject(xy);
-    } catch (const std::invalid_argument &) {
+    const auto xy = getMouseCoords(event);
+    if (!xy) {
         return std::nullopt;
     }
+    return unproject(*xy);
 }
 
 std::optional<glm::vec3> MapCanvasViewport::unproject(const glm::vec2 &xy) const
@@ -170,12 +169,11 @@ std::optional<glm::vec3> MapCanvasViewport::unproject(const glm::vec2 &xy) const
 
 std::optional<MouseSel> MapCanvasViewport::getUnprojectedMouseSel(const QInputEvent *const event) const
 {
-    try {
-        const auto xy = getMouseCoords(event);
-        return getUnprojectedMouseSel(xy);
-    } catch (const std::invalid_argument &) {
+    const auto xy = getMouseCoords(event);
+    if (!xy) {
         return std::nullopt;
     }
+    return getUnprojectedMouseSel(*xy);
 }
 
 std::optional<MouseSel> MapCanvasViewport::getUnprojectedMouseSel(const glm::vec2 &xy) const

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -119,7 +119,7 @@ public:
     NODISCARD std::optional<glm::vec3> unproject(const glm::vec2 &xy) const;
     NODISCARD std::optional<MouseSel> getUnprojectedMouseSel(const QInputEvent *event) const;
     NODISCARD std::optional<MouseSel> getUnprojectedMouseSel(const glm::vec2 &xy) const;
-    NODISCARD glm::vec2 getMouseCoords(const QInputEvent *event) const;
+    NODISCARD std::optional<glm::vec2> getMouseCoords(const QInputEvent *event) const;
 };
 
 class NODISCARD MapScreen final

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -20,7 +20,7 @@
 #include <unordered_map>
 
 #include <QOpenGLTexture>
-#include <QWidget>
+#include <QWindow>
 #include <QtGui/QMatrix4x4>
 #include <QtGui/QMouseEvent>
 #include <QtGui/qopengl.h>
@@ -48,8 +48,6 @@ public:
 
 private:
     float m_scaleFactor = 1.f;
-    // pinch gesture
-    float m_pinchFactor = 1.f;
 
 private:
     NODISCARD static float clamp(float x)
@@ -63,21 +61,10 @@ public:
 
 public:
     NODISCARD float getRaw() const { return clamp(m_scaleFactor); }
-    NODISCARD float getTotal() const { return clamp(m_scaleFactor * m_pinchFactor); }
+    NODISCARD float getTotal() const { return clamp(m_scaleFactor); }
 
 public:
     void set(const float scale) { m_scaleFactor = clamp(scale); }
-    void setPinch(const float pinch)
-    {
-        // Don't bother to clamp this, since the total is clamped.
-        m_pinchFactor = pinch;
-    }
-    void endPinch()
-    {
-        const float total = getTotal();
-        m_scaleFactor = total;
-        m_pinchFactor = 1.f;
-    }
     void reset() { *this = ScaleFactor(); }
 
 public:
@@ -100,7 +87,7 @@ public:
 struct NODISCARD MapCanvasViewport
 {
 private:
-    QWidget &m_sizeWidget;
+    QWindow &m_window;
 
 public:
     glm::mat4 m_viewProj{1.f};
@@ -109,26 +96,29 @@ public:
     int m_currentLayer = 0;
 
 public:
-    explicit MapCanvasViewport(QWidget &sizeWidget)
-        : m_sizeWidget{sizeWidget}
+    explicit MapCanvasViewport(QWindow &window)
+        : m_window{window}
     {}
 
 public:
-    NODISCARD auto width() const { return m_sizeWidget.width(); }
-    NODISCARD auto height() const { return m_sizeWidget.height(); }
+    NODISCARD auto width() const { return m_window.width(); }
+    NODISCARD auto height() const { return m_window.height(); }
     NODISCARD Viewport getViewport() const
     {
-        const auto &r = m_sizeWidget.rect();
-        return Viewport{glm::ivec2{r.x(), r.y()}, glm::ivec2{r.width(), r.height()}};
+        return Viewport{glm::ivec2{0, 0}, glm::ivec2{m_window.width(), m_window.height()}};
     }
     NODISCARD float getTotalScaleFactor() const { return m_scaleFactor.getTotal(); }
 
 public:
     NODISCARD std::optional<glm::vec3> project(const glm::vec3 &) const;
     NODISCARD glm::vec3 unproject_raw(const glm::vec3 &) const;
+    NODISCARD glm::vec3 unproject_raw(const glm::vec3 &, const glm::mat4 &) const;
     NODISCARD glm::vec3 unproject_clamped(const glm::vec2 &) const;
+    NODISCARD glm::vec3 unproject_clamped(const glm::vec2 &, const glm::mat4 &) const;
     NODISCARD std::optional<glm::vec3> unproject(const QInputEvent *event) const;
+    NODISCARD std::optional<glm::vec3> unproject(const glm::vec2 &xy) const;
     NODISCARD std::optional<MouseSel> getUnprojectedMouseSel(const QInputEvent *event) const;
+    NODISCARD std::optional<MouseSel> getUnprojectedMouseSel(const glm::vec2 &xy) const;
     NODISCARD glm::vec2 getMouseCoords(const QInputEvent *event) const;
 };
 

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -37,9 +37,7 @@
 #include <QOpenGLDebugMessage>
 #include <QSize>
 #include <QString>
-#include <QToolTip>
 #include <QtGui>
-#include <QtWidgets>
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #undef near // Bad dog, Microsoft; bad dog!!!
@@ -56,9 +54,9 @@ NODISCARD static NonOwningPointer &primaryMapCanvas()
 MapCanvas::MapCanvas(MapData &mapData,
                      PrespammedPath &prespammedPath,
                      Mmapper2Group &groupManager,
-                     QWidget *const parent)
-    : QOpenGLWidget{parent}
-    , MapCanvasViewport{static_cast<QWidget &>(*this)}
+                     QWindow *const parent)
+    : QOpenGLWindow{NoPartialUpdate, parent}
+    , MapCanvasViewport{static_cast<QWindow &>(*this)}
     , MapCanvasInputState{prespammedPath}
     , m_mapScreen{static_cast<MapCanvasViewport &>(*this)}
     , m_opengl{}
@@ -72,8 +70,6 @@ MapCanvas::MapCanvas(MapData &mapData,
     }
 
     setCursor(Qt::OpenHandCursor);
-    grabGesture(Qt::PinchGesture);
-    setContextMenuPolicy(Qt::CustomContextMenu);
 }
 
 MapCanvas::~MapCanvas()
@@ -224,59 +220,12 @@ void MapCanvas::wheelEvent(QWheelEvent *const event)
                 slot_layerUp();
             }
         } else {
-            const auto zoomAndMaybeRecenter = [this, event](const int numSteps) -> bool {
-                assert(numSteps != 0);
-                const auto optCenter = getUnprojectedMouseSel(event);
-
-                // NOTE: Do a regular zoom if the projection failed.
-                if (!optCenter) {
-                    m_scaleFactor.logStep(numSteps);
-                    return false; // failed to recenter
-                }
-
-                // Our goal is to keep the point under the mouse constant,
-                // so we'll do the usual trick: translate to the origin,
-                // scale/rotate, then translate back. However, the amount
-                // we translate will differ because zoom changes our height.
-                const auto newCenter = optCenter->to_vec3();
-                const auto oldCenter = m_mapScreen.getCenter();
-
-                // 1. recenter to mouse location
-
-                const auto delta1 = glm::ivec2(glm::vec2(newCenter - oldCenter)
-                                               * static_cast<float>(SCROLL_SCALE));
-
-                emit sig_mapMove(delta1.x, delta1.y);
-
-                // 2. zoom in
-                m_scaleFactor.logStep(numSteps);
-
-                // 3. adjust viewport for new projection
-                setViewportAndMvp(width(), height());
-
-                // 4. subtract the offset to same mouse coordinate;
-                // This probably shouldn't ever fail, but let's make it conditional
-                // (worst case: we're left centered on what we clicked on,
-                // which will create infuriating overshoots if it ever happens)
-                if (const auto &optCenter2 = getUnprojectedMouseSel(event)) {
-                    const auto delta2 = glm::ivec2(glm::vec2(optCenter2->to_vec3() - newCenter)
-                                                   * static_cast<float>(SCROLL_SCALE));
-
-                    emit sig_mapMove(-delta2.x, -delta2.y);
-
-                    // NOTE: caller is expected to call update() after this function,
-                    // so we don't have to update the viewport.
-                }
-
-                return true;
-            };
-
             // Change the zoom level
-            const int numSteps = event->angleDelta().y() / 120;
-            if (numSteps != 0) {
-                zoomAndMaybeRecenter(numSteps);
-                zoomChanged();
-                update();
+            const int angleDelta = event->angleDelta().y();
+            if (angleDelta != 0) {
+                const float factor = std::pow(ScaleFactor::ZOOM_STEP,
+                                              static_cast<float>(angleDelta) / 120.0f);
+                zoomAt(factor, getMouseCoords(event));
             }
         }
         break;
@@ -294,46 +243,88 @@ void MapCanvas::slot_onForcedPositionChange()
     slot_requestUpdate();
 }
 
+void MapCanvas::touchEvent(QTouchEvent *const event)
+{
+    const auto &points = event->points();
+    if (points.size() == 2) {
+        const auto &p1 = points[0];
+        const auto &p2 = points[1];
+
+        if (event->type() == QEvent::TouchBegin || p1.state() == QEventPoint::Pressed
+            || p2.state() == QEventPoint::Pressed) {
+            m_initialPinchDistance = glm::distance(glm::vec2(static_cast<float>(p1.position().x()),
+                                                             static_cast<float>(p1.position().y())),
+                                                   glm::vec2(static_cast<float>(p2.position().x()),
+                                                             static_cast<float>(p2.position().y())));
+            m_lastPinchFactor = 1.f;
+        }
+
+        if (m_initialPinchDistance > 1e-3f) {
+            const float currentDistance
+                = glm::distance(glm::vec2(static_cast<float>(p1.position().x()),
+                                          static_cast<float>(p1.position().y())),
+                                glm::vec2(static_cast<float>(p2.position().x()),
+                                          static_cast<float>(p2.position().y())));
+            const float currentPinchFactor = currentDistance / m_initialPinchDistance;
+            const float deltaFactor = currentPinchFactor / m_lastPinchFactor;
+
+            if (std::abs(deltaFactor - 1.f) > 1e-6f) {
+                zoomAt(deltaFactor, getMouseCoords(event));
+            }
+            m_lastPinchFactor = currentPinchFactor;
+        }
+
+        if (event->type() == QEvent::TouchEnd || p1.state() == QEventPoint::Released
+            || p2.state() == QEventPoint::Released) {
+            m_initialPinchDistance = 0.f;
+            m_lastPinchFactor = 1.f;
+        }
+        event->accept();
+    } else {
+        if (m_initialPinchDistance > 0.f) {
+            m_initialPinchDistance = 0.f;
+            m_lastPinchFactor = 1.f;
+        }
+        QOpenGLWindow::touchEvent(event);
+    }
+}
+
 bool MapCanvas::event(QEvent *const event)
 {
-    auto tryHandlePinchZoom = [this, event]() -> bool {
-        if (event->type() != QEvent::Gesture) {
-            return false;
-        }
+    if (event->type() == QEvent::NativeGesture) {
+        auto *const nativeEvent = static_cast<QNativeGestureEvent *>(event);
+        if (nativeEvent->gestureType() == Qt::ZoomNativeGesture) {
+            const auto value = static_cast<float>(nativeEvent->value());
+            const auto *const inputEvent = static_cast<const QInputEvent *>(event);
 
-        const auto *const gestureEvent = dynamic_cast<QGestureEvent *>(event);
-        if (gestureEvent == nullptr) {
-            return false;
-        }
+            if constexpr (CURRENT_PLATFORM == PlatformEnum::Mac) {
+                // On macOS, event->value() for ZoomNativeGesture is the magnification delta
+                // since the last event.
+                const float deltaFactor = 1.f + value;
+                if (std::abs(value) > 1e-6f) {
+                    zoomAt(deltaFactor, getMouseCoords(inputEvent));
+                }
+            } else {
+                // On other platforms, it's typically the cumulative scale factor (1.0 at start).
+                if (nativeEvent->isBeginEvent()) {
+                    m_lastMagnification = 1.f;
+                }
 
-        // Zoom in / out
-        QGesture *const gesture = gestureEvent->gesture(Qt::PinchGesture);
-        const auto *const pinch = dynamic_cast<QPinchGesture *>(gesture);
-        if (pinch == nullptr) {
-            return false;
-        }
-
-        const QPinchGesture::ChangeFlags changeFlags = pinch->changeFlags();
-        if (changeFlags & QPinchGesture::ScaleFactorChanged) {
-            const auto pinchFactor = static_cast<float>(pinch->totalScaleFactor());
-            m_scaleFactor.setPinch(pinchFactor);
-            if ((false)) {
-                zoomChanged(); // Don't call this here, because it's not true yet.
+                if (std::abs(m_lastMagnification) > 1e-6f) {
+                    const float deltaFactor = value / m_lastMagnification;
+                    if (std::abs(deltaFactor - 1.f) > 1e-6f) {
+                        zoomAt(deltaFactor, getMouseCoords(inputEvent));
+                    }
+                }
+                m_lastMagnification = value;
             }
-        }
-        if (pinch->state() == Qt::GestureFinished) {
-            m_scaleFactor.endPinch();
-            zoomChanged(); // might not have actually changed
-        }
-        update();
-        return true;
-    };
 
-    if (tryHandlePinchZoom()) {
-        return true;
+            event->accept();
+            return true;
+        }
     }
 
-    return QOpenGLWidget::event(event);
+    return QOpenGLWindow::event(event);
 }
 
 void MapCanvas::slot_createRoom()
@@ -416,13 +407,20 @@ void MapCanvas::mousePressEvent(QMouseEvent *const event)
     MAYBE_UNUSED const bool hasAlt = (event->modifiers() & Qt::ALT) != 0u;
 
     if (hasLeftButton && hasAlt) {
-        m_altDragState.emplace(AltDragState{event->pos(), cursor()});
+        m_altDragState.emplace(AltDragState{event->position().toPoint(), cursor()});
         setCursor(Qt::ClosedHandCursor);
         event->accept();
         return;
     }
 
-    m_sel1 = m_sel2 = getUnprojectedMouseSel(event);
+    const auto xy = getMouseCoords(event);
+    if (m_canvasMouseMode == CanvasMouseModeEnum::MOVE) {
+        const auto worldPos = unproject_clamped(xy);
+        m_sel1 = m_sel2 = MouseSel{Coordinate2f{worldPos.x, worldPos.y}, m_currentLayer};
+    } else {
+        m_sel1 = m_sel2 = getUnprojectedMouseSel(xy);
+    }
+
     m_mouseLeftPressed = hasLeftButton;
     m_mouseRightPressed = hasRightButton;
 
@@ -477,7 +475,6 @@ void MapCanvas::mousePressEvent(QMouseEvent *const event)
 
     case CanvasMouseModeEnum::RAYPICK_ROOMS:
         if (hasLeftButton) {
-            const auto xy = getMouseCoords(event);
             const auto near = unproject_raw(glm::vec3{xy, 0.f});
             const auto far = unproject_raw(glm::vec3{xy, 1.f});
 
@@ -606,7 +603,7 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
         auto &dragState = m_altDragState.value();
         bool angleChanged = false;
 
-        const auto pos = event->pos();
+        const auto pos = event->position().toPoint();
         const auto delta = pos - dragState.lastPos;
         dragState.lastPos = pos;
 
@@ -694,12 +691,16 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
         infomarksChanged();
         break;
     case CanvasMouseModeEnum::MOVE:
-        if (hasLeftButton && m_mouseLeftPressed && hasSel2() && hasBackup()) {
-            const Coordinate2i delta
-                = ((getSel2().pos - getBackup().pos) * static_cast<float>(SCROLL_SCALE)).truncate();
-            if (delta.x != 0 || delta.y != 0) {
-                // negated because dragging to right is scrolling to the left.
-                emit sig_mapMove(-delta.x, -delta.y);
+        if (hasLeftButton && m_mouseLeftPressed && m_dragState.has_value()) {
+            const auto xy = getMouseCoords(event);
+            const glm::vec3 currWorldPos = unproject_clamped(xy, m_dragState->startViewProj);
+            const glm::vec2 delta = glm::vec2(currWorldPos - m_dragState->startWorldPos);
+
+            if (glm::length(delta) > 1e-6f) {
+                const glm::vec2 newWorldCenter = m_dragState->startScroll - delta;
+                m_scroll = newWorldCenter;
+                emit sig_onCenter(newWorldCenter);
+                update();
             }
         }
         break;
@@ -849,11 +850,7 @@ void MapCanvas::mouseReleaseEvent(QMouseEvent *const event)
                                                  mmqt::StripAnsiEnum::Yes,
                                                  mmqt::PreviewStyleEnum::ForDisplay);
 
-                QToolTip::showText(mapToGlobal(event->position().toPoint()),
-                                   message,
-                                   this,
-                                   rect(),
-                                   5000);
+                emit sig_showTooltip(message, event->position().toPoint());
             }
         }
         break;
@@ -998,14 +995,57 @@ void MapCanvas::mouseReleaseEvent(QMouseEvent *const event)
     m_ctrlPressed = false;
 }
 
-QSize MapCanvas::minimumSizeHint() const
+void MapCanvas::startMoving(const MouseSel &startPos)
 {
-    return {sizeHint().width() / 4, sizeHint().height() / 4};
+    MapCanvasInputState::startMoving(startPos);
+    m_dragState.emplace(DragState{startPos.to_vec3(), m_scroll, m_viewProj});
 }
 
-QSize MapCanvas::sizeHint() const
+void MapCanvas::stopMoving()
 {
-    return {1280, 720};
+    MapCanvasInputState::stopMoving();
+    m_dragState.reset();
+}
+
+void MapCanvas::zoomAt(const float factor, const glm::vec2 &mousePos)
+{
+    const auto optWorldPos = unproject(mousePos);
+    if (!optWorldPos) {
+        m_scaleFactor *= factor;
+        zoomChanged();
+        update();
+        return;
+    }
+
+    const glm::vec2 worldPos = glm::vec2(*optWorldPos);
+
+    // Save current state
+    const glm::vec2 oldScroll = m_scroll;
+
+    // Apply zoom
+    m_scaleFactor *= factor;
+    zoomChanged();
+
+    // Calculate new scroll position to keep worldPos under mousePos.
+    // We update the viewport and MVP to the new zoom level temporarily
+    // to perform the unprojection.
+    setViewportAndMvp(width(), height());
+
+    const auto optNewWorldPos = unproject(mousePos);
+    if (optNewWorldPos) {
+        const glm::vec2 delta = worldPos - glm::vec2(*optNewWorldPos);
+        const glm::vec2 newScroll = oldScroll + delta;
+        m_scroll = newScroll;
+        emit sig_onCenter(newScroll);
+    } else {
+        // Fallback: if we can't find the new world position, just stay where we were.
+        m_scroll = oldScroll;
+        emit sig_onCenter(oldScroll);
+    }
+
+    // Refresh the viewport matrix with the final scroll and zoom before painting.
+    setViewportAndMvp(width(), height());
+    update();
 }
 
 void MapCanvas::slot_setScroll(const glm::vec2 &worldPos)
@@ -1051,7 +1091,9 @@ void MapCanvas::onMovement()
 {
     const Coordinate &pos = m_data.tryGetPosition().value_or(Coordinate{});
     m_currentLayer = pos.z;
-    emit sig_onCenter(pos.to_vec2() + glm::vec2{0.5f, 0.5f});
+    const glm::vec2 newScroll = pos.to_vec2() + glm::vec2{0.5f, 0.5f};
+    m_scroll = newScroll;
+    emit sig_onCenter(newScroll);
     update();
 }
 

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -30,7 +30,7 @@
 #include <QColor>
 #include <QMatrix4x4>
 #include <QOpenGLDebugMessage>
-#include <QOpenGLWidget>
+#include <QOpenGLWindow>
 #include <QtCore>
 
 class CharacterBatch;
@@ -47,7 +47,7 @@ class QWheelEvent;
 class QWidget;
 class RoomSelFakeGL;
 
-class NODISCARD_QOBJECT MapCanvas final : public QOpenGLWidget,
+class NODISCARD_QOBJECT MapCanvas final : public QOpenGLWindow,
                                           private MapCanvasViewport,
                                           private MapCanvasInputState
 {
@@ -152,11 +152,23 @@ private:
     };
     std::optional<AltDragState> m_altDragState;
 
+    struct DragState
+    {
+        glm::vec3 startWorldPos;
+        glm::vec2 startScroll;
+        glm::mat4 startViewProj;
+    };
+    std::optional<DragState> m_dragState;
+
+    float m_initialPinchDistance = 0.f;
+    float m_lastPinchFactor = 1.f;
+    float m_lastMagnification = 1.f;
+
 public:
     explicit MapCanvas(MapData &mapData,
                        PrespammedPath &prespammedPath,
                        Mmapper2Group &groupManager,
-                       QWidget *parent);
+                       QWindow *parent = nullptr);
     ~MapCanvas() final;
 
 public:
@@ -168,9 +180,6 @@ private:
     void cleanupOpenGL();
 
 public:
-    NODISCARD QSize minimumSizeHint() const override;
-    NODISCARD QSize sizeHint() const override;
-
     using MapCanvasViewport::getTotalScaleFactor;
     void setZoom(float zoom)
     {
@@ -180,12 +189,14 @@ public:
     NODISCARD float getRawZoom() const { return m_scaleFactor.getRaw(); }
 
 public:
-    NODISCARD auto width() const { return QOpenGLWidget::width(); }
-    NODISCARD auto height() const { return QOpenGLWidget::height(); }
-    NODISCARD auto rect() const { return QOpenGLWidget::rect(); }
+    NODISCARD auto width() const { return QOpenGLWindow::width(); }
+    NODISCARD auto height() const { return QOpenGLWindow::height(); }
+    NODISCARD QRect rect() const { return QRect(0, 0, width(), height()); }
 
 private:
     void onMovement();
+    void startMoving(const MouseSel &startPos);
+    void stopMoving();
 
 private:
     void reportGLVersion();
@@ -202,6 +213,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
+    void touchEvent(QTouchEvent *event) override;
     bool event(QEvent *e) override;
 
 private:
@@ -227,6 +239,8 @@ private:
                                            int currentLayer);
     void setMvp(const glm::mat4 &viewProj);
     void setViewportAndMvp(int width, int height);
+
+    void zoomAt(float factor, const glm::vec2 &mousePos);
 
     NODISCARD BatchedInfomarksMeshes getInfomarksMeshes();
     void drawInfomark(InfomarksBatch &batch,
@@ -287,6 +301,9 @@ signals:
 
     void sig_setCurrentRoom(RoomId id, bool update);
     void sig_zoomChanged(float);
+
+    void sig_showTooltip(const QString &text, const QPoint &pos);
+    void sig_customContextMenuRequested(const QPoint &pos);
 
 public slots:
     void slot_onForcedPositionChange();

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -48,7 +48,7 @@
 
 #include <QMessageBox>
 #include <QMessageLogContext>
-#include <QOpenGLWidget>
+#include <QOpenGLWindow>
 #include <QtCore>
 #include <QtGui/qopengl.h>
 #include <QtGui>
@@ -96,15 +96,15 @@ void setShowPerfStats(const bool show)
 class NODISCARD MakeCurrentRaii final
 {
 private:
-    QOpenGLWidget &m_glWidget;
+    QOpenGLWindow &m_glWindow;
 
 public:
-    explicit MakeCurrentRaii(QOpenGLWidget &widget)
-        : m_glWidget{widget}
+    explicit MakeCurrentRaii(QOpenGLWindow &window)
+        : m_glWindow{window}
     {
-        m_glWidget.makeCurrent();
+        m_glWindow.makeCurrent();
     }
-    ~MakeCurrentRaii() { m_glWidget.doneCurrent(); }
+    ~MakeCurrentRaii() { m_glWindow.doneCurrent(); }
 
     DELETE_CTORS_AND_ASSIGN_OPS(MakeCurrentRaii);
 };
@@ -215,7 +215,7 @@ void MapCanvas::initializeGL()
     } catch (const std::exception &) {
         hide();
         doneCurrent();
-        QMessageBox::critical(this,
+        QMessageBox::critical(nullptr,
                               "Unable to initialize OpenGL",
                               "Upgrade your video card drivers");
         if constexpr (CURRENT_PLATFORM == PlatformEnum::Windows) {
@@ -859,7 +859,7 @@ void MapCanvas::paintGL()
     const auto &afterBatches = optAfterBatches.value();
     const auto afterPaint = Clock::now();
     const bool calledFinish = std::invoke([this]() -> bool {
-        if (auto *const ctxt = QOpenGLWidget::context()) {
+        if (auto *const ctxt = QOpenGLWindow::context()) {
             if (auto *const func = ctxt->functions()) {
                 func->glFinish();
                 return true;

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -13,6 +13,7 @@
 #include <QLabel>
 #include <QPixmap>
 #include <QPoint>
+#include <QPointer>
 #include <QSize>
 #include <QString>
 #include <QWidget>
@@ -36,15 +37,16 @@ class NODISCARD_QOBJECT MapWindow final : public QWidget
     Q_OBJECT
 
 protected:
-    std::unique_ptr<QTimer> scrollTimer;
+    QPointer<QTimer> scrollTimer;
     int m_verticalScrollStep = 0;
     int m_horizontalScrollStep = 0;
 
-    std::unique_ptr<QGridLayout> m_gridLayout;
-    std::unique_ptr<QScrollBar> m_horizontalScrollBar;
-    std::unique_ptr<QScrollBar> m_verticalScrollBar;
-    std::unique_ptr<MapCanvas> m_canvas;
-    std::unique_ptr<QLabel> m_splashLabel;
+    QPointer<QGridLayout> m_gridLayout;
+    QPointer<QScrollBar> m_horizontalScrollBar;
+    QPointer<QScrollBar> m_verticalScrollBar;
+    QPointer<MapCanvas> m_canvas;
+    QPointer<QWidget> m_canvasContainer;
+    QPointer<QLabel> m_splashLabel;
 
 private:
     struct NODISCARD KnownMapSize final
@@ -91,4 +93,7 @@ public slots:
     void slot_scrollTimerTimeout();
     void slot_graphicsSettingsChanged();
     void slot_zoomChanged(const float zoom) { emit sig_zoomChanged(zoom); }
+    void slot_showTooltip(const QString &text, const QPoint &pos);
+
+    void setCanvasEnabled(bool enabled);
 };

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -465,7 +465,10 @@ void MainWindow::wireConnections()
             &MapCanvas::sig_newInfomarkSelection,
             this,
             &MainWindow::slot_newInfomarkSelection);
-    connect(canvas, &QWidget::customContextMenuRequested, this, &MainWindow::slot_showContextMenu);
+    connect(canvas,
+            &MapCanvas::sig_customContextMenuRequested,
+            this,
+            &MainWindow::slot_showContextMenu);
 
     // Group
     connect(m_groupManager, &Mmapper2Group::sig_log, this, &MainWindow::slot_log);
@@ -1313,7 +1316,6 @@ void MainWindow::slot_setShowMenuBar()
     m_dockDialogGroup->setMouseTracking(!showMenuBar);
     m_dockDialogLog->setMouseTracking(!showMenuBar);
     m_dockDialogRoom->setMouseTracking(!showMenuBar);
-    getCanvas()->setMouseTracking(!showMenuBar);
 
     if (showMenuBar) {
         menuBar()->show();
@@ -1322,14 +1324,12 @@ void MainWindow::slot_setShowMenuBar()
         m_dockDialogGroup->removeEventFilter(this);
         m_dockDialogLog->removeEventFilter(this);
         m_dockDialogRoom->removeEventFilter(this);
-        getCanvas()->removeEventFilter(this);
     } else {
         m_dockDialogAdventure->installEventFilter(this);
         m_dockDialogClient->installEventFilter(this);
         m_dockDialogGroup->installEventFilter(this);
         m_dockDialogLog->installEventFilter(this);
         m_dockDialogRoom->installEventFilter(this);
-        getCanvas()->installEventFilter(this);
     }
 }
 

--- a/src/mainwindow/utils.cpp
+++ b/src/mainwindow/utils.cpp
@@ -9,12 +9,12 @@
 CanvasDisabler::CanvasDisabler(MapWindow &in_window)
     : window{in_window}
 {
-    window.getCanvas()->setEnabled(false);
+    window.setCanvasEnabled(false);
 }
 
 CanvasDisabler::~CanvasDisabler()
 {
-    window.getCanvas()->setEnabled(true);
+    window.setCanvasEnabled(true);
     window.hideSplashImage();
 }
 


### PR DESCRIPTION
This change addresses several points from a code review:
1. Performance: Removed exception throwing from `getMouseCoords` and `unproject` in favor of `std::optional`.
2. Robustness: Used `deref()` for `QPointer` access in `MapWindow` and refactored `scrollTimer` management.
3. UX: Restored tooltip timeout to 5000ms.
4. Style: Applied `clang-format-18` and followed project-specific patterns.

---
*PR created automatically by Jules for task [5822252363301525818](https://jules.google.com/task/5822252363301525818) started by @nschimme*