### PR TITLE
GMCP Room.Known Support and Unvisited Room Highlighting

### DIFF
--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -293,6 +293,7 @@ ConstString KEY_SERVER_NAME = "Server name";
 ConstString KEY_SHOW_HIDDEN_EXIT_FLAGS = "Show hidden exit flags";
 ConstString KEY_SHOW_NOTES = "Show notes";
 ConstString KEY_SHOW_UNSAVED_CHANGES = "Show unsaved changes";
+ConstString KEY_SHOW_UNVISITED_HIGHLIGHT = "Show unvisited highlight";
 ConstString KEY_SHOW_MISSING_MAP_ID = "Show missing map id";
 ConstString KEY_TAB_COMPLETION_DICTIONARY_SIZE = "Tab completion dictionary size";
 ConstString KEY_THEME = "Theme";
@@ -649,6 +650,7 @@ void Configuration::CanvasSettings::read(const QSettings &conf)
                              .toString();
     showMissingMapId.set(conf.value(KEY_SHOW_MISSING_MAP_ID, true).toBool());
     showUnsavedChanges.set(conf.value(KEY_SHOW_UNSAVED_CHANGES, true).toBool());
+    showUnvisitedHighlight.set(conf.value(KEY_SHOW_UNVISITED_HIGHLIGHT, true).toBool());
     showUnmappedExits.set(conf.value(KEY_DRAW_NOT_MAPPED_EXITS, true).toBool());
     drawUpperLayersTextured = conf.value(KEY_DRAW_UPPER_LAYERS_TEXTURED, false).toBool();
     drawDoorNames = conf.value(KEY_DRAW_DOOR_NAMES, true).toBool();
@@ -856,6 +858,7 @@ void Configuration::CanvasSettings::write(QSettings &conf) const
     conf.setValue(KEY_RESOURCES_DIRECTORY, resourcesDirectory);
     conf.setValue(KEY_SHOW_MISSING_MAP_ID, showMissingMapId.get());
     conf.setValue(KEY_SHOW_UNSAVED_CHANGES, showUnsavedChanges.get());
+    conf.setValue(KEY_SHOW_UNVISITED_HIGHLIGHT, showUnvisitedHighlight.get());
     conf.setValue(KEY_DRAW_NOT_MAPPED_EXITS, showUnmappedExits.get());
     conf.setValue(KEY_DRAW_UPPER_LAYERS_TEXTURED, drawUpperLayersTextured);
     conf.setValue(KEY_DRAW_DOOR_NAMES, drawDoorNames);
@@ -1039,6 +1042,7 @@ void Configuration::NamedColorOptions::resetToDefaults()
     BACKGROUND = background;
     CONNECTION_NORMAL = Colors::white;
     HIGHLIGHT_UNSAVED = Colors::cyan;
+    HIGHLIGHT_UNVISITED = Colors::white;
     HIGHLIGHT_TEMPORARY = Colors::red;
     HIGHLIGHT_NEEDS_SERVER_ID = Colors::yellow;
     INFOMARK_COMMENT = Colors::gray75;

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -1042,7 +1042,7 @@ void Configuration::NamedColorOptions::resetToDefaults()
     BACKGROUND = background;
     CONNECTION_NORMAL = Colors::white;
     HIGHLIGHT_UNSAVED = Colors::cyan;
-    HIGHLIGHT_UNVISITED = Colors::white;
+    HIGHLIGHT_UNVISITED = Colors::magenta;
     HIGHLIGHT_TEMPORARY = Colors::red;
     HIGHLIGHT_NEEDS_SERVER_ID = Colors::yellow;
     INFOMARK_COMMENT = Colors::gray75;

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -169,6 +169,7 @@ public:
         NamedConfig<bool> trilinearFiltering{"TRILINEAR_FILTERING", true};
         NamedConfig<bool> showMissingMapId{"SHOW_MISSING_MAPID", false};
         NamedConfig<bool> showUnsavedChanges{"SHOW_UNSAVED_CHANGES", false};
+        NamedConfig<bool> showUnvisitedHighlight{"SHOW_UNVISITED_HIGHLIGHT", true};
         NamedConfig<bool> showUnmappedExits{"SHOW_UNMAPPED_EXITS", false};
         bool drawUpperLayersTextured = false;
         bool drawDoorNames = false;

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -86,6 +86,11 @@ MapCanvas::MapCanvas(MapData &mapData,
     }
 
     setCursor(Qt::OpenHandCursor);
+
+    connect(&m_data, &MapData::sig_knownRoomsChanged, this, [this]() {
+        m_diff.resetExistingMeshesAndIgnorePendingRemesh();
+        update();
+    });
 }
 
 MapCanvas::~MapCanvas()

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -10,6 +10,7 @@
 #include "../global/parserutils.h"
 #include "../global/progresscounter.h"
 #include "../global/utils.h"
+#include "../group/mmapper2group.h"
 #include "../map/ExitDirection.h"
 #include "../map/coordinate.h"
 #include "../map/exit.h"
@@ -87,7 +88,7 @@ MapCanvas::MapCanvas(MapData &mapData,
 
     setCursor(Qt::OpenHandCursor);
 
-    connect(&m_data, &MapData::sig_knownRoomsChanged, this, [this]() {
+    connect(&m_groupManager, &Mmapper2Group::sig_knownRoomsChanged, this, [this]() {
         m_diff.resetExistingMeshesAndIgnorePendingRemesh();
         update();
     });

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -133,7 +133,10 @@ private:
                                   bool showUnvisited) const;
         NODISCARD bool hasRelatedDiff(const Map &save) const;
         void cancelUpdates(const Map &saved);
-        void maybeAsyncUpdate(const Map &saved, const Map &current, const MapData &mapData);
+        void maybeAsyncUpdate(const Map &saved,
+                              const Map &current,
+                              const std::unordered_set<ServerRoomId> &knownRooms,
+                              bool hasKnownRoomsData);
 
         void resetExistingMeshesAndIgnorePendingRemesh()
         {

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -115,16 +115,19 @@ private:
         {
             Map saved;
             Map current;
+            bool hasKnownRoomsData = false;
             MaybeDataOrMesh highlights;
         };
 
         std::optional<std::future<HighlightDiff>> futureHighlight;
         std::optional<HighlightDiff> highlight;
 
-        NODISCARD bool isUpToDate(const Map &saved, const Map &current) const;
+        NODISCARD bool isUpToDate(const Map &saved,
+                                  const Map &current,
+                                  bool hasKnownRoomsData) const;
         NODISCARD bool hasRelatedDiff(const Map &save) const;
         void cancelUpdates(const Map &saved);
-        void maybeAsyncUpdate(const Map &saved, const Map &current);
+        void maybeAsyncUpdate(const Map &saved, const Map &current, const MapData &mapData);
 
         void resetExistingMeshesAndIgnorePendingRemesh()
         {

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -116,6 +116,9 @@ private:
             Map saved;
             Map current;
             bool hasKnownRoomsData = false;
+            bool showNeedsServerId = false;
+            bool showChanged = false;
+            bool showUnvisited = false;
             MaybeDataOrMesh highlights;
         };
 
@@ -124,7 +127,10 @@ private:
 
         NODISCARD bool isUpToDate(const Map &saved,
                                   const Map &current,
-                                  bool hasKnownRoomsData) const;
+                                  bool hasKnownRoomsData,
+                                  bool showNeedsServerId,
+                                  bool showChanged,
+                                  bool showUnvisited) const;
         NODISCARD bool hasRelatedDiff(const Map &save) const;
         void cancelUpdates(const Map &saved);
         void maybeAsyncUpdate(const Map &saved, const Map &current, const MapData &mapData);

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -551,11 +551,16 @@ void MapCanvas::actuallyPaintGL()
 
 NODISCARD bool MapCanvas::Diff::isUpToDate(const Map &saved,
                                            const Map &current,
-                                           const bool hasKnownRoomsData) const
+                                           const bool hasKnownRoomsData,
+                                           const bool showNeedsServerId,
+                                           const bool showChanged,
+                                           const bool showUnvisited) const
 {
     return highlight && highlight->saved.isSamePointer(saved)
            && highlight->current.isSamePointer(current)
-           && highlight->hasKnownRoomsData == hasKnownRoomsData;
+           && highlight->hasKnownRoomsData == hasKnownRoomsData
+           && highlight->showNeedsServerId == showNeedsServerId
+           && highlight->showChanged == showChanged && highlight->showUnvisited == showUnvisited;
 }
 
 // this differs from isUpToDate in that it allows display of a diff based on the current saved map,
@@ -578,7 +583,13 @@ void MapCanvas::Diff::cancelUpdates(const Map &saved)
 void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current, const MapData &mapData)
 {
     auto &diff = *this;
-    const auto knownRooms = mapData.getKnownRoomsSnapshot();
+
+    const auto &config = getConfig();
+    const auto &canvas = config.canvas;
+    const bool showNeedsServerId = canvas.showMissingMapId.get();
+    const bool showChanged = canvas.showUnsavedChanges.get();
+    const bool showUnvisited = canvas.showUnvisitedHighlight.get();
+
     const bool hasKnownRoomsData = mapData.hasKnownRoomsData();
 
     // Pending takes precedence. This also usually guarantees at most one pending update at a time,
@@ -598,15 +609,16 @@ void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current, con
     }
 
     // no change necessary
-    if (isUpToDate(saved, current, hasKnownRoomsData)) {
+    if (isUpToDate(saved,
+                   current,
+                   hasKnownRoomsData,
+                   showNeedsServerId,
+                   showChanged,
+                   showUnvisited)) {
         return;
     }
 
-    const auto &config = getConfig();
-    const auto &canvas = config.canvas;
-    const bool showNeedsServerId = canvas.showMissingMapId.get();
-    const bool showChanged = canvas.showUnsavedChanges.get();
-    const bool showUnvisited = canvas.showUnvisitedHighlight.get();
+    const auto knownRooms = mapData.getKnownRoomsSnapshot();
 
     diff.futureHighlight = std::async(
         std::launch::async,
@@ -674,7 +686,13 @@ void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current, con
                 return Diff::MaybeDataOrMesh{std::move(highlights)};
             };
 
-            return Diff::HighlightDiff{saved, current, hasKnownRoomsData, getHighlights()};
+            return Diff::HighlightDiff{saved,
+                                       current,
+                                       hasKnownRoomsData,
+                                       showNeedsServerId,
+                                       showChanged,
+                                       showUnvisited,
+                                       getHighlights()};
         });
 }
 

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -10,6 +10,7 @@
 #include "../global/logging.h"
 #include "../global/progresscounter.h"
 #include "../global/utils.h"
+#include "../group/mmapper2group.h"
 #include "../map/coordinate.h"
 #include "../mapdata/mapdata.h"
 #include "../opengl/Font.h"
@@ -580,7 +581,10 @@ void MapCanvas::Diff::cancelUpdates(const Map &saved)
     }
 }
 
-void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current, const MapData &mapData)
+void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved,
+                                       const Map &current,
+                                       const std::unordered_set<ServerRoomId> &knownRooms,
+                                       const bool hasKnownRoomsData)
 {
     auto &diff = *this;
 
@@ -589,8 +593,6 @@ void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current, con
     const bool showNeedsServerId = canvas.showMissingMapId.get();
     const bool showChanged = canvas.showUnsavedChanges.get();
     const bool showUnvisited = canvas.showUnvisitedHighlight.get();
-
-    const bool hasKnownRoomsData = mapData.hasKnownRoomsData();
 
     // Pending takes precedence. This also usually guarantees at most one pending update at a time,
     // but calling resetExistingMeshesAndIgnorePendingRemesh() could result in more than one diff
@@ -612,8 +614,6 @@ void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current, con
     if (isUpToDate(saved, current, hasKnownRoomsData, showNeedsServerId, showChanged, showUnvisited)) {
         return;
     }
-
-    const auto knownRooms = mapData.getKnownRoomsSnapshot();
 
     diff.futureHighlight = std::async(
         std::launch::async,
@@ -697,7 +697,9 @@ void MapCanvas::paintDifferences()
     const auto &saved = m_data.getSavedMap();
     const auto &current = m_data.getCurrentMap();
 
-    diff.maybeAsyncUpdate(saved, current, m_data);
+    const auto self = m_groupManager.getSelf();
+
+    diff.maybeAsyncUpdate(saved, current, self->getKnownRooms(), self->hasKnownRoomsData());
     if (!diff.hasRelatedDiff(saved)) {
         return;
     }

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -293,6 +293,9 @@ void MapCanvas::initializeGL()
         }
     });
 
+    setConfig().canvas.showUnvisitedHighlight.registerChangeCallback(m_lifetime,
+                                                                     [this]() { this->update(); });
+
     setConfig().canvas.showUnmappedExits.registerChangeCallback(m_lifetime, [this]() {
         this->forceUpdateMeshes();
     });
@@ -546,10 +549,13 @@ void MapCanvas::actuallyPaintGL()
     gl.blitFboToDefault();
 }
 
-NODISCARD bool MapCanvas::Diff::isUpToDate(const Map &saved, const Map &current) const
+NODISCARD bool MapCanvas::Diff::isUpToDate(const Map &saved,
+                                           const Map &current,
+                                           const bool hasKnownRoomsData) const
 {
     return highlight && highlight->saved.isSamePointer(saved)
-           && highlight->current.isSamePointer(current);
+           && highlight->current.isSamePointer(current)
+           && highlight->hasKnownRoomsData == hasKnownRoomsData;
 }
 
 // this differs from isUpToDate in that it allows display of a diff based on the current saved map,
@@ -569,9 +575,11 @@ void MapCanvas::Diff::cancelUpdates(const Map &saved)
     }
 }
 
-void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current)
+void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current, const MapData &mapData)
 {
     auto &diff = *this;
+    const auto knownRooms = mapData.getKnownRoomsSnapshot();
+    const bool hasKnownRoomsData = mapData.hasKnownRoomsData();
 
     // Pending takes precedence. This also usually guarantees at most one pending update at a time,
     // but calling resetExistingMeshesAndIgnorePendingRemesh() could result in more than one diff
@@ -590,7 +598,7 @@ void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current)
     }
 
     // no change necessary
-    if (isUpToDate(saved, current)) {
+    if (isUpToDate(saved, current, hasKnownRoomsData)) {
         return;
     }
 
@@ -598,16 +606,28 @@ void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current)
     const auto &canvas = config.canvas;
     const bool showNeedsServerId = canvas.showMissingMapId.get();
     const bool showChanged = canvas.showUnsavedChanges.get();
+    const bool showUnvisited = canvas.showUnvisitedHighlight.get();
 
     diff.futureHighlight = std::async(
         std::launch::async,
-        [saved, current, showNeedsServerId, showChanged]() -> Diff::HighlightDiff {
+        [saved,
+         current,
+         knownRooms,
+         showNeedsServerId,
+         showChanged,
+         showUnvisited,
+         hasKnownRoomsData]() -> Diff::HighlightDiff {
             DECL_TIMER(t2,
                        "[async] actuallyPaintGL: highlight changes, temporary, and needs update");
 
-            auto getHighlights =
-                [&saved, &current, showChanged, showNeedsServerId]() -> Diff::MaybeDataOrMesh {
-                if (!showChanged && !showNeedsServerId) {
+            auto getHighlights = [&saved,
+                                  &current,
+                                  &knownRooms,
+                                  showChanged,
+                                  showNeedsServerId,
+                                  showUnvisited,
+                                  hasKnownRoomsData]() -> Diff::MaybeDataOrMesh {
+                if (!showChanged && !showNeedsServerId && !(showUnvisited && hasKnownRoomsData)) {
                     return Diff::MaybeDataOrMesh{};
                 }
 
@@ -618,14 +638,23 @@ void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current)
                     highlights.emplace_back(pos, 0, color);
                 };
 
-                // Handle rooms needing a server ID or that are temporary
-                if (showNeedsServerId) {
+                // Handle rooms needing a server ID, temporary, or unvisited
+                if (showNeedsServerId || (showUnvisited && hasKnownRoomsData)) {
                     current.getRooms().for_each([&](auto id) {
                         if (auto h = current.getRoomHandle(id)) {
-                            if (h.isTemporary()) {
-                                drawQuad(h.getRaw(), NamedColorEnum::HIGHLIGHT_TEMPORARY);
-                            } else if (h.getServerId() == INVALID_SERVER_ROOMID) {
-                                drawQuad(h.getRaw(), NamedColorEnum::HIGHLIGHT_NEEDS_SERVER_ID);
+                            if (showNeedsServerId) {
+                                if (h.isTemporary()) {
+                                    drawQuad(h.getRaw(), NamedColorEnum::HIGHLIGHT_TEMPORARY);
+                                } else if (h.getServerId() == INVALID_SERVER_ROOMID) {
+                                    drawQuad(h.getRaw(), NamedColorEnum::HIGHLIGHT_NEEDS_SERVER_ID);
+                                }
+                            }
+                            if (showUnvisited && hasKnownRoomsData) {
+                                const ServerRoomId serverId = h.getServerId();
+                                if (serverId != INVALID_SERVER_ROOMID
+                                    && knownRooms.count(serverId) == 0) {
+                                    drawQuad(h.getRaw(), NamedColorEnum::HIGHLIGHT_UNVISITED);
+                                }
                             }
                         }
                     });
@@ -645,7 +674,7 @@ void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current)
                 return Diff::MaybeDataOrMesh{std::move(highlights)};
             };
 
-            return Diff::HighlightDiff{saved, current, getHighlights()};
+            return Diff::HighlightDiff{saved, current, hasKnownRoomsData, getHighlights()};
         });
 }
 
@@ -655,7 +684,7 @@ void MapCanvas::paintDifferences()
     const auto &saved = m_data.getSavedMap();
     const auto &current = m_data.getCurrentMap();
 
-    diff.maybeAsyncUpdate(saved, current);
+    diff.maybeAsyncUpdate(saved, current, m_data);
     if (!diff.hasRelatedDiff(saved)) {
         return;
     }

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -609,12 +609,7 @@ void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current, con
     }
 
     // no change necessary
-    if (isUpToDate(saved,
-                   current,
-                   hasKnownRoomsData,
-                   showNeedsServerId,
-                   showChanged,
-                   showUnvisited)) {
+    if (isUpToDate(saved, current, hasKnownRoomsData, showNeedsServerId, showChanged, showUnvisited)) {
         return;
     }
 

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -22,6 +22,7 @@ struct NamedColorsBlock;
     X(HIGHLIGHT_NEEDS_SERVER_ID, "highlight-needs-server-id") \
     X(HIGHLIGHT_UNSAVED, "highlight-unsaved") \
     X(HIGHLIGHT_TEMPORARY, "highlight-temporary") \
+    X(HIGHLIGHT_UNVISITED, "highlight-unvisited") \
     X(INFOMARK_COMMENT, "infomark-comment") \
     X(INFOMARK_HERB, "infomark-herb") \
     X(INFOMARK_MOB, "infomark-mob") \
@@ -56,7 +57,7 @@ enum class NODISCARD NamedColorEnum : uint8_t { DEFAULT = 0, XFOREACH_NAMED_COLO
 static inline constexpr size_t NUM_NAMED_COLORS = XFOREACH_NAMED_COLOR_OPTIONS(X_COUNT) + 1;
 #undef X_COUNT
 
-static inline constexpr size_t MAX_NAMED_COLORS = 32;
+static inline constexpr size_t MAX_NAMED_COLORS = 64;
 static_assert(MAX_NAMED_COLORS >= NUM_NAMED_COLORS);
 
 // TODO: rename this, but to what? NamedColorHandle?

--- a/src/group/CGroupChar.cpp
+++ b/src/group/CGroupChar.cpp
@@ -206,6 +206,22 @@ bool CGroupChar::updateFromGmcp(const JsonObj &obj)
     return updated;
 }
 
+void CGroupChar::addKnownRooms(std::vector<ServerRoomId> rooms)
+{
+    m_server.knownRooms.insert(rooms.begin(), rooms.end());
+}
+
+void CGroupChar::setKnownRoomsDataReady(const bool ready)
+{
+    m_server.hasKnownRoomsData = ready;
+}
+
+void CGroupChar::clearKnownRooms()
+{
+    m_server.knownRooms.clear();
+    m_server.hasKnownRoomsData = false;
+}
+
 static bool isDeathHall(const ServerRoomId id)
 {
     switch (id.asUint32()) {

--- a/src/group/CGroupChar.h
+++ b/src/group/CGroupChar.h
@@ -11,6 +11,7 @@
 #include "mmapper2character.h"
 
 #include <memory>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -84,6 +85,9 @@ private:
         CharacterTypeEnum type = CharacterTypeEnum::UNDEFINED;
         CharacterAffectFlags affects;
 
+        std::unordered_set<ServerRoomId> knownRooms;
+        bool hasKnownRoomsData = false;
+
         void reset() { *this = Server{}; }
     };
 
@@ -144,6 +148,15 @@ public:
     bool setScore(const QString &hp, const QString &mana, const QString &moves);
     void setRoomName(CharacterRoomName name) { m_server.roomName = std::move(name); }
     NODISCARD const CharacterRoomName &getRoomName() const { return m_server.roomName; }
+
+    void addKnownRooms(std::vector<ServerRoomId> rooms);
+    void setKnownRoomsDataReady(bool ready);
+    void clearKnownRooms();
+    NODISCARD bool hasKnownRoomsData() const { return m_server.hasKnownRoomsData; }
+    NODISCARD const std::unordered_set<ServerRoomId> &getKnownRooms() const
+    {
+        return m_server.knownRooms;
+    }
 
     void setScore(int _hp, int _maxhp, int _mana, int _maxmana, int _moves, int _maxmoves)
     {

--- a/src/group/GroupManagerApi.cpp
+++ b/src/group/GroupManagerApi.cpp
@@ -11,6 +11,21 @@ void GroupManagerApi::refresh()
     return m_group.characterChanged();
 }
 
+void GroupManagerApi::addKnownRooms(std::vector<ServerRoomId> rooms)
+{
+    m_group.addKnownRooms(rooms);
+}
+
+void GroupManagerApi::setKnownRoomsDataReady(const bool ready)
+{
+    m_group.setKnownRoomsDataReady(ready);
+}
+
+void GroupManagerApi::clearKnownRooms()
+{
+    m_group.clearKnownRooms();
+}
+
 SharedGroupChar GroupManagerApi::getMember(const GroupId id)
 {
     if (id == INVALID_GROUPID) {

--- a/src/group/GroupManagerApi.h
+++ b/src/group/GroupManagerApi.h
@@ -21,6 +21,9 @@ public:
 
 public:
     void refresh();
+    void addKnownRooms(std::vector<ServerRoomId> rooms);
+    void setKnownRoomsDataReady(bool ready);
+    void clearKnownRooms();
     NODISCARD SharedGroupChar getMember(const GroupId id);
     NODISCARD SharedGroupChar getMember(const CharacterName &name);
     NODISCARD const GroupVector &getMembers();

--- a/src/group/mmapper2group.cpp
+++ b/src/group/mmapper2group.cpp
@@ -59,6 +59,24 @@ void Mmapper2Group::onReset()
     resetChars();
 }
 
+void Mmapper2Group::addKnownRooms(std::vector<ServerRoomId> rooms)
+{
+    getSelf()->addKnownRooms(rooms);
+    emit sig_knownRoomsChanged();
+}
+
+void Mmapper2Group::setKnownRoomsDataReady(const bool ready)
+{
+    getSelf()->setKnownRoomsDataReady(ready);
+    emit sig_knownRoomsChanged();
+}
+
+void Mmapper2Group::clearKnownRooms()
+{
+    getSelf()->clearKnownRooms();
+    emit sig_knownRoomsChanged();
+}
+
 void Mmapper2Group::parseGmcpCharName(const JsonObj &obj)
 {
     // "Char.Name" "{\"fullname\":\"Gandalf the Grey\",\"name\":\"Gandalf\"}"

--- a/src/group/mmapper2group.h
+++ b/src/group/mmapper2group.h
@@ -60,8 +60,10 @@ private:
     void parseGmcpGroupSet(const JsonArray &arr);
     void parseGmcpRoomInfo(const JsonObj &obj);
 
-private:
+public:
     NODISCARD SharedGroupChar getSelf();
+
+private:
     NODISCARD SharedGroupChar addChar(const GroupId id);
     void removeChar(const GroupId id);
     NODISCARD bool updateChar(SharedGroupChar sharedCh,
@@ -78,6 +80,10 @@ public:
 public:
     void onReset();
 
+    void addKnownRooms(std::vector<ServerRoomId> rooms);
+    void setKnownRoomsDataReady(bool ready);
+    void clearKnownRooms();
+
 signals:
     // MainWindow::log (via MainWindow)
     void sig_log(const QString &, const QString &);
@@ -88,6 +94,7 @@ signals:
     void sig_characterRemoved(GroupId characterId);
     void sig_characterUpdated(SharedGroupChar character);
     void sig_groupReset(const GroupVector &newCharacterList);
+    void sig_knownRoomsChanged();
 
 public slots:
     void slot_parseGmcpInput(const GmcpMessage &msg);

--- a/src/mapdata/mapdata.cpp
+++ b/src/mapdata/mapdata.cpp
@@ -176,13 +176,6 @@ NODISCARD RoomIdSet MapData::genericFind(const RoomFilter &f) const
 
 MapData::~MapData() = default;
 
-void MapData::setKnownRoomsFull(std::vector<ServerRoomId> rooms)
-{
-    m_knownRooms.clear();
-    m_knownRooms.insert(rooms.begin(), rooms.end());
-    m_hasKnownRoomsData = true;
-    emit sig_knownRoomsChanged();
-}
 
 void MapData::addKnownRooms(std::vector<ServerRoomId> rooms)
 {

--- a/src/mapdata/mapdata.cpp
+++ b/src/mapdata/mapdata.cpp
@@ -176,39 +176,6 @@ NODISCARD RoomIdSet MapData::genericFind(const RoomFilter &f) const
 
 MapData::~MapData() = default;
 
-void MapData::addKnownRooms(std::vector<ServerRoomId> rooms)
-{
-    m_knownRooms.insert(rooms.begin(), rooms.end());
-    if (m_hasKnownRoomsData) {
-        emit sig_knownRoomsChanged();
-    }
-}
-
-void MapData::setKnownRoomsDataReady(const bool ready)
-{
-    if (m_hasKnownRoomsData != ready) {
-        m_hasKnownRoomsData = ready;
-        emit sig_knownRoomsChanged();
-    }
-}
-
-void MapData::clearKnownRooms()
-{
-    m_knownRooms.clear();
-    m_hasKnownRoomsData = false;
-    emit sig_knownRoomsChanged();
-}
-
-bool MapData::isRoomKnown(ServerRoomId id) const
-{
-    return m_knownRooms.count(id) > 0;
-}
-
-std::unordered_set<ServerRoomId> MapData::getKnownRoomsSnapshot() const
-{
-    return m_knownRooms;
-}
-
 void MapData::slot_scheduleAction(const SigMapChangeList &change)
 {
     this->applyChanges(change.deref());

--- a/src/mapdata/mapdata.cpp
+++ b/src/mapdata/mapdata.cpp
@@ -176,7 +176,6 @@ NODISCARD RoomIdSet MapData::genericFind(const RoomFilter &f) const
 
 MapData::~MapData() = default;
 
-
 void MapData::addKnownRooms(std::vector<ServerRoomId> rooms)
 {
     m_knownRooms.insert(rooms.begin(), rooms.end());

--- a/src/mapdata/mapdata.cpp
+++ b/src/mapdata/mapdata.cpp
@@ -176,6 +176,47 @@ NODISCARD RoomIdSet MapData::genericFind(const RoomFilter &f) const
 
 MapData::~MapData() = default;
 
+void MapData::setKnownRoomsFull(std::vector<ServerRoomId> rooms)
+{
+    m_knownRooms.clear();
+    m_knownRooms.insert(rooms.begin(), rooms.end());
+    m_hasKnownRoomsData = true;
+    emit sig_knownRoomsChanged();
+}
+
+void MapData::addKnownRooms(std::vector<ServerRoomId> rooms)
+{
+    m_knownRooms.insert(rooms.begin(), rooms.end());
+    if (m_hasKnownRoomsData) {
+        emit sig_knownRoomsChanged();
+    }
+}
+
+void MapData::setKnownRoomsDataReady(const bool ready)
+{
+    if (m_hasKnownRoomsData != ready) {
+        m_hasKnownRoomsData = ready;
+        emit sig_knownRoomsChanged();
+    }
+}
+
+void MapData::clearKnownRooms()
+{
+    m_knownRooms.clear();
+    m_hasKnownRoomsData = false;
+    emit sig_knownRoomsChanged();
+}
+
+bool MapData::isRoomKnown(ServerRoomId id) const
+{
+    return m_knownRooms.count(id) > 0;
+}
+
+std::unordered_set<ServerRoomId> MapData::getKnownRoomsSnapshot() const
+{
+    return m_knownRooms;
+}
+
 void MapData::slot_scheduleAction(const SigMapChangeList &change)
 {
     this->applyChanges(change.deref());

--- a/src/mapdata/mapdata.h
+++ b/src/mapdata/mapdata.h
@@ -26,6 +26,7 @@
 #include <memory>
 #include <optional>
 #include <ostream>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -64,6 +65,9 @@ private:
     bool m_fileReadOnly = false;
     QString m_fileName;
     std::optional<RoomId> m_selectedRoom;
+
+    std::unordered_set<ServerRoomId> m_knownRooms;
+    bool m_hasKnownRoomsData = false;
 
 public:
     explicit MapData(QObject *parent);
@@ -137,6 +141,14 @@ public:
     NODISCARD const QString &getFileName() const { return m_fileName; }
     NODISCARD bool isFileReadOnly() const { return m_fileReadOnly; }
 
+    void setKnownRoomsFull(std::vector<ServerRoomId> rooms);
+    void addKnownRooms(std::vector<ServerRoomId> rooms);
+    void setKnownRoomsDataReady(bool ready);
+    void clearKnownRooms();
+    NODISCARD bool hasKnownRoomsData() const { return m_hasKnownRoomsData; }
+    NODISCARD bool isRoomKnown(ServerRoomId id) const;
+    NODISCARD std::unordered_set<ServerRoomId> getKnownRoomsSnapshot() const;
+
 public:
     NODISCARD ExitDirFlags getExitDirections(const Coordinate &pos);
 
@@ -208,6 +220,7 @@ signals:
     void sig_onForcedPositionChange();
     void sig_checkMapConsistency();
     void sig_generateBaseMap();
+    void sig_knownRoomsChanged();
 
 public slots:
     void slot_scheduleAction(const SigMapChangeList &);

--- a/src/mapdata/mapdata.h
+++ b/src/mapdata/mapdata.h
@@ -66,9 +66,6 @@ private:
     QString m_fileName;
     std::optional<RoomId> m_selectedRoom;
 
-    std::unordered_set<ServerRoomId> m_knownRooms;
-    bool m_hasKnownRoomsData = false;
-
 public:
     explicit MapData(QObject *parent);
     ~MapData() final;
@@ -141,12 +138,6 @@ public:
     NODISCARD const QString &getFileName() const { return m_fileName; }
     NODISCARD bool isFileReadOnly() const { return m_fileReadOnly; }
 
-    void addKnownRooms(std::vector<ServerRoomId> rooms);
-    void setKnownRoomsDataReady(bool ready);
-    void clearKnownRooms();
-    NODISCARD bool hasKnownRoomsData() const { return m_hasKnownRoomsData; }
-    NODISCARD bool isRoomKnown(ServerRoomId id) const;
-    NODISCARD std::unordered_set<ServerRoomId> getKnownRoomsSnapshot() const;
 
 public:
     NODISCARD ExitDirFlags getExitDirections(const Coordinate &pos);
@@ -219,7 +210,6 @@ signals:
     void sig_onForcedPositionChange();
     void sig_checkMapConsistency();
     void sig_generateBaseMap();
-    void sig_knownRoomsChanged();
 
 public slots:
     void slot_scheduleAction(const SigMapChangeList &);

--- a/src/mapdata/mapdata.h
+++ b/src/mapdata/mapdata.h
@@ -141,7 +141,6 @@ public:
     NODISCARD const QString &getFileName() const { return m_fileName; }
     NODISCARD bool isFileReadOnly() const { return m_fileReadOnly; }
 
-    void setKnownRoomsFull(std::vector<ServerRoomId> rooms);
     void addKnownRooms(std::vector<ServerRoomId> rooms);
     void setKnownRoomsDataReady(bool ready);
     void clearKnownRooms();

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -191,7 +191,7 @@ void MumeXmlParserBase::onReset()
     m_commonData.promptFlags.reset();
     m_commonData.lastPrompt = "";
     getQueue().clear();
-    m_mapData.clearKnownRooms();
+    m_group.clearKnownRooms();
 }
 
 void MumeXmlParserBase::parseExits(std::ostream &os)

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -191,6 +191,7 @@ void MumeXmlParserBase::onReset()
     m_commonData.promptFlags.reset();
     m_commonData.lastPrompt = "";
     getQueue().clear();
+    m_mapData.clearKnownRooms();
 }
 
 void MumeXmlParserBase::parseExits(std::ostream &os)

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -39,6 +39,8 @@ void MumeXmlParser::slot_parseGmcpInput(const GmcpMessage &msg)
         parseGmcpStatusVars(obj);
     } else if (msg.isCharVitals()) {
         parseGmcpCharVitals(obj);
+    } else if (msg.isCharName()) {
+        parseGmcpCharName(obj);
     } else if (msg.isEventMoved()) {
         parseGmcpEventMoved(obj);
     } else if (msg.isRoomInfo()) {
@@ -378,6 +380,11 @@ void MumeXmlParser::parseGmcpEventMoved(const JsonObj &obj)
     using namespace mume_xml_parser_gmcp_detail;
     const CommandEnum move = getMove(obj);
     setMove(move);
+}
+
+void MumeXmlParser::parseGmcpCharName(const JsonObj & /*obj*/)
+{
+    m_proxyMudGmcp.gmcpToMud(GmcpMessage{GmcpMessageTypeEnum::ROOM_KNOWN_LIST});
 }
 
 void MumeXmlParser::parseGmcpRoomInfo(const JsonObj &obj)

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -420,7 +420,7 @@ void MumeXmlParser::parseGmcpRoomKnownAdd(const GmcpMessage &msg)
             if (verbose_debugging) {
                 qInfo().noquote() << "Room.Known.Add:" << serverId.asUint32();
             }
-            m_mapData.addKnownRooms({serverId});
+            m_group.addKnownRooms({serverId});
         }
     }
 }
@@ -439,20 +439,20 @@ void MumeXmlParser::parseGmcpRoomKnownList(const GmcpMessage &msg)
             if (verbose_debugging) {
                 qInfo().noquote() << "Room.Known.List: received" << rooms.size() << "rooms";
             }
-            m_mapData.addKnownRooms(rooms);
-            m_mapData.setKnownRoomsDataReady(true);
+            m_group.addKnownRooms(rooms);
+            m_group.setKnownRoomsDataReady(true);
         } else if (msg.getJson()) {
             const auto json = msg.getJson()->toQString();
             if (json == "null") {
                 if (verbose_debugging) {
                     qInfo().noquote() << "Room.Known.List: terminated (null)";
                 }
-                m_mapData.setKnownRoomsDataReady(true);
+                m_group.setKnownRoomsDataReady(true);
             } else if (json == "false") {
                 if (verbose_debugging) {
                     qInfo().noquote() << "Room.Known.List: not available (false)";
                 }
-                m_mapData.clearKnownRooms();
+                m_group.clearKnownRooms();
             }
         }
     }
@@ -463,6 +463,6 @@ void MumeXmlParser::parseGmcpRoomKnownUpdated(const GmcpMessage & /*msg*/)
     if (verbose_debugging) {
         qInfo().noquote() << "Room.Known.Updated: clearing and re-requesting";
     }
-    m_mapData.clearKnownRooms();
+    m_group.clearKnownRooms();
     m_proxyMudGmcp.gmcpToMud(GmcpMessage{GmcpMessageTypeEnum::ROOM_KNOWN_LIST});
 }

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -25,27 +25,31 @@ static volatile bool verbose_debugging = IS_DEBUG_BUILD;
 
 void MumeXmlParser::slot_parseGmcpInput(const GmcpMessage &msg)
 {
-    if (!msg.getJsonDocument().has_value()) {
-        return;
-    }
-
     if (msg.isCharStatusVars()) {
-        if (auto obj = msg.getJsonDocument()->getObject()) {
-            parseGmcpStatusVars(*obj);
+        if (auto doc = msg.getJsonDocument()) {
+            if (auto obj = doc->getObject()) {
+                parseGmcpStatusVars(*obj);
+            }
         }
     } else if (msg.isCharVitals()) {
-        if (auto obj = msg.getJsonDocument()->getObject()) {
-            parseGmcpCharVitals(*obj);
+        if (auto doc = msg.getJsonDocument()) {
+            if (auto obj = doc->getObject()) {
+                parseGmcpCharVitals(*obj);
+            }
         }
     } else if (msg.isCharName()) {
         parseGmcpCharName(msg);
     } else if (msg.isEventMoved()) {
-        if (auto obj = msg.getJsonDocument()->getObject()) {
-            parseGmcpEventMoved(*obj);
+        if (auto doc = msg.getJsonDocument()) {
+            if (auto obj = doc->getObject()) {
+                parseGmcpEventMoved(*obj);
+            }
         }
     } else if (msg.isRoomInfo()) {
-        if (auto obj = msg.getJsonDocument()->getObject()) {
-            parseGmcpRoomInfo(*obj);
+        if (auto doc = msg.getJsonDocument()) {
+            if (auto obj = doc->getObject()) {
+                parseGmcpRoomInfo(*obj);
+            }
         }
     } else if (msg.isRoomKnownAdd()) {
         parseGmcpRoomKnownAdd(msg);
@@ -436,6 +440,7 @@ void MumeXmlParser::parseGmcpRoomKnownList(const GmcpMessage &msg)
                 qInfo().noquote() << "Room.Known.List: received" << rooms.size() << "rooms";
             }
             m_mapData.addKnownRooms(rooms);
+            m_mapData.setKnownRoomsDataReady(true);
         } else if (msg.getJson()) {
             const auto json = msg.getJson()->toQString();
             if (json == "null") {

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -29,22 +29,24 @@ void MumeXmlParser::slot_parseGmcpInput(const GmcpMessage &msg)
         return;
     }
 
-    auto pObj = msg.getJsonDocument()->getObject();
-    if (!pObj) {
-        return;
-    }
-    const auto &obj = *pObj;
-
     if (msg.isCharStatusVars()) {
-        parseGmcpStatusVars(obj);
+        if (auto obj = msg.getJsonDocument()->getObject()) {
+            parseGmcpStatusVars(*obj);
+        }
     } else if (msg.isCharVitals()) {
-        parseGmcpCharVitals(obj);
+        if (auto obj = msg.getJsonDocument()->getObject()) {
+            parseGmcpCharVitals(*obj);
+        }
     } else if (msg.isCharName()) {
-        parseGmcpCharName(obj);
+        parseGmcpCharName(msg);
     } else if (msg.isEventMoved()) {
-        parseGmcpEventMoved(obj);
+        if (auto obj = msg.getJsonDocument()->getObject()) {
+            parseGmcpEventMoved(*obj);
+        }
     } else if (msg.isRoomInfo()) {
-        parseGmcpRoomInfo(obj);
+        if (auto obj = msg.getJsonDocument()->getObject()) {
+            parseGmcpRoomInfo(*obj);
+        }
     } else if (msg.isRoomKnownAdd()) {
         parseGmcpRoomKnownAdd(msg);
     } else if (msg.isRoomKnownList()) {
@@ -382,7 +384,7 @@ void MumeXmlParser::parseGmcpEventMoved(const JsonObj &obj)
     setMove(move);
 }
 
-void MumeXmlParser::parseGmcpCharName(const JsonObj & /*obj*/)
+void MumeXmlParser::parseGmcpCharName(const GmcpMessage & /*msg*/)
 {
     m_proxyMudGmcp.gmcpToMud(GmcpMessage{GmcpMessageTypeEnum::ROOM_KNOWN_LIST});
 }

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -403,7 +403,11 @@ void MumeXmlParser::parseGmcpRoomKnownAdd(const GmcpMessage &msg)
     using namespace mume_xml_parser_gmcp_detail;
     if (auto doc = msg.getJsonDocument()) {
         if (auto id = doc->getInt()) {
-            m_mapData.addKnownRooms({asServerId(*id)});
+            const auto serverId = asServerId(*id);
+            if (verbose_debugging) {
+                qInfo().noquote() << "Room.Known.Add:" << serverId.asUint32();
+            }
+            m_mapData.addKnownRooms({serverId});
         }
     }
 }
@@ -419,12 +423,21 @@ void MumeXmlParser::parseGmcpRoomKnownList(const GmcpMessage &msg)
                     rooms.push_back(asServerId(*id));
                 }
             }
+            if (verbose_debugging) {
+                qInfo().noquote() << "Room.Known.List: received" << rooms.size() << "rooms";
+            }
             m_mapData.addKnownRooms(rooms);
         } else if (msg.getJson()) {
             const auto json = msg.getJson()->toQString();
             if (json == "null") {
+                if (verbose_debugging) {
+                    qInfo().noquote() << "Room.Known.List: terminated (null)";
+                }
                 m_mapData.setKnownRoomsDataReady(true);
             } else if (json == "false") {
+                if (verbose_debugging) {
+                    qInfo().noquote() << "Room.Known.List: not available (false)";
+                }
                 m_mapData.clearKnownRooms();
             }
         }
@@ -433,6 +446,9 @@ void MumeXmlParser::parseGmcpRoomKnownList(const GmcpMessage &msg)
 
 void MumeXmlParser::parseGmcpRoomKnownUpdated(const GmcpMessage & /*msg*/)
 {
+    if (verbose_debugging) {
+        qInfo().noquote() << "Room.Known.Updated: clearing and re-requesting";
+    }
     m_mapData.clearKnownRooms();
     m_proxyMudGmcp.gmcpToMud(GmcpMessage{GmcpMessageTypeEnum::ROOM_KNOWN_LIST});
 }

--- a/src/parser/mumexmlparser.cpp
+++ b/src/parser/mumexmlparser.cpp
@@ -64,6 +64,7 @@ MumeXmlParser::MumeXmlParser(MapData &md,
                              MumeClock &mc,
                              ProxyMudConnectionApi & /*proxyMudConnection*/,
                              ProxyUserGmcpApi &proxyGmcp,
+                             ProxyMudGmcpApi &proxyMudGmcp,
                              GroupManagerApi &group,
                              GameObserver &observer,
                              HotkeyManager &hm,
@@ -71,6 +72,7 @@ MumeXmlParser::MumeXmlParser(MapData &md,
                              AbstractParserOutputs &outputs,
                              ParserCommonData &parserCommonData)
     : MumeXmlParserBase{parent, mc, md, group, hm, proxyGmcp, outputs, parserCommonData}
+    , m_proxyMudGmcp{proxyMudGmcp}
     , m_observer{observer}
 {}
 

--- a/src/parser/mumexmlparser.h
+++ b/src/parser/mumexmlparser.h
@@ -107,7 +107,7 @@ private:
     void parseGmcpStatusVars(const JsonObj &obj);
     void parseGmcpCharVitals(const JsonObj &obj);
     void parseGmcpEventMoved(const JsonObj &obj);
-    void parseGmcpCharName(const JsonObj &obj);
+    void parseGmcpCharName(const GmcpMessage &msg);
     void parseGmcpRoomInfo(const JsonObj &obj);
     void parseGmcpRoomKnownAdd(const GmcpMessage &msg);
     void parseGmcpRoomKnownList(const GmcpMessage &msg);

--- a/src/parser/mumexmlparser.h
+++ b/src/parser/mumexmlparser.h
@@ -107,6 +107,7 @@ private:
     void parseGmcpStatusVars(const JsonObj &obj);
     void parseGmcpCharVitals(const JsonObj &obj);
     void parseGmcpEventMoved(const JsonObj &obj);
+    void parseGmcpCharName(const JsonObj &obj);
     void parseGmcpRoomInfo(const JsonObj &obj);
     void parseGmcpRoomKnownAdd(const GmcpMessage &msg);
     void parseGmcpRoomKnownList(const GmcpMessage &msg);

--- a/src/parser/mumexmlparser.h
+++ b/src/parser/mumexmlparser.h
@@ -58,6 +58,7 @@ private:
     bool m_exitsReady = false;
     bool m_descriptionReady = false;
     bool m_eventReady = false;
+    ProxyMudGmcpApi &m_proxyMudGmcp;
     GameObserver &m_observer;
 
 private:
@@ -81,6 +82,7 @@ public:
                            MumeClock &,
                            ProxyMudConnectionApi &,
                            ProxyUserGmcpApi &,
+                           ProxyMudGmcpApi &,
                            GroupManagerApi &,
                            GameObserver &,
                            HotkeyManager &,
@@ -106,4 +108,7 @@ private:
     void parseGmcpCharVitals(const JsonObj &obj);
     void parseGmcpEventMoved(const JsonObj &obj);
     void parseGmcpRoomInfo(const JsonObj &obj);
+    void parseGmcpRoomKnownAdd(const GmcpMessage &msg);
+    void parseGmcpRoomKnownList(const GmcpMessage &msg);
+    void parseGmcpRoomKnownUpdated(const GmcpMessage &msg);
 };

--- a/src/preferences/graphicspage.cpp
+++ b/src/preferences/graphicspage.cpp
@@ -72,6 +72,10 @@ GraphicsPage::GraphicsPage(QWidget *parent)
             &QCheckBox::stateChanged,
             this,
             &GraphicsPage::slot_drawNeedsUpdateStateChanged);
+    connect(ui->drawUnvisitedRooms,
+            &QCheckBox::stateChanged,
+            this,
+            &GraphicsPage::slot_drawUnvisitedRoomsStateChanged);
     connect(ui->drawNotMappedExits,
             &QCheckBox::stateChanged,
             this,
@@ -139,6 +143,7 @@ void GraphicsPage::slot_loadConfig()
 
     ui->drawUnsavedChanges->setChecked(settings.showUnsavedChanges.get());
     ui->drawNeedsUpdate->setChecked(settings.showMissingMapId.get());
+    ui->drawUnvisitedRooms->setChecked(settings.showUnvisitedHighlight.get());
     ui->drawNotMappedExits->setChecked(settings.showUnmappedExits.get());
     ui->drawDoorNames->setChecked(settings.drawDoorNames);
 
@@ -160,6 +165,12 @@ void GraphicsPage::changeColorClicked(XNamedColor &namedColor, QPushButton *cons
 void GraphicsPage::slot_drawNeedsUpdateStateChanged(int /*unused*/)
 {
     setConfig().canvas.showMissingMapId.set(ui->drawNeedsUpdate->isChecked());
+    graphicsSettingsChanged();
+}
+
+void GraphicsPage::slot_drawUnvisitedRoomsStateChanged(int /*unused*/)
+{
+    setConfig().canvas.showUnvisitedHighlight.set(ui->drawUnvisitedRooms->isChecked());
     graphicsSettingsChanged();
 }
 

--- a/src/preferences/graphicspage.h
+++ b/src/preferences/graphicspage.h
@@ -41,6 +41,7 @@ signals:
 public slots:
     void slot_loadConfig();
     void slot_drawNeedsUpdateStateChanged(int);
+    void slot_drawUnvisitedRoomsStateChanged(int);
     void slot_drawNotMappedExitsStateChanged(int);
     void slot_drawDoorNamesStateChanged(int);
     void slot_drawUpperLayersTexturedStateChanged(int);

--- a/src/preferences/graphicspage.ui
+++ b/src/preferences/graphicspage.ui
@@ -121,6 +121,13 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="drawUnvisitedRooms">
+        <property name="text">
+         <string>Show unvisited rooms</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/proxy/GmcpMessage.h
+++ b/src/proxy/GmcpMessage.h
@@ -53,6 +53,9 @@ class ParseEvent;
     X(ROOM_CHARS_SET, RoomCharsSet, "room.chars.set", "Room.Chars.Set") \
     X(ROOM_CHARS_UPDATE, RoomCharsUpdate, "room.chars.update", "Room.Chars.Update") \
     X(ROOM_INFO, RoomInfo, "room.info", "Room.Info") \
+    X(ROOM_KNOWN_ADD, RoomKnownAdd, "room.known.add", "Room.Known.Add") \
+    X(ROOM_KNOWN_LIST, RoomKnownList, "room.known.list", "Room.Known.List") \
+    X(ROOM_KNOWN_UPDATED, RoomKnownUpdated, "room.known.updated", "Room.Known.Updated") \
     X(ROOM_UPDATE_EXITS, RoomUpdateExits, "room.update.exits", "Room.Update.Exits") \
     /* define gmcp message types above */
 
@@ -66,7 +69,7 @@ enum class NODISCARD GmcpMessageTypeEnum {
 #define X_COUNT(...) +1
 static constexpr const size_t NUM_GMCP_MESSAGES = XFOREACH_GMCP_MESSAGE_TYPE(X_COUNT);
 #undef X_COUNT
-static_assert(NUM_GMCP_MESSAGES == 30);
+static_assert(NUM_GMCP_MESSAGES == 33);
 DEFINE_ENUM_COUNT(GmcpMessageTypeEnum, NUM_GMCP_MESSAGES)
 
 namespace tags {

--- a/src/proxy/GmcpModule.h
+++ b/src/proxy/GmcpModule.h
@@ -23,6 +23,7 @@
     X(MUME_CLIENT, MumeClient, "mume.client", "MUME.Client") \
     X(ROOM_CHARS, RoomChars, "room.chars", "Room.Chars") \
     X(ROOM, Room, "room", "Room") \
+    X(ROOM_KNOWN, RoomKnown, "room.known", "Room.Known") \
     /* define gmcp module types above */
 
 enum class NODISCARD GmcpModuleTypeEnum {
@@ -35,7 +36,7 @@ enum class NODISCARD GmcpModuleTypeEnum {
 #define X_COUNT(...) +1
 static constexpr const size_t NUM_GMCP_MODULES = XFOREACH_GMCP_MODULE_TYPE(X_COUNT);
 #undef X_COUNT
-static_assert(NUM_GMCP_MODULES == 7);
+static_assert(NUM_GMCP_MODULES == 8);
 DEFINE_ENUM_COUNT(GmcpModuleTypeEnum, NUM_GMCP_MODULES)
 
 namespace tags {

--- a/src/proxy/MudTelnet.cpp
+++ b/src/proxy/MudTelnet.cpp
@@ -546,9 +546,6 @@ void MudTelnet::virt_onGmcpEnabled()
     sendGmcpMessage(GmcpMessage{GmcpMessageTypeEnum::MUME_CLIENT_XML,
                                 GmcpJson{R"({ "enable": true, "silent": true })"}});
 
-    // Request the initial list of known rooms
-    sendGmcpMessage(GmcpMessage{GmcpMessageTypeEnum::ROOM_KNOWN_LIST});
-
     // Check if user has requested we remember our login credentials
     m_outputs.onTryCharLogin();
 }

--- a/src/proxy/MudTelnet.cpp
+++ b/src/proxy/MudTelnet.cpp
@@ -546,6 +546,9 @@ void MudTelnet::virt_onGmcpEnabled()
     sendGmcpMessage(GmcpMessage{GmcpMessageTypeEnum::MUME_CLIENT_XML,
                                 GmcpJson{R"({ "enable": true, "silent": true })"}});
 
+    // Request the initial list of known rooms
+    sendGmcpMessage(GmcpMessage{GmcpMessageTypeEnum::ROOM_KNOWN_LIST});
+
     // Check if user has requested we remember our login credentials
     m_outputs.onTryCharLogin();
 }
@@ -575,6 +578,7 @@ void MudTelnet::resetGmcpModules()
     receiveGmcpModule(GmcpModule{GmcpModuleTypeEnum::GROUP, GmcpModuleVersion{1}}, true);
     receiveGmcpModule(GmcpModule{GmcpModuleTypeEnum::ROOM_CHARS, GmcpModuleVersion{1}}, true);
     receiveGmcpModule(GmcpModule{GmcpModuleTypeEnum::ROOM, GmcpModuleVersion{1}}, true);
+    receiveGmcpModule(GmcpModule{GmcpModuleTypeEnum::ROOM_KNOWN, GmcpModuleVersion{1}}, true);
     receiveGmcpModule(GmcpModule{GmcpModuleTypeEnum::MUME_CLIENT, GmcpModuleVersion{1}}, true);
 }
 

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -707,6 +707,7 @@ void Proxy::allocParser()
     auto &pipe = getPipeline();
     auto &conn = pipe.apis.proxyMudConnection = std::make_unique<ProxyMudConnectionApi>(*this);
     auto &gmcp = pipe.apis.proxyGmcp = std::make_unique<ProxyUserGmcpApi>(*this);
+    auto &mudGmcp = pipe.apis.proxyMudGmcp = std::make_unique<ProxyMudGmcpApi>(*this);
     auto &out = pipe.outputs.parserXmlOutputs = std::make_unique<LocalParserOutputs>(*this);
 
     // REVISIIT: does CTimers actually need a parent?
@@ -722,6 +723,7 @@ void Proxy::allocParser()
                                                          m_mumeClock,
                                                          deref(conn),
                                                          deref(gmcp),
+                                                         deref(mudGmcp),
                                                          m_groupManager.getGroupManagerApi(),
                                                          m_gameObserver,
                                                          m_mainWindow.getHotkeyManager(),

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -107,6 +107,7 @@ private:
         {
             std::unique_ptr<ProxyMudConnectionApi> proxyMudConnection;
             std::unique_ptr<ProxyUserGmcpApi> proxyGmcp;
+            std::unique_ptr<ProxyMudGmcpApi> proxyMudGmcp;
             std::optional<Signal2Lifetime> sendToUserLifetime;
         };
         Apis apis;

--- a/tests/TestProxy.cpp
+++ b/tests/TestProxy.cpp
@@ -34,6 +34,14 @@ void TestProxy::gmcpMessageDeserializeTest()
     GmcpMessage gmcp3 = GmcpMessage::fromRawBytes(R"(External.Discord.Hello)");
     QCOMPARE(gmcp3.getName().toQByteArray(), QByteArray("External.Discord.Hello"));
     QVERIFY(!gmcp3.getJson());
+
+    GmcpMessage gmcp4 = GmcpMessage::fromRawBytes(R"(Room.Known.List [1,2,3])");
+    QCOMPARE(gmcp4.getName().toQByteArray(), QByteArray("Room.Known.List"));
+    QVERIFY(gmcp4.isRoomKnownList());
+
+    GmcpMessage gmcp5 = GmcpMessage::fromRawBytes(R"(Room.Known.Add 4711)");
+    QCOMPARE(gmcp5.getName().toQByteArray(), QByteArray("Room.Known.Add"));
+    QVERIFY(gmcp5.isRoomKnownAdd());
 }
 
 void TestProxy::gmcpMessageSerializeTest()


### PR DESCRIPTION
Implemented support for the GMCP `Room.Known` module to track and highlight visited rooms. The visited state is stored per-character session and cleared upon logout or disconnection. Unvisited rooms are highlighted on the map with a toggleable preference. Addressed thread-safety issues in the rendering pipeline by passing a snapshot of the visited rooms set to the asynchronous highlight generation task.

---
*PR created automatically by Jules for task [13386136753493179451](https://jules.google.com/task/13386136753493179451) started by @nschimme*