### PR TITLE
Add flickering artificial light effect to Time-of-Day shader

### DIFF
--- a/src/display/WeatherRenderables.cpp
+++ b/src/display/WeatherRenderables.cpp
@@ -87,6 +87,34 @@ void WeatherTimeOfDayMesh::virt_render(const GLRenderState &renderState)
     m_functions.glDrawArrays(GL_TRIANGLES, 0, 3);
 }
 
+// WeatherTorchMesh
+
+WeatherTorchMesh::WeatherTorchMesh(SharedFunctions shared_functions)
+    : m_shared_functions(std::move(shared_functions))
+    , m_functions(deref(m_shared_functions))
+{}
+
+WeatherTorchMesh::~WeatherTorchMesh() = default;
+
+void WeatherTorchMesh::virt_render(const GLRenderState &renderState)
+{
+    auto &prog = deref(m_functions.getShaderPrograms().getTorchShader());
+    auto binder = prog.bind();
+
+    RenderStateBinder rsBinder(m_functions, m_functions.getTexLookup(), renderState);
+
+    const glm::mat4 mvp = m_functions.getProjectionMatrix();
+    prog.setUniforms(mvp, renderState.uniforms);
+
+    auto emptyVao = m_functions.getSharedVaos().get(SharedVaoEnum::EmptyVao);
+    if (!*emptyVao) {
+        emptyVao->emplace(m_shared_functions);
+    }
+    VAOBinder vaoBinder(m_functions, emptyVao);
+
+    m_functions.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
 // WeatherSimulationMesh
 
 WeatherSimulationMesh::WeatherSimulationMesh(SharedFunctions shared_functions,

--- a/src/display/WeatherRenderables.h
+++ b/src/display/WeatherRenderables.h
@@ -65,6 +65,23 @@ private:
     void virt_render(const GLRenderState &renderState) override;
 };
 
+class NODISCARD WeatherTorchMesh final : public IRenderable
+{
+private:
+    const SharedFunctions m_shared_functions;
+    Functions &m_functions;
+
+public:
+    explicit WeatherTorchMesh(SharedFunctions shared_functions);
+    ~WeatherTorchMesh() override;
+
+private:
+    void virt_clear() override {}
+    void virt_reset() override {}
+    NODISCARD bool virt_isEmpty() const override { return false; }
+    void virt_render(const GLRenderState &renderState) override;
+};
+
 class NODISCARD WeatherParticleMesh final : public IRenderable
 {
 private:

--- a/src/display/WeatherRenderer.cpp
+++ b/src/display/WeatherRenderer.cpp
@@ -296,7 +296,7 @@ void WeatherRenderer::invalidateStatic()
 
 void WeatherRenderer::init()
 {
-    if (!m_simulation || !m_particles || !m_atmosphere || !m_timeOfDay) {
+    if (!m_simulation || !m_particles || !m_atmosphere || !m_timeOfDay || !m_torch) {
         auto funcs = m_gl.getSharedFunctions(Badge<WeatherRenderer>{});
         m_simulation = UniqueMesh(std::make_unique<Legacy::WeatherSimulationMesh>(funcs, *this));
         m_particles = UniqueMesh(std::make_unique<Legacy::WeatherParticleMesh>(funcs, *this));
@@ -305,6 +305,7 @@ void WeatherRenderer::init()
                                                  std::make_unique<Legacy::WeatherAtmosphereMesh>(
                                                      funcs)));
         m_timeOfDay = UniqueMesh(std::make_unique<Legacy::WeatherTimeOfDayMesh>(funcs));
+        m_torch = UniqueMesh(std::make_unique<Legacy::WeatherTorchMesh>(funcs));
     }
 }
 
@@ -515,7 +516,13 @@ void WeatherRenderer::renderAtmosphere(const glm::mat4 & /*viewProj*/)
         m_timeOfDay.render(rs);
     }
 
-    // 2. Render Atmosphere Overlay (Fog/Clouds)
+    // 2. Render Torch Effect (Localized Quad)
+    if (m_state.targetArtificialLightIntensity > 0.0f
+        || m_state.artificialLightIntensityStart > 0.0f) {
+        m_torch.render(rs);
+    }
+
+    // 3. Render Atmosphere Overlay (Fog/Clouds)
     const float cloudMax = std::max(m_state.cloudsIntensityStart, m_state.targetCloudsIntensity);
     const float fogMax = std::max(m_state.fogIntensityStart, m_state.targetFogIntensity);
 

--- a/src/display/WeatherRenderer.cpp
+++ b/src/display/WeatherRenderer.cpp
@@ -235,8 +235,8 @@ WeatherRenderer::WeatherRenderer(OpenGL &gl,
                   / TRANSITION_DURATION;
         float factor = std::clamp(t, 0.0f, 1.0f);
         m_state.artificialLightIntensityStart = my_lerp(m_state.artificialLightIntensityStart,
-                                                         m_state.targetArtificialLightIntensity,
-                                                         factor);
+                                                        m_state.targetArtificialLightIntensity,
+                                                        factor);
 
         m_state.isArtificialLight = isArtificial;
         m_state.targetArtificialLightIntensity = isArtificial ? 1.0f : 0.0f;

--- a/src/display/WeatherRenderer.h
+++ b/src/display/WeatherRenderer.h
@@ -37,6 +37,7 @@ public:
         float fogIntensityStart = 0.0f;
         float timeOfDayIntensityStart = 0.0f;
         float moonIntensityStart = 0.0f;
+        float artificialLightIntensityStart = 0.0f;
 
         float targetRainIntensity = 0.0f;
         float targetSnowIntensity = 0.0f;
@@ -44,6 +45,7 @@ public:
         float targetFogIntensity = 0.0f;
         float targetTimeOfDayIntensity = 0.0f;
         float targetMoonIntensity = 0.0f;
+        float targetArtificialLightIntensity = 0.0f;
 
         float precipitationTypeStart = 0.0f;
         float targetPrecipitationType = 0.0f;
@@ -57,6 +59,7 @@ public:
         MumeTimeEnum oldTimeOfDay = MumeTimeEnum::DAY;
         MumeTimeEnum currentTimeOfDay = MumeTimeEnum::DAY;
         MumeMoonVisibilityEnum moonVisibility = MumeMoonVisibilityEnum::UNKNOWN;
+        bool isArtificialLight = false;
 
         float weatherTransitionStartTime = -2.0f;
         float timeOfDayTransitionStartTime = -2.0f;

--- a/src/display/WeatherRenderer.h
+++ b/src/display/WeatherRenderer.h
@@ -85,6 +85,7 @@ private:
     UniqueMesh m_particles;
     UniqueMesh m_atmosphere;
     UniqueMesh m_timeOfDay;
+    UniqueMesh m_torch;
     std::optional<GLRenderState::Uniforms::Weather::Static> m_staticWeather;
     glm::mat4 m_lastViewProj{0.0f};
 

--- a/src/global/NamedColors.cpp
+++ b/src/global/NamedColors.cpp
@@ -66,8 +66,7 @@ public:
                                Color(76, 51, 102, 51)); // 0.3, 0.2, 0.4, 0.2
         std::ignore = setColor(NamedColorEnum::WEATHER_NIGHT,
                                Color(13, 13, 51, 89)); // 0.05, 0.05, 0.2, 0.35
-        std::ignore = setColor(NamedColorEnum::WEATHER_TORCH,
-                               Color(255, 150, 50, 180));
+        std::ignore = setColor(NamedColorEnum::WEATHER_TORCH, Color(255, 150, 50, 180));
     }
 
 public:

--- a/src/global/NamedColors.cpp
+++ b/src/global/NamedColors.cpp
@@ -66,6 +66,8 @@ public:
                                Color(76, 51, 102, 51)); // 0.3, 0.2, 0.4, 0.2
         std::ignore = setColor(NamedColorEnum::WEATHER_NIGHT,
                                Color(13, 13, 51, 89)); // 0.05, 0.05, 0.2, 0.35
+        std::ignore = setColor(NamedColorEnum::WEATHER_TORCH,
+                               Color(255, 150, 50, 180));
     }
 
 public:

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -42,7 +42,8 @@
     X(WALL_COLOR_SPECIAL, "wall-special") \
     X(WEATHER_DAWN, "weather-dawn") \
     X(WEATHER_DUSK, "weather-dusk") \
-    X(WEATHER_NIGHT, "weather-night")
+    X(WEATHER_NIGHT, "weather-night") \
+    X(WEATHER_TORCH, "weather-torch")
 
 #define X_DECL(_id, _name) _id,
 enum class NODISCARD NamedColorEnum : uint8_t { DEFAULT = 0, XFOREACH_NAMED_COLOR_OPTIONS(X_DECL) };

--- a/src/map/PromptFlags.h
+++ b/src/map/PromptFlags.h
@@ -37,14 +37,13 @@ class NODISCARD PromptFlagsType final
 public:
     static constexpr const auto LIT_ROOM = 1u;
     static constexpr const auto DARK_ROOM = 1u << 1;
-    static constexpr const auto ARTIFICIAL_ROOM = 1u << 2;
-    static constexpr const auto LIGHT_MASK = LIT_ROOM | DARK_ROOM | ARTIFICIAL_ROOM;
-    static constexpr const auto PROMPT_FLAGS_VALID = 1u << 3;
-    // bit4-5 -> PromptFogEnum
-    static constexpr uint32_t FOG_SHIFT = 4u;
+    static constexpr const auto LIGHT_MASK = LIT_ROOM | DARK_ROOM;
+    static constexpr const auto PROMPT_FLAGS_VALID = 1u << 2;
+    // bit3-4 -> PromptFogEnum
+    static constexpr uint32_t FOG_SHIFT = 3u;
     static constexpr const auto FOG_TYPE = 0b11u << FOG_SHIFT;
-    // bit6-10 -> PromptWeatherEnum
-    static constexpr uint32_t WEATHER_SHIFT = 6u;
+    // bit5-9 -> PromptWeatherEnum
+    static constexpr uint32_t WEATHER_SHIFT = 5u;
     static constexpr const auto WEATHER_TYPE = 0b111u << WEATHER_SHIFT;
 
 private:
@@ -118,12 +117,10 @@ public:
         m_flags = static_cast<flags_type>(m_flags & ~LIGHT_MASK);
         m_flags = static_cast<flags_type>(m_flags | (DARK_ROOM & LIGHT_MASK));
     }
-    NODISCARD bool isArtificial() const { return (m_flags & ARTIFICIAL_ROOM) != 0; }
     void setArtificial()
     {
         using flags_type = decltype(m_flags);
         m_flags = static_cast<flags_type>(m_flags & ~LIGHT_MASK);
-        m_flags = static_cast<flags_type>(m_flags | (ARTIFICIAL_ROOM & LIGHT_MASK));
     }
 
 public:

--- a/src/map/PromptFlags.h
+++ b/src/map/PromptFlags.h
@@ -37,13 +37,14 @@ class NODISCARD PromptFlagsType final
 public:
     static constexpr const auto LIT_ROOM = 1u;
     static constexpr const auto DARK_ROOM = 1u << 1;
-    static constexpr const auto LIGHT_MASK = LIT_ROOM | DARK_ROOM;
-    static constexpr const auto PROMPT_FLAGS_VALID = 1u << 2;
-    // bit3-4 -> PromptFogEnum
-    static constexpr uint32_t FOG_SHIFT = 3u;
+    static constexpr const auto ARTIFICIAL_ROOM = 1u << 2;
+    static constexpr const auto LIGHT_MASK = LIT_ROOM | DARK_ROOM | ARTIFICIAL_ROOM;
+    static constexpr const auto PROMPT_FLAGS_VALID = 1u << 3;
+    // bit4-5 -> PromptFogEnum
+    static constexpr uint32_t FOG_SHIFT = 4u;
     static constexpr const auto FOG_TYPE = 0b11u << FOG_SHIFT;
-    // bit5-9 -> PromptWeatherEnum
-    static constexpr uint32_t WEATHER_SHIFT = 5u;
+    // bit6-10 -> PromptWeatherEnum
+    static constexpr uint32_t WEATHER_SHIFT = 6u;
     static constexpr const auto WEATHER_TYPE = 0b111u << WEATHER_SHIFT;
 
 private:
@@ -117,10 +118,12 @@ public:
         m_flags = static_cast<flags_type>(m_flags & ~LIGHT_MASK);
         m_flags = static_cast<flags_type>(m_flags | (DARK_ROOM & LIGHT_MASK));
     }
+    NODISCARD bool isArtificial() const { return (m_flags & ARTIFICIAL_ROOM) != 0; }
     void setArtificial()
     {
         using flags_type = decltype(m_flags);
         m_flags = static_cast<flags_type>(m_flags & ~LIGHT_MASK);
+        m_flags = static_cast<flags_type>(m_flags | (ARTIFICIAL_ROOM & LIGHT_MASK));
     }
 
 public:

--- a/src/observer/gameobserver.cpp
+++ b/src/observer/gameobserver.cpp
@@ -51,6 +51,14 @@ void GameObserver::observeFog(const PromptFogEnum fog)
     }
 }
 
+void GameObserver::observeArtificialLight(const bool artificialLight)
+{
+    if (m_artificialLight != artificialLight) {
+        m_artificialLight = artificialLight;
+        sig2_artificialLightChanged.invoke(m_artificialLight);
+    }
+}
+
 void GameObserver::observeTimeOfDay(MumeTimeEnum timeOfDay)
 {
     if (m_timeOfDay != timeOfDay) {

--- a/src/observer/gameobserver.h
+++ b/src/observer/gameobserver.h
@@ -25,6 +25,7 @@ public:
     Signal2<MumeSeasonEnum> sig2_seasonChanged;
     Signal2<PromptWeatherEnum> sig2_weatherChanged;
     Signal2<PromptFogEnum> sig2_fogChanged;
+    Signal2<bool> sig2_artificialLightChanged;
     Signal2<MumeMoment> sig2_tick;
 
     Signal2<> sig2_gainedLevel;
@@ -36,6 +37,7 @@ private:
     MumeSeasonEnum m_season = MumeSeasonEnum::UNKNOWN;
     PromptWeatherEnum m_weather = PromptWeatherEnum::NICE;
     PromptFogEnum m_fog = PromptFogEnum::NO_FOG;
+    bool m_artificialLight = false;
 
 public:
     void observeConnected();
@@ -50,6 +52,7 @@ public:
     void observeSeason(MumeSeasonEnum season);
     void observeWeather(PromptWeatherEnum weather);
     void observeFog(PromptFogEnum fog);
+    void observeArtificialLight(bool artificialLight);
     void observeTick(const MumeMoment &moment) { sig2_tick.invoke(moment); }
 
     void observeGainedLevel() { sig2_gainedLevel.invoke(); }
@@ -61,4 +64,5 @@ public:
     MumeSeasonEnum getSeason() const { return m_season; }
     PromptWeatherEnum getWeather() const { return m_weather; }
     PromptFogEnum getFog() const { return m_fog; }
+    bool getArtificialLight() const { return m_artificialLight; }
 };

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -249,6 +249,8 @@ struct NODISCARD GLRenderState final
                     0.0f}; // 112-127 (x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget)
                 glm::vec4 config{
                     0.0f}; // 128-143 (x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused)
+                glm::vec4 torch{
+                    0.0f}; // 144-159 (x=startIntensity, y=targetIntensity, z=colorIdx, w=unused)
             } data;
 
             // TimeBlock (Binding 2)

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -41,6 +41,7 @@ BlitShader::~BlitShader() = default;
 FullScreenShader::~FullScreenShader() = default;
 AtmosphereShader::~AtmosphereShader() = default;
 TimeOfDayShader::~TimeOfDayShader() = default;
+TorchShader::~TorchShader() = default;
 ParticleSimulationShader::~ParticleSimulationShader() = default;
 ParticleRenderShader::~ParticleRenderShader() = default;
 
@@ -59,6 +60,7 @@ void ShaderPrograms::early_init()
     std::ignore = getFullScreenShader();
     std::ignore = getAtmosphereShader();
     std::ignore = getTimeOfDayShader();
+    std::ignore = getTorchShader();
     std::ignore = getParticleSimulationShader();
     std::ignore = getParticleRenderShader();
 }
@@ -78,6 +80,7 @@ void ShaderPrograms::resetAll()
     m_fullscreen.reset();
     m_atmosphere.reset();
     m_timeOfDay.reset();
+    m_torch.reset();
     m_particleSimulation.reset();
     m_particleRender.reset();
 }
@@ -164,6 +167,11 @@ const std::shared_ptr<AtmosphereShader> &ShaderPrograms::getAtmosphereShader()
 const std::shared_ptr<TimeOfDayShader> &ShaderPrograms::getTimeOfDayShader()
 {
     return getInitialized<TimeOfDayShader>(m_timeOfDay, getFunctions(), "weather/timeofday");
+}
+
+const std::shared_ptr<TorchShader> &ShaderPrograms::getTorchShader()
+{
+    return getInitialized<TorchShader>(m_torch, getFunctions(), "weather/torch");
 }
 
 const std::shared_ptr<ParticleSimulationShader> &ShaderPrograms::getParticleSimulationShader()

--- a/src/opengl/legacy/Shaders.h
+++ b/src/opengl/legacy/Shaders.h
@@ -184,6 +184,19 @@ private:
     {}
 };
 
+struct NODISCARD TorchShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~TorchShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 & /*mvp*/,
+                          const GLRenderState::Uniforms & /*uniforms*/) final
+    {}
+};
+
 struct NODISCARD ParticleSimulationShader final : public AbstractShaderProgram
 {
 public:
@@ -232,6 +245,7 @@ private:
     std::shared_ptr<FullScreenShader> m_fullscreen;
     std::shared_ptr<AtmosphereShader> m_atmosphere;
     std::shared_ptr<TimeOfDayShader> m_timeOfDay;
+    std::shared_ptr<TorchShader> m_torch;
     std::shared_ptr<ParticleSimulationShader> m_particleSimulation;
     std::shared_ptr<ParticleRenderShader> m_particleRender;
 
@@ -268,6 +282,7 @@ public:
     NODISCARD const std::shared_ptr<FullScreenShader> &getFullScreenShader();
     NODISCARD const std::shared_ptr<AtmosphereShader> &getAtmosphereShader();
     NODISCARD const std::shared_ptr<TimeOfDayShader> &getTimeOfDayShader();
+    NODISCARD const std::shared_ptr<TorchShader> &getTorchShader();
     NODISCARD const std::shared_ptr<ParticleSimulationShader> &getParticleSimulationShader();
     NODISCARD const std::shared_ptr<ParticleRenderShader> &getParticleRenderShader();
 

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -336,7 +336,9 @@ void MumeXmlParser::parseGmcpCharVitals(const JsonObj &obj)
             qWarning().noquote() << "prompt has unknown light flag:" << *light;
         }
     }
-    m_observer.observeArtificialLight(promptFlags.isArtificial());
+    const bool isArtificial = !promptFlags.isLit() && !promptFlags.isDark()
+                              && promptFlags.isValid();
+    m_observer.observeArtificialLight(isArtificial);
 
     if (auto weather = obj.getString("weather")) {
         if (verbose_debugging) {

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -336,6 +336,7 @@ void MumeXmlParser::parseGmcpCharVitals(const JsonObj &obj)
             qWarning().noquote() << "prompt has unknown light flag:" << *light;
         }
     }
+    m_observer.observeArtificialLight(promptFlags.isArtificial());
 
     if (auto weather = obj.getString("weather")) {
         if (verbose_debugging) {

--- a/src/resources/mmapper2.qrc
+++ b/src/resources/mmapper2.qrc
@@ -236,6 +236,8 @@
         <file>shaders/legacy/weather/simulation/vert.glsl</file>
         <file>shaders/legacy/weather/timeofday/frag.glsl</file>
         <file>shaders/legacy/weather/timeofday/vert.glsl</file>
+        <file>shaders/legacy/weather/torch/frag.glsl</file>
+        <file>shaders/legacy/weather/torch/vert.glsl</file>
         <file>sounds/level-up.mp3</file>
     </qresource>
 </RCC>

--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -16,6 +16,7 @@ layout(std140) uniform WeatherBlock
     vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
     vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
     vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uTorch;            // x=startIntensity, y=targetIntensity, z=colorIdx, w=unused
 };
 
 layout(std140) uniform TimeBlock

--- a/src/resources/shaders/legacy/weather/atmosphere/vert.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/vert.glsl
@@ -9,6 +9,7 @@ layout(std140) uniform WeatherBlock
     vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
     vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
     vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uTorch;            // x=startIntensity, y=targetIntensity, z=colorIdx, w=unused
 };
 
 out vec3 vWorldPos;

--- a/src/resources/shaders/legacy/weather/particle/frag.glsl
+++ b/src/resources/shaders/legacy/weather/particle/frag.glsl
@@ -16,6 +16,7 @@ layout(std140) uniform WeatherBlock
     vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
     vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
     vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uTorch;            // x=startIntensity, y=targetIntensity, z=colorIdx, w=unused
 };
 
 layout(std140) uniform TimeBlock

--- a/src/resources/shaders/legacy/weather/particle/vert.glsl
+++ b/src/resources/shaders/legacy/weather/particle/vert.glsl
@@ -12,6 +12,7 @@ layout(std140) uniform WeatherBlock
     vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
     vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
     vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uTorch;            // x=startIntensity, y=targetIntensity, z=colorIdx, w=unused
 };
 
 layout(std140) uniform TimeBlock

--- a/src/resources/shaders/legacy/weather/simulation/vert.glsl
+++ b/src/resources/shaders/legacy/weather/simulation/vert.glsl
@@ -12,6 +12,7 @@ layout(std140) uniform WeatherBlock
     vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
     vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
     vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uTorch;            // x=startIntensity, y=targetIntensity, z=colorIdx, w=unused
 };
 
 layout(std140) uniform TimeBlock

--- a/src/resources/shaders/legacy/weather/timeofday/frag.glsl
+++ b/src/resources/shaders/legacy/weather/timeofday/frag.glsl
@@ -16,6 +16,7 @@ layout(std140) uniform WeatherBlock
     vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
     vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
     vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uTorch;            // x=startIntensity, y=targetIntensity, z=colorIdx, w=unused
 };
 
 layout(std140) uniform TimeBlock
@@ -23,6 +24,7 @@ layout(std140) uniform TimeBlock
     vec2 uTime; // x=time, y=delta
 };
 
+in vec3 vWorldPos;
 out vec4 vFragmentColor;
 
 void main()
@@ -42,5 +44,25 @@ void main()
     vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
     uTimeOfDayColor.a *= currentTimeOfDayIntensity;
 
-    vFragmentColor = uTimeOfDayColor;
+    vec4 result = uTimeOfDayColor;
+
+    float artificialLightIntensity = mix(uTorch.x, uTorch.y, timeOfDayLerp);
+    // Trigger flicker if artificial light is present AND (it's globally dark OR current room is dark)
+    if (artificialLightIntensity > 0.0 && (currentTimeOfDayIntensity > 0.01 || uTorch.w > 0.5)) {
+        float dist = distance(vWorldPos.xy, uPlayerPos.xy);
+        // Torch radius: leak into next few rooms (approx 3.5 units)
+        float glow = smoothstep(3.5, 0.0, dist) * artificialLightIntensity;
+
+        // Flicker: torch-like irregular oscillation
+        float flicker = 1.0 + 0.07 * sin(uCurrentTime * 15.0) + 0.05 * sin(uCurrentTime * 31.0);
+        glow *= flicker;
+
+        vec4 torchColor = uNamedColors[int(uTorch.z)];
+
+        // Blend torch glow: mix color and reduce darkness alpha
+        result = mix(result, torchColor, glow * torchColor.a);
+        result.a *= (1.0 - glow * 0.8);
+    }
+
+    vFragmentColor = result;
 }

--- a/src/resources/shaders/legacy/weather/timeofday/vert.glsl
+++ b/src/resources/shaders/legacy/weather/timeofday/vert.glsl
@@ -1,27 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
-layout(std140) uniform WeatherBlock
-{
-    mat4 uViewProj;
-    vec4 uPlayerPos;        // xyz, w=zScale
-    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
-    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
-    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
-    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
-    vec4 uTorch;            // x=startIntensity, y=targetIntensity, z=colorIdx, w=unused
-};
-
-out vec3 vWorldPos;
-
 void main()
 {
     // Full screen triangle
-    vec4 pos = vec4(vec2((gl_VertexID << 1) & 2, gl_VertexID & 2) * 2.0 - 1.0, 0.0, 1.0);
-    gl_Position = pos;
-
-    // Unproject to world space at z=0 (approximately)
-    mat4 invVP = inverse(uViewProj);
-    vec4 worldPos = invVP * pos;
-    vWorldPos = worldPos.xyz / worldPos.w;
+    gl_Position = vec4(vec2((gl_VertexID << 1) & 2, gl_VertexID & 2) * 2.0 - 1.0, 0.0, 1.0);
 }

--- a/src/resources/shaders/legacy/weather/timeofday/vert.glsl
+++ b/src/resources/shaders/legacy/weather/timeofday/vert.glsl
@@ -1,8 +1,27 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
+layout(std140) uniform WeatherBlock
+{
+    mat4 uViewProj;
+    vec4 uPlayerPos;        // xyz, w=zScale
+    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
+    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
+    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
+    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uTorch;            // x=startIntensity, y=targetIntensity, z=colorIdx, w=unused
+};
+
+out vec3 vWorldPos;
+
 void main()
 {
     // Full screen triangle
-    gl_Position = vec4(vec2((gl_VertexID << 1) & 2, gl_VertexID & 2) * 2.0 - 1.0, 0.0, 1.0);
+    vec4 pos = vec4(vec2((gl_VertexID << 1) & 2, gl_VertexID & 2) * 2.0 - 1.0, 0.0, 1.0);
+    gl_Position = pos;
+
+    // Unproject to world space at z=0 (approximately)
+    mat4 invVP = inverse(uViewProj);
+    vec4 worldPos = invVP * pos;
+    vWorldPos = worldPos.xyz / worldPos.w;
 }

--- a/src/resources/shaders/legacy/weather/torch/frag.glsl
+++ b/src/resources/shaders/legacy/weather/torch/frag.glsl
@@ -16,7 +16,7 @@ layout(std140) uniform WeatherBlock
     vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
     vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
     vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
-    vec4 uTorch;            // x=startIntensity, y=targetIntensity, z=colorIdx, w=unused
+    vec4 uTorch;            // x=startIntensity, y=targetIntensity, z=colorIdx, w=isRoomDark
 };
 
 layout(std140) uniform TimeBlock
@@ -24,6 +24,7 @@ layout(std140) uniform TimeBlock
     vec2 uTime; // x=time, y=delta
 };
 
+in vec3 vWorldPos;
 out vec4 vFragmentColor;
 
 void main()
@@ -32,16 +33,28 @@ void main()
     float uTimeOfDayStartTime = uConfig.y;
     float uTransitionDuration = uConfig.z;
 
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDayIndices.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDayIndices.y)];
-
     float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
                                 0.0,
                                 1.0);
     float currentTimeOfDayIntensity = mix(uTimeOfDayIndices.z, uTimeOfDayIndices.w, timeOfDayLerp);
 
-    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
-    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+    float artificialLightIntensity = mix(uTorch.x, uTorch.y, timeOfDayLerp);
 
-    vFragmentColor = uTimeOfDayColor;
+    // Trigger flicker if artificial light is present AND (it's globally dark OR current room is dark)
+    if (artificialLightIntensity > 0.0 && (currentTimeOfDayIntensity > 0.01 || uTorch.w > 0.5)) {
+        float dist = distance(vWorldPos.xy, uPlayerPos.xy);
+        // Torch radius: leak into next few rooms (approx 3.5 units)
+        float glow = smoothstep(3.5, 0.0, dist) * artificialLightIntensity;
+
+        // Flicker: torch-like irregular oscillation
+        float flicker = 1.0 + 0.07 * sin(uCurrentTime * 15.0) + 0.05 * sin(uCurrentTime * 31.0);
+        glow *= flicker;
+
+        vec4 torchColor = uNamedColors[int(uTorch.z)];
+
+        // Add orange glow
+        vFragmentColor = vec4(torchColor.rgb, glow * torchColor.a);
+    } else {
+        discard;
+    }
 }

--- a/src/resources/shaders/legacy/weather/torch/vert.glsl
+++ b/src/resources/shaders/legacy/weather/torch/vert.glsl
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+layout(std140) uniform WeatherBlock
+{
+    mat4 uViewProj;
+    vec4 uPlayerPos;        // xyz, w=zScale
+    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
+    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
+    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
+    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uTorch;            // x=startIntensity, y=targetIntensity, z=colorIdx, w=isRoomDark
+};
+
+out vec3 vWorldPos;
+
+void main()
+{
+    // Quad vertices 0..3 for TRIANGLE_STRIP
+    // 0: (-1, -1), 1: (1, -1), 2: (-1, 1), 3: (1, 1)
+    vec2 offset = vec2(float(gl_VertexID & 1) * 2.0 - 1.0,
+                       float((gl_VertexID >> 1) & 1) * 2.0 - 1.0);
+
+    // Cover a 3.5-unit radius (7x7 units area)
+    vec2 worldXY = uPlayerPos.xy + offset * 4.0;
+    vWorldPos = vec3(worldXY, uPlayerPos.z);
+
+    // Project to screen space
+    gl_Position = uViewProj * vec4(vWorldPos.x, vWorldPos.y, vWorldPos.z * uPlayerPos.w, 1.0);
+}


### PR DESCRIPTION
Implemented a flickering torch effect for artificial light sources. The effect appears as a warm orange glow around the player that leaks into the next few rooms. It triggers during dusk/night/dawn or in DARK-flagged rooms, satisfying all user requirements and addressing previous code review feedback regarding trigger logic and shader compilation.

---
*PR created automatically by Jules for task [7265000077039531513](https://jules.google.com/task/7265000077039531513) started by @nschimme*