### PR TITLE
Fix PasswordDialog focus and tabbing for WASM

### DIFF
--- a/src/client/PasswordDialog.cpp
+++ b/src/client/PasswordDialog.cpp
@@ -6,6 +6,7 @@
 #include "inputwidget.h"
 
 #include <QDialogButtonBox>
+#include <QShowEvent>
 #include <QVBoxLayout>
 
 PasswordDialog::PasswordDialog(InputWidgetOutputs &outputs, QWidget *const parent)
@@ -16,6 +17,8 @@ PasswordDialog::PasswordDialog(InputWidgetOutputs &outputs, QWidget *const paren
 
     m_passwordLineEdit = new QLineEdit(this);
     m_passwordLineEdit->setEchoMode(QLineEdit::Password);
+    m_passwordLineEdit->setPlaceholderText("Password");
+    m_passwordLineEdit->setObjectName("passwordLineEdit");
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok
                                                            | QDialogButtonBox::Cancel,
@@ -31,10 +34,10 @@ PasswordDialog::PasswordDialog(InputWidgetOutputs &outputs, QWidget *const paren
     connect(buttonBox, &QDialogButtonBox::rejected, this, &PasswordDialog::reject);
 }
 
-bool PasswordDialog::focusNextPrevChild(bool /*next*/)
+void PasswordDialog::showEvent(QShowEvent *event)
 {
-    // Disable tabbing
-    return false;
+    QDialog::showEvent(event);
+    m_passwordLineEdit->setFocus();
 }
 
 void PasswordDialog::accept()

--- a/src/client/PasswordDialog.h
+++ b/src/client/PasswordDialog.h
@@ -16,7 +16,7 @@ public:
     explicit PasswordDialog(InputWidgetOutputs &outputs, QWidget *parent = nullptr);
 
 protected:
-    NODISCARD bool focusNextPrevChild(bool next) override;
+    void showEvent(QShowEvent *event) override;
 
 private slots:
     void accept() override;

--- a/src/client/stackedinputwidget.cpp
+++ b/src/client/stackedinputwidget.cpp
@@ -149,6 +149,7 @@ void StackedInputWidget::gotPasswordInput(const QString &input)
 {
     getOutput().sendUserInput(input + "\n");
     displayInputMessage("******");
+    setFocus();
 }
 
 void StackedInputWidget::displayInputMessage(const QString &input)


### PR DESCRIPTION
This change addresses issues with the PasswordDialog in WebAssembly builds where the password field was not automatically focused, tabbing was disabled, and focus did not return to the main input widget after the dialog was closed. It also adds basic metadata to the password field to assist browser heuristics.

---
*PR created automatically by Jules for task [5847107653042169440](https://jules.google.com/task/5847107653042169440) started by @nschimme*