### PR TITLE
Fix invisible connection points on Linux

### DIFF
--- a/src/opengl/legacy/FunctionsGL33.cpp
+++ b/src/opengl/legacy/FunctionsGL33.cpp
@@ -49,8 +49,18 @@ void FunctionsGL33::virt_enableProgramPointSize(const bool enable)
 #ifndef MMAPPER_NO_OPENGL
     if (enable) {
         Base::glEnable(GL_PROGRAM_POINT_SIZE);
+
+        // In Compatibility profile (common on Linux/Mesa), gl_PointCoord in the
+        // fragment shader is often only populated if GL_POINT_SPRITE is enabled.
+        if (OpenGLConfig::getIsCompat()) {
+            Base::glEnable(0x8861); // GL_POINT_SPRITE
+        }
     } else {
         Base::glDisable(GL_PROGRAM_POINT_SIZE);
+
+        if (OpenGLConfig::getIsCompat()) {
+            Base::glDisable(0x8861); // GL_POINT_SPRITE
+        }
     }
 #endif
 }

--- a/src/resources/shaders/legacy/point/frag.glsl
+++ b/src/resources/shaders/legacy/point/frag.glsl
@@ -9,7 +9,7 @@ out vec4 vFragmentColor;
 
 void main()
 {
-    if (dot(gl_PointCoord-0.5, gl_PointCoord-0.5) > 0.25) {
+    if (dot(gl_PointCoord - 0.5, gl_PointCoord - 0.5) > 0.25) {
         discard;
     }
     vFragmentColor = vColor * uColor;

--- a/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 The MMapper Authors
 
 uniform mat4 uMVP;
-uniform NamedColorsBlock {
+uniform NamedColorsBlock
+{
     vec4 uNamedColors[MAX_NAMED_COLORS];
 };
 
@@ -14,7 +15,10 @@ out vec3 vTexCoord;
 void main()
 {
     // ccw-order assumes it's a triangle fan (as opposed to a triangle strip)
-    const ivec3[4] ioffsets_ccw = ivec3[4](ivec3(0, 0, 0), ivec3(1, 0, 0), ivec3(1, 1, 0), ivec3(0, 1, 0));
+    const ivec3[4] ioffsets_ccw = ivec3[4](ivec3(0, 0, 0),
+                                           ivec3(1, 0, 0),
+                                           ivec3(1, 1, 0),
+                                           ivec3(0, 1, 0));
     ivec3 ioffset = ioffsets_ccw[gl_VertexID];
 
     int texZ = aVertTexCol.w & 0xFF;


### PR DESCRIPTION
Enable GL_POINT_SPRITE in Compatibility profile to fix invisible connection points on Linux.

---
*PR created automatically by Jules for task [3511452546952993923](https://jules.google.com/task/3511452546952993923) started by @nschimme*