### PR TITLE
Fix widget focus, lifecycle, and map centering issues

### DIFF
--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -245,6 +245,8 @@ void MapWindow::slot_centerOnWorldPos(const glm::vec2 &worldPos)
     const auto scrollPos = m_knownMapSize.worldToScroll(worldPos);
     horz.setValue(scrollPos.x);
     vert.setValue(scrollPos.y);
+
+    emit sig_setScroll(worldPos);
 }
 
 void MapWindow::centerOnScrollPos(const glm::ivec2 &scrollPos)

--- a/src/mainwindow/findroomsdlg.cpp
+++ b/src/mainwindow/findroomsdlg.cpp
@@ -35,6 +35,8 @@ FindRoomsDlg::FindRoomsDlg(MapData &md, QWidget *const parent)
     selectButton->setEnabled(false);
     editButton->setEnabled(false);
 
+    findButton->setDefault(true);
+
     connect(lineEdit, &QLineEdit::textChanged, this, &FindRoomsDlg::slot_enableFindButton);
     connect(findButton, &QAbstractButton::clicked, this, &FindRoomsDlg::slot_findClicked);
     connect(closeButton, &QAbstractButton::clicked, this, &QWidget::close);
@@ -98,6 +100,12 @@ FindRoomsDlg::FindRoomsDlg(MapData &md, QWidget *const parent)
 FindRoomsDlg::~FindRoomsDlg()
 {
     resultTable->clear();
+}
+
+void FindRoomsDlg::showEvent(QShowEvent *const event)
+{
+    QDialog::showEvent(event);
+    lineEdit->setFocus();
 }
 
 void FindRoomsDlg::readSettings()

--- a/src/mainwindow/findroomsdlg.h
+++ b/src/mainwindow/findroomsdlg.h
@@ -48,6 +48,7 @@ public:
     explicit FindRoomsDlg(MapData &, QWidget *parent);
     ~FindRoomsDlg() final;
 
+    void showEvent(QShowEvent *event) override;
     void readSettings();
     void writeSettings();
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1451,16 +1451,20 @@ void MainWindow::slot_onPreferences()
 {
     if (m_configDialog == nullptr) {
         m_configDialog = std::make_unique<ConfigDialog>(this);
+
+        connect(m_configDialog.get(),
+                &ConfigDialog::sig_graphicsSettingsChanged,
+                m_mapWindow,
+                &MapWindow::slot_graphicsSettingsChanged);
+        connect(m_configDialog.get(),
+                &ConfigDialog::sig_groupSettingsChanged,
+                m_groupManager,
+                &Mmapper2Group::slot_groupSettingsChanged);
+        connect(m_configDialog.get(), &QDialog::finished, this, [this](MAYBE_UNUSED int result) {
+            m_configDialog.reset();
+        });
     }
 
-    connect(m_configDialog.get(),
-            &ConfigDialog::sig_graphicsSettingsChanged,
-            m_mapWindow,
-            &MapWindow::slot_graphicsSettingsChanged);
-    connect(m_configDialog.get(),
-            &ConfigDialog::sig_groupSettingsChanged,
-            m_groupManager,
-            &Mmapper2Group::slot_groupSettingsChanged);
     m_configDialog->show();
 }
 

--- a/src/mpi/remoteeditwidget.cpp
+++ b/src/mpi/remoteeditwidget.cpp
@@ -711,6 +711,7 @@ RemoteEditWidget::RemoteEditWidget(const bool editSession,
     mainLayout->addWidget(m_textEdit.get(), 1);
 
     m_statusBar = new QStatusBar(this);
+    setAttribute(Qt::WA_DeleteOnClose);
     mainLayout->addWidget(m_statusBar);
 
     addStatusBar(m_textEdit.get());
@@ -1463,8 +1464,13 @@ QSize RemoteEditWidget::sizeHint() const
 
 void RemoteEditWidget::closeEvent(QCloseEvent *event)
 {
+    if (m_submitted) {
+        event->accept();
+        return;
+    }
+
     if (m_editSession) {
-        if (m_submitted || slot_maybeCancel()) {
+        if (slot_maybeCancel()) {
             event->accept();
         } else {
             event->ignore();


### PR DESCRIPTION
This PR addresses several UI and functionality issues reported by the user:

1. **Map Centering**: The `MapWindow::slot_centerOnWorldPos` function was blocking scrollbar signals but not notifying the map canvas of the change. I added an explicit `sig_setScroll` emission to fix this, which restores the "Center on XXX" functionality in both the GroupWidget and the FindRooms widget.
2. **Preferences (ConfigDialog)**: Previously, signal connections were added every time the dialog was opened, leading to performance degradation. I've moved these connections to the creation block and added logic to reset the dialog pointer when it's closed, ensuring a clean state.
3. **Remote Edit Widgets**: Fixed an infinite recursion bug in the closing logic and ensured widgets are properly destroyed by setting `Qt::WA_DeleteOnClose`.
4. **FindRooms Usability**: 
   - Set the `findButton` as the default button so pressing Enter triggers the search.
   - Overrode `showEvent` to explicitly focus the search input, which is particularly important for WebAssembly compatibility.
   - Verified that centering now works for double-clicked rooms in the results list.

---
*PR created automatically by Jules for task [5213885759225792847](https://jules.google.com/task/5213885759225792847) started by @nschimme*