### PR TITLE
Resolve WebGL2 UBO size mismatch warning for weather shaders

### DIFF
--- a/src/display/WeatherRenderer.cpp
+++ b/src/display/WeatherRenderer.cpp
@@ -374,7 +374,7 @@ void WeatherRenderer::updateUbo(const glm::mat4 &viewProj)
     }
 
     GLRenderState::Uniforms::Weather::Frame f;
-    f.time = glm::vec2(m_state.animationTime, m_state.lastDt);
+    f.time = glm::vec4(m_state.animationTime, m_state.lastDt, 0.0f, 0.0f);
 
     funcs.glBindBuffer(GL_UNIFORM_BUFFER, vboFrame->get());
     funcs.glBufferData(GL_UNIFORM_BUFFER, sizeof(f), &f, GL_DYNAMIC_DRAW);

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -254,7 +254,7 @@ struct NODISCARD GLRenderState final
             // TimeBlock (Binding 2)
             struct NODISCARD Frame final
             {
-                glm::vec2 time{0.0f}; // 0-7 (x=time, y=delta)
+                glm::vec4 time{0.0f}; // 0-15 (x=time, y=delta, zw=unused)
             } frame;
         } weather;
     };

--- a/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/room/tex/acolor/vert.glsl
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 The MMapper Authors
 
 uniform mat4 uMVP;
-uniform NamedColorsBlock {
+layout(std140) uniform NamedColorsBlock
+{
     vec4 uNamedColors[MAX_NAMED_COLORS];
 };
 

--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -20,7 +20,7 @@ layout(std140) uniform WeatherBlock
 
 layout(std140) uniform TimeBlock
 {
-    vec2 uTime; // x=time, y=delta
+    vec4 uTime; // x=time, y=delta, zw=unused
 };
 
 uniform sampler2D uNoiseTex;

--- a/src/resources/shaders/legacy/weather/particle/frag.glsl
+++ b/src/resources/shaders/legacy/weather/particle/frag.glsl
@@ -20,7 +20,7 @@ layout(std140) uniform WeatherBlock
 
 layout(std140) uniform TimeBlock
 {
-    vec2 uTime; // x=time, y=delta
+    vec4 uTime; // x=time, y=delta, zw=unused
 };
 
 in float vLife;

--- a/src/resources/shaders/legacy/weather/particle/vert.glsl
+++ b/src/resources/shaders/legacy/weather/particle/vert.glsl
@@ -16,7 +16,7 @@ layout(std140) uniform WeatherBlock
 
 layout(std140) uniform TimeBlock
 {
-    vec2 uTime; // x=time, y=delta
+    vec4 uTime; // x=time, y=delta, zw=unused
 };
 
 uniform float uType;

--- a/src/resources/shaders/legacy/weather/simulation/vert.glsl
+++ b/src/resources/shaders/legacy/weather/simulation/vert.glsl
@@ -16,7 +16,7 @@ layout(std140) uniform WeatherBlock
 
 layout(std140) uniform TimeBlock
 {
-    vec2 uTime; // x=time, y=delta
+    vec4 uTime; // x=time, y=delta, zw=unused
 };
 
 out vec2 vPos;

--- a/src/resources/shaders/legacy/weather/timeofday/frag.glsl
+++ b/src/resources/shaders/legacy/weather/timeofday/frag.glsl
@@ -20,7 +20,7 @@ layout(std140) uniform WeatherBlock
 
 layout(std140) uniform TimeBlock
 {
-    vec2 uTime; // x=time, y=delta
+    vec4 uTime; // x=time, y=delta, zw=unused
 };
 
 out vec4 vFragmentColor;


### PR DESCRIPTION
The WebGL2 warning "drawArraysInstanced: Buffer for uniform block is smaller than UNIFORM_BLOCK_DATA_SIZE" was caused by the `TimeBlock` uniform block being only 8 bytes (`vec2`) while the `std140` layout requires a minimum block size of 16 bytes (the size of a `vec4`).

This PR:
- Updates `GLRenderState::Uniforms::Weather::Frame` in `src/opengl/OpenGLTypes.h` to use `glm::vec4`.
- Updates `WeatherRenderer::updateUbo` in `src/display/WeatherRenderer.cpp` to populate the `vec4`.
- Updates all weather shaders to declare `TimeBlock` as `vec4`.
- Adds `layout(std140)` to `NamedColorsBlock` in `src/resources/shaders/legacy/room/tex/acolor/vert.glsl` for consistency.

---
*PR created automatically by Jules for task [7115420100884331022](https://jules.google.com/task/7115420100884331022) started by @nschimme*