### PR TITLE
Refactor MapCanvas: move viewport and input logic

### DIFF
--- a/src/display/Characters.h
+++ b/src/display/Characters.h
@@ -20,7 +20,7 @@
 
 #include <QColor>
 
-class MapScreen;
+struct MapCanvasViewport;
 class OpenGL;
 struct MapCanvasTextures;
 
@@ -41,7 +41,7 @@ public:
 public:
     // Caller must apply the correct translation and rotation.
     NODISCARD static DistantObjectTransform construct(const glm::vec3 &pos,
-                                                      const MapScreen &mapScreen,
+                                                      const MapCanvasViewport &viewport,
                                                       float marginPixels);
 };
 
@@ -184,14 +184,16 @@ private:
     };
 
 private:
-    const MapScreen &m_mapScreen;
+    const MapCanvasViewport &m_viewport;
     const int m_currentLayer;
     const float m_scale;
     CharFakeGL m_fakeGL;
 
 public:
-    explicit CharacterBatch(const MapScreen &mapScreen, const int currentLayer, const float scale)
-        : m_mapScreen(mapScreen)
+    explicit CharacterBatch(const MapCanvasViewport &viewport,
+                            const int currentLayer,
+                            const float scale)
+        : m_viewport(viewport)
         , m_currentLayer(currentLayer)
         , m_scale(scale)
     {}

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -237,9 +237,7 @@ public:
     NODISCARD MouseSel getBackup() const { return getMouseSel(m_moveBackup); }
 
 public:
-    void startMoving(const MouseSel &startPos,
-                     const glm::vec2 &scroll,
-                     const glm::mat4 &viewProj)
+    void startMoving(const MouseSel &startPos, const glm::vec2 &scroll, const glm::mat4 &viewProj)
     {
         m_moveBackup = startPos;
         m_dragState.emplace(DragState{startPos.to_vec3(), scroll, viewProj});

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -136,31 +136,31 @@ public:
     void layerReset() { m_currentLayer = 0; }
     void centerOn(const Coordinate &pos);
     void updateViewProj(bool want3D);
+    NODISCARD std::pair<int, int> calculateContinuousScroll(const glm::vec2 &mousePos) const;
+    bool performPanning(const glm::vec2 &mousePos,
+                        const glm::vec3 &startWorldPos,
+                        const glm::vec2 &startScroll,
+                        const glm::mat4 &startViewProj);
+    bool applyRotationDelta(int dx, int dy);
+    NODISCARD std::vector<Coordinate> calculateRaypickCoordinates(const glm::vec2 &xy) const;
+    NODISCARD std::pair<Coordinate, Coordinate> calculateInfomarkProbeRange(
+        const MouseSel &sel) const;
 
 protected:
     NODISCARD float getPitchDegrees() const;
     NODISCARD glm::mat4 getViewProj_old(const glm::ivec2 &size) const;
     NODISCARD glm::mat4 getViewProj(const glm::ivec2 &size) const;
-};
 
-class NODISCARD MapScreen final
-{
 public:
     static constexpr const float DEFAULT_MARGIN_PIXELS = 24.f;
 
 private:
-    const MapCanvasViewport &m_viewport;
     enum class NODISCARD VisiblityResultEnum {
         INSIDE_MARGIN,
         ON_MARGIN,
         OUTSIDE_MARGIN,
         OFF_SCREEN
     };
-
-public:
-    explicit MapScreen(const MapCanvasViewport &);
-    ~MapScreen();
-    DELETE_CTORS_AND_ASSIGN_OPS(MapScreen);
 
 public:
     NODISCARD glm::vec3 getCenter() const;
@@ -173,6 +173,13 @@ private:
 
 struct NODISCARD MapCanvasInputState
 {
+public:
+    void updateButtonState(const QMouseEvent *event);
+    void updateModifierState(const QInputEvent *event);
+    NODISCARD std::optional<float> calculatePinchDelta(const QTouchEvent *event);
+    NODISCARD std::optional<float> calculateNativeZoomDelta(const QNativeGestureEvent *event);
+
+public:
     CanvasMouseModeEnum m_canvasMouseMode = CanvasMouseModeEnum::MOVE;
 
     bool m_mouseRightPressed = false;

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -154,7 +154,7 @@ protected:
 public:
     static constexpr const float DEFAULT_MARGIN_PIXELS = 24.f;
 
-private:
+public:
     enum class NODISCARD VisiblityResultEnum {
         INSIDE_MARGIN,
         ON_MARGIN,
@@ -178,6 +178,14 @@ public:
     void updateModifierState(const QInputEvent *event);
     NODISCARD std::optional<float> calculatePinchDelta(const QTouchEvent *event);
     NODISCARD std::optional<float> calculateNativeZoomDelta(const QNativeGestureEvent *event);
+
+    void handleEscape();
+    void updateRoomSelectionArea();
+    NODISCARD std::shared_ptr<InfomarkSelection> getInfomarkSelectionAt(
+        const MouseSel &sel, const MapCanvasViewport &viewport) const;
+    void handleMoveModeRightClick(const MouseSel &sel, const MapCanvasViewport &viewport);
+    void handleRoomSelectionRelease();
+    NODISCARD std::optional<Coordinate> handleInfomarkSelectionRelease();
 
 public:
     CanvasMouseModeEnum m_canvasMouseMode = CanvasMouseModeEnum::MOVE;
@@ -203,7 +211,7 @@ public:
     };
 
     std::optional<RoomSelMove> m_roomSelectionMove;
-    NODISCARD bool hasRoomSelectionMove() { return m_roomSelectionMove.has_value(); }
+    NODISCARD bool hasRoomSelectionMove() const { return m_roomSelectionMove.has_value(); }
 
     std::shared_ptr<InfomarkSelection> m_infoMarkSelection;
 
@@ -216,10 +224,11 @@ public:
 
     std::shared_ptr<ConnectionSelection> m_connectionSelection;
 
+    MapData &m_mapData;
     PrespammedPath &m_prespammedPath;
 
 public:
-    explicit MapCanvasInputState(PrespammedPath &prespammedPath);
+    explicit MapCanvasInputState(MapData &mapData, PrespammedPath &prespammedPath);
     ~MapCanvasInputState();
 
 public:

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -19,6 +19,7 @@
 #include <optional>
 #include <unordered_map>
 
+#include <QCursor>
 #include <QOpenGLTexture>
 #include <QWindow>
 #include <QtGui/QMatrix4x4>
@@ -86,6 +87,10 @@ public:
 
 struct NODISCARD MapCanvasViewport
 {
+public:
+    static constexpr const int BASESIZE = 528;
+    static constexpr const int SCROLL_SCALE = 64;
+
 private:
     QWindow &m_window;
 
@@ -120,6 +125,22 @@ public:
     NODISCARD std::optional<MouseSel> getUnprojectedMouseSel(const QInputEvent *event) const;
     NODISCARD std::optional<MouseSel> getUnprojectedMouseSel(const glm::vec2 &xy) const;
     NODISCARD std::optional<glm::vec2> getMouseCoords(const QInputEvent *event) const;
+
+public:
+    void zoomAt(float factor, const glm::vec2 &mousePos, bool want3D);
+    void zoomIn() { m_scaleFactor.logStep(1); }
+    void zoomOut() { m_scaleFactor.logStep(-1); }
+    void zoomReset() { m_scaleFactor.set(1.f); }
+    void layerUp() { ++m_currentLayer; }
+    void layerDown() { --m_currentLayer; }
+    void layerReset() { m_currentLayer = 0; }
+    void centerOn(const Coordinate &pos);
+    void updateViewProj(bool want3D);
+
+protected:
+    NODISCARD float getPitchDegrees() const;
+    NODISCARD glm::mat4 getViewProj_old(const glm::ivec2 &size) const;
+    NODISCARD glm::mat4 getViewProj(const glm::ivec2 &size) const;
 };
 
 class NODISCARD MapScreen final
@@ -216,6 +237,36 @@ public:
     NODISCARD MouseSel getBackup() const { return getMouseSel(m_moveBackup); }
 
 public:
-    void startMoving(const MouseSel &startPos) { m_moveBackup = startPos; }
-    void stopMoving() { m_moveBackup.reset(); }
+    void startMoving(const MouseSel &startPos,
+                     const glm::vec2 &scroll,
+                     const glm::mat4 &viewProj)
+    {
+        m_moveBackup = startPos;
+        m_dragState.emplace(DragState{startPos.to_vec3(), scroll, viewProj});
+    }
+    void stopMoving()
+    {
+        m_moveBackup.reset();
+        m_dragState.reset();
+    }
+
+public:
+    struct NODISCARD AltDragState
+    {
+        QPoint lastPos;
+        QCursor originalCursor;
+    };
+    std::optional<AltDragState> m_altDragState;
+
+    struct NODISCARD DragState
+    {
+        glm::vec3 startWorldPos;
+        glm::vec2 startScroll;
+        glm::mat4 startViewProj;
+    };
+    std::optional<DragState> m_dragState;
+
+    float m_initialPinchDistance = 0.f;
+    float m_lastPinchFactor = 1.f;
+    float m_lastMagnification = 1.f;
 };

--- a/src/display/RoomSelections.cpp
+++ b/src/display/RoomSelections.cpp
@@ -124,12 +124,14 @@ void MapCanvas::paintSelectedRoom(RoomSelFakeGL &gl, const RawRoom &room)
     // This fake GL uses resetMatrix() before this function.
     gl.resetMatrix();
 
-    const float marginPixels = MapScreen::DEFAULT_MARGIN_PIXELS;
+    const float marginPixels = MapCanvasViewport::DEFAULT_MARGIN_PIXELS;
     const bool isMoving = hasRoomSelectionMove();
 
-    if (!isMoving && !m_mapScreen.isRoomVisible(roomPos, marginPixels / 2.f)) {
+    if (!isMoving && !isRoomVisible(roomPos, marginPixels / 2.f)) {
         const glm::vec3 roomCenter = roomPos.to_vec3() + glm::vec3{0.5f, 0.5f, 0.f};
-        const auto dot = DistantObjectTransform::construct(roomCenter, m_mapScreen, marginPixels);
+        const auto dot = DistantObjectTransform::construct(roomCenter,
+                                                           static_cast<MapCanvasViewport &>(*this),
+                                                           marginPixels);
         gl.glTranslatef(dot.offset.x, dot.offset.y, dot.offset.z);
         gl.glRotatef(dot.rotationDegrees, 0.f, 0.f, 1.f);
         const glm::vec2 iconCenter{0.5f, 0.5f};
@@ -137,7 +139,7 @@ void MapCanvas::paintSelectedRoom(RoomSelFakeGL &gl, const RawRoom &room)
 
         // Scale based upon distance
         const auto scaleFactor = std::invoke([this, roomCenter]() -> float {
-            const auto delta = roomCenter - m_mapScreen.getCenter();
+            const auto delta = roomCenter - getCenter();
             const auto distance = std::sqrt((delta.y * delta.y) + (delta.x * delta.x));
             // If we're too far away just scale down to 50% at most
             if (distance >= static_cast<float>(BASESIZE)) {

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -7,7 +7,6 @@
 #include "mapcanvas.h"
 
 #include "../configuration/configuration.h"
-#include "MapCanvasConfig.h"
 #include "../global/parserutils.h"
 #include "../global/progresscounter.h"
 #include "../global/utils.h"
@@ -20,6 +19,7 @@
 #include "../mapdata/mapdata.h"
 #include "../mapdata/roomselection.h"
 #include "InfomarkSelection.h"
+#include "MapCanvasConfig.h"
 #include "MapCanvasData.h"
 #include "MapCanvasRoomDrawer.h"
 #include "connectionselection.h"

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -64,7 +64,6 @@ MapCanvas::MapCanvas(MapData &mapData,
     : QOpenGLWindow{NoPartialUpdate, parent}
     , MapCanvasViewport{static_cast<QWindow &>(*this)}
     , MapCanvasInputState{prespammedPath}
-    , m_mapScreen{static_cast<MapCanvasViewport &>(*this)}
     , m_opengl{}
     , m_glFont{m_opengl}
     , m_data{mapData}
@@ -200,14 +199,9 @@ void MapCanvas::slot_setInfomarkSelection(const std::shared_ptr<InfomarkSelectio
     selectionChanged();
 }
 
-NODISCARD static uint32_t operator&(const Qt::KeyboardModifiers left, const Qt::Modifier right)
-{
-    return static_cast<uint32_t>(left) & static_cast<uint32_t>(right);
-}
-
 void MapCanvas::wheelEvent(QWheelEvent *const event)
 {
-    const bool hasCtrl = (event->modifiers() & Qt::CTRL) != 0u;
+    updateModifierState(event);
 
     switch (m_canvasMouseMode) {
     case CanvasMouseModeEnum::MOVE:
@@ -219,7 +213,7 @@ void MapCanvas::wheelEvent(QWheelEvent *const event)
     case CanvasMouseModeEnum::CREATE_ROOMS:
     case CanvasMouseModeEnum::CREATE_CONNECTIONS:
     case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
-        if (hasCtrl) {
+        if (m_ctrlPressed) {
             if (event->angleDelta().y() > 100) {
                 slot_layerDown();
             } else if (event->angleDelta().y() < -100) {
@@ -257,48 +251,14 @@ void MapCanvas::touchEvent(QTouchEvent *const event)
         emit sig_dismissContextMenu();
     }
 
-    const auto &points = event->points();
-    if (points.size() == 2) {
-        const auto &p1 = points[0];
-        const auto &p2 = points[1];
-
-        if (event->type() == QEvent::TouchBegin || p1.state() == QEventPoint::Pressed
-            || p2.state() == QEventPoint::Pressed) {
-            m_initialPinchDistance = glm::distance(glm::vec2(static_cast<float>(p1.position().x()),
-                                                             static_cast<float>(p1.position().y())),
-                                                   glm::vec2(static_cast<float>(p2.position().x()),
-                                                             static_cast<float>(p2.position().y())));
-            m_lastPinchFactor = 1.f;
-        }
-
-        if (m_initialPinchDistance > PINCH_DISTANCE_THRESHOLD) {
-            const float currentDistance
-                = glm::distance(glm::vec2(static_cast<float>(p1.position().x()),
-                                          static_cast<float>(p1.position().y())),
-                                glm::vec2(static_cast<float>(p2.position().x()),
-                                          static_cast<float>(p2.position().y())));
-            const float currentPinchFactor = currentDistance / m_initialPinchDistance;
-            const float deltaFactor = currentPinchFactor / m_lastPinchFactor;
-
-            handleZoomAtEvent(event, deltaFactor);
-            m_lastPinchFactor = currentPinchFactor;
-        }
-
-        if (event->type() == QEvent::TouchEnd || p1.state() == QEventPoint::Released
-            || p2.state() == QEventPoint::Released) {
-            m_initialPinchDistance = 0.f;
-            m_lastPinchFactor = 1.f;
-        }
+    if (const auto deltaFactor = calculatePinchDelta(event)) {
+        handleZoomAtEvent(event, *deltaFactor);
         event->accept();
     } else {
-        if (points.size() > 2) {
+        if (event->points().size() > 2) {
             // Explicitly ignore more than 2 touch points for pinch zoom.
-            qDebug() << "MapCanvas::touchEvent: ignoring" << points.size() << "touch points";
-        }
-
-        if (m_initialPinchDistance > 0.f) {
-            m_initialPinchDistance = 0.f;
-            m_lastPinchFactor = 1.f;
+            qDebug() << "MapCanvas::touchEvent: ignoring" << event->points().size()
+                     << "touch points";
         }
         QOpenGLWindow::touchEvent(event);
     }
@@ -318,24 +278,9 @@ bool MapCanvas::event(QEvent *const event)
     if (event->type() == QEvent::NativeGesture) {
         auto *const nativeEvent = static_cast<QNativeGestureEvent *>(event);
         if (nativeEvent->gestureType() == Qt::ZoomNativeGesture) {
-            const auto value = static_cast<float>(nativeEvent->value());
-            float deltaFactor = 1.f;
-            if constexpr (CURRENT_PLATFORM == PlatformEnum::Mac) {
-                // On macOS, event->value() for ZoomNativeGesture is the magnification delta
-                // since the last event.
-                deltaFactor += value;
-            } else {
-                // On other platforms, it's typically the cumulative scale factor (1.0 at start).
-                if (nativeEvent->isBeginEvent()) {
-                    m_lastMagnification = 1.f;
-                }
-
-                if (std::abs(m_lastMagnification) > GESTURE_EPSILON) {
-                    deltaFactor = value / m_lastMagnification;
-                }
-                m_lastMagnification = value;
+            if (const auto deltaFactor = calculateNativeZoomDelta(nativeEvent)) {
+                handleZoomAtEvent(nativeEvent, *deltaFactor);
             }
-            handleZoomAtEvent(nativeEvent, deltaFactor);
             event->accept();
             return true;
         }
@@ -365,54 +310,7 @@ void MapCanvas::slot_createRoom()
 // REVISIT: This function doesn't need to return a shared ptr. Consider refactoring InfomarkSelection?
 std::shared_ptr<InfomarkSelection> MapCanvas::getInfomarkSelection(const MouseSel &sel)
 {
-    static constexpr float CLICK_RADIUS = 10.f;
-
-    const auto center = sel.to_vec3();
-    const auto optClickPoint = project(center);
-    if (!optClickPoint) {
-        // This should never happen, so we'll crash in debug, but let's do something
-        // "sane" in release build since the assert will not trigger.
-        assert(false);
-
-        // This distance is in world space, but the mouse click is in screen space.
-        static_assert(INFOMARK_SCALE % 5 == 0);
-        static constexpr auto INFOMARK_CLICK_RADIUS = INFOMARK_SCALE / 5;
-        const auto pos = sel.getScaledCoordinate(INFOMARK_SCALE);
-        const auto lo = pos + Coordinate{-INFOMARK_CLICK_RADIUS, -INFOMARK_CLICK_RADIUS, 0};
-        const auto hi = pos + Coordinate{+INFOMARK_CLICK_RADIUS, +INFOMARK_CLICK_RADIUS, 0};
-        return InfomarkSelection::alloc(m_data, lo, hi);
-    }
-
-    const glm::vec2 clickPoint = glm::vec2{optClickPoint.value()};
-    glm::vec3 maxCoord = center;
-    glm::vec3 minCoord = center;
-
-    const auto probe = [this, &clickPoint, &maxCoord, &minCoord](const glm::vec2 &offset) -> void {
-        const auto coord = unproject_clamped(clickPoint + offset);
-        maxCoord = glm::max(maxCoord, coord);
-        minCoord = glm::min(minCoord, coord);
-    };
-
-    // screen space can rotate relative to world space, and the projected world
-    // space positions can be highly ansitropic (e.g. steep vertical angle),
-    // so we'll expand the search area by probing in all 45 and 90 degree angles
-    // from the mouse. This isn't perfect, but it should be good enough.
-    for (int dy = -1; dy <= 1; ++dy) {
-        for (int dx = -1; dx <= 1; ++dx) {
-            probe(glm::vec2{static_cast<float>(dx) * CLICK_RADIUS,
-                            static_cast<float>(dy) * CLICK_RADIUS});
-        }
-    }
-
-    const auto getScaled = [this](const glm::vec3 &c) -> Coordinate {
-        const auto pos = glm::ivec3(glm::vec2(c) * static_cast<float>(INFOMARK_SCALE),
-                                    m_currentLayer);
-        return Coordinate{pos.x, pos.y, pos.z};
-    };
-
-    const auto hi = getScaled(maxCoord);
-    const auto lo = getScaled(minCoord);
-
+    const auto [lo, hi] = calculateInfomarkProbeRange(sel);
     return InfomarkSelection::alloc(m_data, lo, hi);
 }
 
@@ -422,12 +320,10 @@ void MapCanvas::mousePressEvent(QMouseEvent *const event)
         emit sig_dismissContextMenu();
     }
 
-    const bool hasLeftButton = (event->buttons() & Qt::LeftButton) != 0u;
-    const bool hasRightButton = (event->buttons() & Qt::RightButton) != 0u;
-    const bool hasCtrl = (event->modifiers() & Qt::CTRL) != 0u;
-    MAYBE_UNUSED const bool hasAlt = (event->modifiers() & Qt::ALT) != 0u;
+    updateButtonState(event);
+    updateModifierState(event);
 
-    if (hasLeftButton && hasAlt) {
+    if (m_mouseLeftPressed && m_altPressed) {
         m_altDragState.emplace(AltDragState{event->position().toPoint(), cursor()});
         setCursor(Qt::ClosedHandCursor);
         event->accept();
@@ -445,9 +341,6 @@ void MapCanvas::mousePressEvent(QMouseEvent *const event)
     } else {
         m_sel1 = m_sel2 = getUnprojectedMouseSel(xy);
     }
-
-    m_mouseLeftPressed = hasLeftButton;
-    m_mouseRightPressed = hasRightButton;
 
     if (event->button() == Qt::ForwardButton) {
         slot_layerUp();
@@ -479,7 +372,7 @@ void MapCanvas::mousePressEvent(QMouseEvent *const event)
         break;
     case CanvasMouseModeEnum::SELECT_INFOMARKS:
         // Select infomarks
-        if (hasLeftButton && hasSel1()) {
+        if (m_mouseLeftPressed && hasSel1()) {
             auto tmpSel = getInfomarkSelection(getSel1());
             if (m_infoMarkSelection != nullptr && !tmpSel->empty()
                 && m_infoMarkSelection->contains(tmpSel->front().getId())) {
@@ -493,39 +386,16 @@ void MapCanvas::mousePressEvent(QMouseEvent *const event)
         selectionChanged();
         break;
     case CanvasMouseModeEnum::MOVE:
-        if (hasLeftButton && hasSel1()) {
+        if (m_mouseLeftPressed && hasSel1()) {
             setCursor(Qt::ClosedHandCursor);
             startMoving(m_sel1.value());
         }
         break;
 
     case CanvasMouseModeEnum::RAYPICK_ROOMS:
-        if (hasLeftButton) {
-            const auto near = unproject_raw(glm::vec3{xy, 0.f});
-            const auto far = unproject_raw(glm::vec3{xy, 1.f});
-
-            // Note: this rounding assumes we're looking down.
-            // We're looking for integer z-planes that cross between
-            // the hi and lo points.
-            const auto hiz = static_cast<int>(std::floor(near.z));
-            const auto loz = static_cast<int>(std::ceil(far.z));
-            if (hiz <= loz) {
-                break;
-            }
-
-            const auto inv_denom = 1.f / (far.z - near.z);
-
-            // REVISIT: This loop might feel laggy.
-            // Consider clamping the bounds of what we know we're currently displaying (including XY).
-            // (If you're looking almost parallel to the world, then the ray could pass through the
-            // visible region but still be within the visible Z-range.)
+        if (m_mouseLeftPressed) {
             RoomIdSet tmpSel;
-            for (int z = hiz; z >= loz; --z) {
-                const float t = (static_cast<float>(z) - near.z) * inv_denom;
-                assert(isClamped(t, 0.f, 1.f));
-                const auto pos = glm::mix(near, far, t);
-                assert(static_cast<int>(std::lround(pos.z)) == z);
-                const Coordinate c2 = MouseSel{Coordinate2f{pos.x, pos.y}, z}.getCoordinate();
+            for (const auto &c2 : calculateRaypickCoordinates(xy)) {
                 if (const auto r = m_data.findRoomHandle(c2)) {
                     tmpSel.insert(r.getId());
                 }
@@ -542,13 +412,13 @@ void MapCanvas::mousePressEvent(QMouseEvent *const event)
 
     case CanvasMouseModeEnum::SELECT_ROOMS:
         // Cancel
-        if (hasRightButton) {
+        if (m_mouseRightPressed) {
             m_selectedArea = false;
             slot_clearRoomSelection();
         }
         // Select rooms
-        if (hasLeftButton && hasSel1()) {
-            if (!hasCtrl) {
+        if (m_mouseLeftPressed && hasSel1()) {
+            if (!m_ctrlPressed) {
                 const auto pRoom = m_data.findRoomHandle(getSel1().getCoordinate());
                 if (pRoom.exists() && m_roomSelection != nullptr
                     && m_roomSelection->contains(pRoom.getId())) {
@@ -568,7 +438,7 @@ void MapCanvas::mousePressEvent(QMouseEvent *const event)
     case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
     case CanvasMouseModeEnum::CREATE_CONNECTIONS:
         // Select connection
-        if (hasLeftButton && hasSel1()) {
+        if (m_mouseLeftPressed && hasSel1()) {
             m_connectionSelection = ConnectionSelection::alloc(m_data, getSel1());
             if (!m_connectionSelection->isFirstValid()) {
                 m_connectionSelection = nullptr;
@@ -576,14 +446,14 @@ void MapCanvas::mousePressEvent(QMouseEvent *const event)
             emit sig_newConnectionSelection(nullptr);
         }
         // Cancel
-        if (hasRightButton) {
+        if (m_mouseRightPressed) {
             slot_clearConnectionSelection();
         }
         selectionChanged();
         break;
 
     case CanvasMouseModeEnum::SELECT_CONNECTIONS:
-        if (hasLeftButton && hasSel1()) {
+        if (m_mouseLeftPressed && hasSel1()) {
             m_connectionSelection = ConnectionSelection::alloc(m_data, getSel1());
             if (!m_connectionSelection->isFirstValid()) {
                 m_connectionSelection = nullptr;
@@ -598,7 +468,7 @@ void MapCanvas::mousePressEvent(QMouseEvent *const event)
             emit sig_newConnectionSelection(nullptr);
         }
         // Cancel
-        if (hasRightButton) {
+        if (m_mouseRightPressed) {
             slot_clearConnectionSelection();
         }
         selectionChanged();
@@ -624,79 +494,29 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
 
     if (m_altDragState.has_value()) {
         // The user released the Alt key mid-drag.
-        if (!((event->modifiers() & Qt::ALT) != 0u)) {
+        if (!((event->modifiers() & Qt::AltModifier) != 0u)) {
             setCursor(m_altDragState->originalCursor);
             m_altDragState.reset();
             // Don't accept the event; let the underlying widgets handle it.
             return;
         }
 
-        auto &conf = setConfig().canvas.advanced;
         auto &dragState = m_altDragState.value();
-        bool angleChanged = false;
-
         const auto pos = event->position().toPoint();
         const auto delta = pos - dragState.lastPos;
         dragState.lastPos = pos;
 
-        // Camera rotation sensitivity: 3 degree per pixel
-        constexpr float SENSITIVITY = 0.3f;
-
-        // Horizontal movement adjusts yaw (horizontalAngle)
-        const int dx = delta.x();
-        if (dx != 0) {
-            conf.horizontalAngle.set(conf.horizontalAngle.get()
-                                     + static_cast<int>(static_cast<float>(dx) * SENSITIVITY));
-            angleChanged = true;
-        }
-
-        // Vertical movement adjusts pitch (verticalAngle), if auto-tilt is off
-        if (!conf.autoTilt.get()) {
-            const int dy = delta.y();
-            if (dy != 0) {
-                // Negated to match intuitive up/down dragging
-                conf.verticalAngle.set(conf.verticalAngle.get()
-                                       + static_cast<int>(static_cast<float>(-dy) * SENSITIVITY));
-                angleChanged = true;
-            }
-        }
-
-        if (angleChanged) {
+        if (applyRotationDelta(delta.x(), delta.y())) {
             graphicsSettingsChanged();
         }
         event->accept();
         return;
     }
 
-    const bool hasLeftButton = (event->buttons() & Qt::LeftButton) != 0u;
+    updateButtonState(event);
 
     if (m_canvasMouseMode != CanvasMouseModeEnum::MOVE) {
-        // NOTE: Y is opposite of what you might expect here.
-        const int vScroll = std::invoke([this, &xy]() -> int {
-            const int h = height();
-            const int MARGIN = std::min(100, h / 4);
-            const auto y = static_cast<int>(static_cast<float>(h) - xy.y);
-            if (y < MARGIN) {
-                return SCROLL_SCALE;
-            } else if (y > h - MARGIN) {
-                return -SCROLL_SCALE;
-            } else {
-                return 0;
-            }
-        });
-        const int hScroll = std::invoke([this, &xy]() -> int {
-            const int w = width();
-            const int MARGIN = std::min(100, w / 4);
-            const auto x = static_cast<int>(xy.x);
-            if (x < MARGIN) {
-                return -SCROLL_SCALE;
-            } else if (x > w - MARGIN) {
-                return SCROLL_SCALE;
-            } else {
-                return 0;
-            }
-        });
-
+        const auto [hScroll, vScroll] = calculateContinuousScroll(xy);
         emit sig_continuousScroll(hScroll, vScroll);
     }
 
@@ -704,7 +524,7 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
 
     switch (m_canvasMouseMode) {
     case CanvasMouseModeEnum::SELECT_INFOMARKS:
-        if (hasLeftButton && hasSel1() && hasSel2()) {
+        if (m_mouseLeftPressed && hasSel1() && hasSel2()) {
             if (hasInfomarkSelectionMove()) {
                 m_infoMarkSelectionMove->pos = getSel2().pos - getSel1().pos;
                 setCursor(Qt::ClosedHandCursor);
@@ -716,21 +536,19 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
         selectionChanged();
         break;
     case CanvasMouseModeEnum::CREATE_INFOMARKS:
-        if (hasLeftButton) {
+        if (m_mouseLeftPressed) {
             m_selectedArea = true;
         }
         // REVISIT: It doesn't look like anything actually changed here?
         infomarksChanged();
         break;
     case CanvasMouseModeEnum::MOVE:
-        if (hasLeftButton && m_mouseLeftPressed && m_dragState.has_value()) {
-            const glm::vec3 currWorldPos = unproject_clamped(xy, m_dragState->startViewProj);
-            const glm::vec2 delta = glm::vec2(currWorldPos - m_dragState->startWorldPos);
-
-            if (glm::length(delta) > GESTURE_EPSILON) {
-                const glm::vec2 newWorldCenter = m_dragState->startScroll - delta;
-                m_scroll = newWorldCenter;
-                emit sig_onCenter(newWorldCenter);
+        if (m_mouseLeftPressed && m_dragState.has_value()) {
+            if (performPanning(xy,
+                               m_dragState->startWorldPos,
+                               m_dragState->startScroll,
+                               m_dragState->startViewProj)) {
+                emit sig_onCenter(m_scroll);
                 update();
             }
         }
@@ -740,7 +558,7 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
         break;
 
     case CanvasMouseModeEnum::SELECT_ROOMS:
-        if (hasLeftButton) {
+        if (m_mouseLeftPressed) {
             if (hasRoomSelectionMove() && hasSel1() && hasSel2()) {
                 auto &map = this->m_data;
                 auto isMovable = [&map](RoomSelection &sel, const Coordinate &offset) -> bool {
@@ -763,7 +581,7 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
 
     case CanvasMouseModeEnum::CREATE_ONEWAY_CONNECTIONS:
     case CanvasMouseModeEnum::CREATE_CONNECTIONS:
-        if (hasLeftButton && hasSel2()) {
+        if (m_mouseLeftPressed && hasSel2()) {
             if (m_connectionSelection != nullptr) {
                 m_connectionSelection->setSecond(getSel2());
 
@@ -779,7 +597,7 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
         break;
 
     case CanvasMouseModeEnum::SELECT_CONNECTIONS:
-        if (hasLeftButton && hasSel2()) {
+        if (m_mouseLeftPressed && hasSel2()) {
             if (m_connectionSelection != nullptr) {
                 m_connectionSelection->setSecond(getSel2());
 

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -54,8 +54,8 @@ class NODISCARD_QOBJECT MapCanvas final : public QOpenGLWindow,
     Q_OBJECT
 
 public:
-    static constexpr const int BASESIZE = 528; // REVISIT: Why this size? 16*33 isn't special.
-    static constexpr const int SCROLL_SCALE = 64;
+    using MapCanvasViewport::BASESIZE;
+    using MapCanvasViewport::SCROLL_SCALE;
 
 private:
     struct NODISCARD FrameRateController final
@@ -145,25 +145,6 @@ private:
     std::unique_ptr<QOpenGLDebugLogger> m_logger;
     Signal2Lifetime m_lifetime;
 
-    struct AltDragState
-    {
-        QPoint lastPos;
-        QCursor originalCursor;
-    };
-    std::optional<AltDragState> m_altDragState;
-
-    struct DragState
-    {
-        glm::vec3 startWorldPos;
-        glm::vec2 startScroll;
-        glm::mat4 startViewProj;
-    };
-    std::optional<DragState> m_dragState;
-
-    float m_initialPinchDistance = 0.f;
-    float m_lastPinchFactor = 1.f;
-    float m_lastMagnification = 1.f;
-
 public:
     explicit MapCanvas(MapData &mapData,
                        PrespammedPath &prespammedPath,
@@ -229,14 +210,7 @@ private:
     void updateMultisampling();
 
     NODISCARD std::shared_ptr<InfomarkSelection> getInfomarkSelection(const MouseSel &sel);
-    NODISCARD static glm::mat4 getViewProj_old(const glm::vec2 &scrollPos,
-                                               const glm::ivec2 &size,
-                                               float zoomScale,
-                                               int currentLayer);
-    NODISCARD static glm::mat4 getViewProj(const glm::vec2 &scrollPos,
-                                           const glm::ivec2 &size,
-                                           float zoomScale,
-                                           int currentLayer);
+
     void setMvp(const glm::mat4 &viewProj);
     void setViewportAndMvp(int width, int height);
 

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -133,7 +133,6 @@ private:
     };
 
 private:
-    MapScreen m_mapScreen;
     OpenGL m_opengl;
     GLFont m_glFont;
     Batches m_batches;

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -335,7 +335,6 @@ void MapCanvas::initLogger()
                              QOpenGLDebugMessage::AnySeverity);
 }
 
-
 void MapCanvas::setMvp(const glm::mat4 &viewProj)
 {
     auto &gl = getOpenGL();

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -816,7 +816,7 @@ void MapCanvas::paintGL()
                             static_cast<double>(zoom),
                             1.0 / static_cast<double>(zoom)));
 
-    const auto ctr = m_mapScreen.getCenter();
+    const auto ctr = getCenter();
     print(QString::asprintf("center: %.1f, %.1f, %.1f",
                             static_cast<double>(ctr.x),
                             static_cast<double>(ctr.y),

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -335,120 +335,6 @@ void MapCanvas::initLogger()
                              QOpenGLDebugMessage::AnySeverity);
 }
 
-glm::mat4 MapCanvas::getViewProj_old(const glm::vec2 &scrollPos,
-                                     const glm::ivec2 &size,
-                                     const float zoomScale,
-                                     const int /*currentLayer*/)
-{
-    constexpr float FIXED_VIEW_DISTANCE = 60.f;
-    constexpr float ROOM_Z_SCALE = 7.f;
-    constexpr auto baseSize = static_cast<float>(BASESIZE);
-
-    const float swp = zoomScale * baseSize / static_cast<float>(size.x);
-    const float shp = zoomScale * baseSize / static_cast<float>(size.y);
-
-    QMatrix4x4 proj;
-    proj.frustum(-0.5f, +0.5f, -0.5f, 0.5f, 5.f, 10000.f);
-    proj.scale(swp, shp, 1.f);
-    proj.translate(-scrollPos.x, -scrollPos.y, -FIXED_VIEW_DISTANCE);
-    proj.scale(1.f, 1.f, ROOM_Z_SCALE);
-
-    return glm::make_mat4(proj.constData());
-}
-
-NODISCARD static float getPitchDegrees(const float zoomScale)
-{
-    const float degrees = getConfig().canvas.advanced.verticalAngle.getFloat();
-    if (!MapCanvasConfig::isAutoTilt()) {
-        return degrees;
-    }
-
-    static_assert(ScaleFactor::MAX_VALUE >= 2.f);
-    return glm::smoothstep(0.5f, 2.f, zoomScale) * degrees;
-}
-
-glm::mat4 MapCanvas::getViewProj(const glm::vec2 &scrollPos,
-                                 const glm::ivec2 &size,
-                                 const float zoomScale,
-                                 const int currentLayer)
-{
-    static_assert(GLM_CONFIG_CLIP_CONTROL == GLM_CLIP_CONTROL_RH_NO);
-
-    const int width = size.x;
-    const int height = size.y;
-
-    const float aspect = static_cast<float>(width) / static_cast<float>(height);
-
-    const auto &advanced = getConfig().canvas.advanced;
-    const float fovDegrees = advanced.fov.getFloat();
-    const auto pitchRadians = glm::radians(getPitchDegrees(zoomScale));
-    const auto yawRadians = glm::radians(advanced.horizontalAngle.getFloat());
-    const auto layerHeight = advanced.layerHeight.getFloat();
-
-    const auto pixelScale = std::invoke([aspect, fovDegrees, width]() -> float {
-        constexpr float HARDCODED_LOGICAL_PIXELS = 44.f;
-        const auto dummyProj = glm::perspective(glm::radians(fovDegrees), aspect, 1.f, 10.f);
-
-        const auto centerRoomProj = glm::inverse(dummyProj) * glm::vec4(0.f, 0.f, 0.f, 1.f);
-        const auto centerRoom = glm::vec3(centerRoomProj) / centerRoomProj.w;
-
-        // Use east instead of north, so that tilted perspective matches horizontally.
-        const auto oneRoomEast = dummyProj * glm::vec4(centerRoom + glm::vec3(1.f, 0.f, 0.f), 1.f);
-        const float clipDist = std::abs(oneRoomEast.x / oneRoomEast.w);
-        const float ndcDist = clipDist * 0.5f;
-
-        // width is in logical pixels
-        const float screenDist = ndcDist * static_cast<float>(width);
-        const auto pixels = std::abs(centerRoom.z) * screenDist;
-        return pixels / HARDCODED_LOGICAL_PIXELS;
-    });
-
-    const float ZSCALE = layerHeight;
-    const float camDistance = pixelScale / zoomScale;
-    const auto center = glm::vec3(scrollPos, static_cast<float>(currentLayer) * ZSCALE);
-
-    // The view matrix will transform from world space to eye-space.
-    // Eye space has the camera at the origin, with +X right, +Y up, and -Z forward.
-    //
-    // Our camera's orientation is based on the world-space ENU coordinates.
-    // We'll define right-handed basis vectors forward, right, and up.
-
-    // The horizontal rotation in the XY plane will affect both forward and right vectors.
-    // Currently the convention is: -45 is northwest, and +45 is northeast.
-    //
-    // If you want to modify this, keep in mind that the angle is inverted since the
-    // camera is subtracted from the center, so the result is that positive angle
-    // appears clockwise (backwards) on screen.
-    const auto rotateHorizontal = glm::mat3(
-        glm::rotate(glm::mat4(1), -yawRadians, glm::vec3(0, 0, 1)));
-
-    // Our unrotated pitch is defined so that 0 is straight down, and 90 degrees is north,
-    // but the yaw rotation can cause it to point northeast or northwest.
-    //
-    // Here we use an ENU coordinate system, so we have:
-    //   forward(pitch= 0 degrees) = -Z (down), and
-    //   forward(pitch=90 degrees) = +Y (north).
-    const auto forward = rotateHorizontal
-                         * glm::vec3(0.f, std::sin(pitchRadians), -std::cos(pitchRadians));
-    // Unrotated right is east (+X).
-    const auto right = rotateHorizontal * glm::vec3(1, 0, 0);
-    // right x forward = up
-    const auto up = glm::cross(right, glm::normalize(forward));
-
-    // Subtract because camera looks at the center.
-    const auto eye = center - camDistance * forward;
-
-    // NOTE: may need to modify near and far planes by pixelScale and zoomScale.
-    // Be aware that a 24-bit depth buffer only gives about 12 bits of usable
-    // depth range; we may need to reduce this for people with 16-bit depth buffers.
-    // Keep in mind: Arda is about 600x300 rooms, so viewing the blue mountains
-    // from mordor requires approx 700 room units of view distance.
-    const auto proj = glm::perspective(glm::radians(fovDegrees), aspect, 0.25f, 1024.f);
-    const auto view = glm::lookAt(eye, center, up);
-    const auto scaleZ = glm::scale(glm::mat4(1), glm::vec3(1.f, 1.f, ZSCALE));
-
-    return proj * view * scaleZ;
-}
 
 void MapCanvas::setMvp(const glm::mat4 &viewProj)
 {
@@ -459,19 +345,10 @@ void MapCanvas::setMvp(const glm::mat4 &viewProj)
 
 void MapCanvas::setViewportAndMvp(int width, int height)
 {
-    const bool want3D = getConfig().canvas.advanced.use3D.get();
-
-    auto &gl = getOpenGL();
-
-    gl.glViewport(0, 0, width, height);
-    const auto size = getViewport().size;
-    assert(size.x == width);
-    assert(size.y == height);
-
-    const float zoomScale = getTotalScaleFactor();
-    const auto viewProj = (!want3D) ? getViewProj_old(m_scroll, size, zoomScale, m_currentLayer)
-                                    : getViewProj(m_scroll, size, zoomScale, m_currentLayer);
-    setMvp(viewProj);
+    const bool want3D = MapCanvasConfig::isIn3dMode();
+    getOpenGL().glViewport(0, 0, width, height);
+    MapCanvasViewport::updateViewProj(want3D);
+    getOpenGL().setProjectionMatrix(m_viewProj);
 }
 
 void MapCanvas::resizeGL(int width, int height)
@@ -924,7 +801,7 @@ void MapCanvas::paintGL()
     if (is3d) {
         print(QString::asprintf("3d mode: %.1f fovy, %.1f pitch, %.1f yaw, %.1f zscale",
                                 advanced.fov.getDouble(),
-                                static_cast<double>(getPitchDegrees(zoom)),
+                                static_cast<double>(getPitchDegrees()),
                                 advanced.horizontalAngle.getDouble(),
                                 advanced.layerHeight.getDouble()));
     } else {


### PR DESCRIPTION
This refactoring improves the maintainability and cleanliness of the MapCanvas class by delegating viewport-related math and interaction state management to its private base classes, MapCanvasViewport and MapCanvasInputState. This ensures a better separation of concerns while maintaining the existing inheritance-based architectural pattern.

---
*PR created automatically by Jules for task [16062342575276383798](https://jules.google.com/task/16062342575276383798) started by @nschimme*