### PR TITLE
Fix compilation errors

### DIFF
--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -235,7 +235,6 @@ void MapCanvas::initializeGL()
     initLogger();
 
     gl.initializeRenderer(static_cast<float>(QPaintDevice::devicePixelRatioF()));
-    m_frameManager.init(gl.getUboManager());
 
     gl.getUboManager().registerRebuildFunction(
         Legacy::SharedVboEnum::NamedColorsBlock, [&gl](Legacy::Functions &funcs) {
@@ -614,8 +613,7 @@ void MapCanvas::finishPendingMapBatches()
 void MapCanvas::actuallyPaintGL(float /*deltaTime*/)
 {
     // deltaTime is currently unused here but advanced in FrameManager::beginFrame()
-    // Update animation state and weather
-    m_weather.update();
+    // Update animation state
 
     // DECL_TIMER(t, __FUNCTION__);
     setViewportAndMvp(width(), height());

--- a/src/opengl/legacy/AttributeLessMeshes.h
+++ b/src/opengl/legacy/AttributeLessMeshes.h
@@ -62,7 +62,7 @@ protected:
             vao.emplace(m_shared_functions);
         }
 
-        m_functions.glBindVertexArray(vao);
+        m_functions.glBindVertexArray(vao.get());
         m_functions.glDrawArrays(m_mode, 0, m_numVerts);
         m_functions.glBindVertexArray(0);
     }

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -6,6 +6,7 @@
 #include "../../display/Textures.h"
 #include "../../global/utils.h"
 #include "../OpenGLTypes.h"
+#include "../UboManager.h"
 #include "AbstractShaderProgram.h"
 #include "Binders.h"
 #include "FontMesh3d.h"
@@ -338,6 +339,16 @@ TexLookup &Functions::getTexLookup()
 FBO &Functions::getFBO()
 {
     return deref(m_fbo);
+}
+
+void Functions::setUboManager(UboManager *manager)
+{
+    m_uboManager = manager;
+}
+
+UboManager &Functions::getUboManager()
+{
+    return deref(m_uboManager);
 }
 
 /// This only exists so we can detect errors in contexts that don't support \c glDebugMessageCallback().

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -7,7 +7,6 @@
 #include "../../global/utils.h"
 #include "../OpenGLConfig.h"
 #include "../OpenGLTypes.h"
-#include "../UboManager.h"
 #include "FBO.h"
 
 #include <cmath>
@@ -26,6 +25,7 @@ class OpenGL;
 
 namespace Legacy {
 
+class UboManager;
 class StaticVbos;
 class SharedVbos;
 class SharedVaos;
@@ -214,6 +214,7 @@ public:
     using Base::glDisable;
     using Base::glDisableVertexAttribArray;
     using Base::glDrawArrays;
+    using Base::glDrawArraysInstanced;
     using Base::glDrawElementsInstanced;
     using Base::glEnable;
     using Base::glEnableVertexAttribArray;
@@ -328,8 +329,8 @@ public:
 
     NODISCARD FBO &getFBO();
 
-    void setUboManager(UboManager *manager) { m_uboManager = manager; }
-    NODISCARD UboManager &getUboManager() { return deref(m_uboManager); }
+    void setUboManager(UboManager *manager);
+    NODISCARD UboManager &getUboManager();
 
 private:
     friend PointSizeBinder;


### PR DESCRIPTION
This submission fixes several compilation errors:
1. Circular dependency: `Legacy.h` and `UboManager.h` were including each other. I forward declared `UboManager` in `Legacy.h` and moved the implementations of `setUboManager` and `getUboManager` to `Legacy.cpp`.
2. Obsolete members: Removed calls to `m_frameManager.init()` and `m_weather.update()` in `mapcanvas_gl.cpp` as these members/methods no longer exist.
3. OpenGL API usage: Fixed `glBindVertexArray(vao)` in `AttributeLessMeshes.h` to use `vao.get()` since `VAO` is a wrapper class.
4. Missing exports: Added `using Base::glDrawArraysInstanced;` to `Legacy::Functions` to fix an accessibility error in `SimpleMesh.cpp`.

The project now compiles successfully and all 13 unit tests pass.

---
*PR created automatically by Jules for task [11899897826137063864](https://jules.google.com/task/11899897826137063864) started by @nschimme*