### PR TITLE
Restore Windows Dark Title Bar and Fix WASM Links

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -801,7 +801,7 @@ if(NOT IMMER_FOUND)
 endif()
 
 if(WIN32)
-    target_link_libraries(mmapper PRIVATE ws2_32)
+    target_link_libraries(mmapper PRIVATE ws2_32 dwmapi)
 endif()
 
 if(WITH_MAP)

--- a/src/mainwindow/ThemeManager.cpp
+++ b/src/mainwindow/ThemeManager.cpp
@@ -15,6 +15,7 @@
 #endif
 
 #ifdef Q_OS_WIN
+#include <dwmapi.h>
 #include <windows.h>
 #endif
 
@@ -23,11 +24,12 @@ ThemeManager::ThemeManager(QObject *const parent)
 {
     setConfig().general.registerChangeCallback(m_lifetime, [this]() { applyTheme(); });
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
     if constexpr (CURRENT_PLATFORM == PlatformEnum::Windows) {
         qApp->installNativeEventFilter(this);
+        qApp->installEventFilter(this);
     }
-#else
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     connect(qApp->styleHints(), &QStyleHints::colorSchemeChanged, this, [this](Qt::ColorScheme) {
         if (getConfig().general.getTheme() == ThemeEnum::System) {
             applyTheme();
@@ -40,11 +42,10 @@ ThemeManager::ThemeManager(QObject *const parent)
 
 ThemeManager::~ThemeManager()
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
     if constexpr (CURRENT_PLATFORM == PlatformEnum::Windows) {
         qApp->removeNativeEventFilter(this);
+        qApp->removeEventFilter(this);
     }
-#endif
 }
 
 bool ThemeManager::nativeEventFilter(const QByteArray &eventType,
@@ -70,35 +71,28 @@ bool ThemeManager::nativeEventFilter(const QByteArray &eventType,
     return false;
 }
 
+bool ThemeManager::eventFilter(QObject *watched, QEvent *event)
+{
+#ifdef Q_OS_WIN
+    if (event->type() == QEvent::Show || event->type() == QEvent::WinIdChange) {
+        QWidget *widget = qobject_cast<QWidget *>(watched);
+        if (widget && widget->isWindow()) {
+            applyThemeToWindow(widget);
+        }
+    }
+#else
+    std::ignore = watched;
+    std::ignore = event;
+#endif
+    return false;
+}
+
 void ThemeManager::applyTheme()
 {
     const auto theme = getConfig().general.getTheme();
     if (theme == ThemeEnum::System) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 5, 0) && defined(Q_OS_WIN)
-        const bool isDarkMode = std::invoke([]() {
-            DWORD value = 1; // Default to light mode
-            HKEY hKey;
-            if (RegOpenKeyExW(HKEY_CURRENT_USER,
-                              L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
-                              0,
-                              KEY_READ,
-                              &hKey)
-                == ERROR_SUCCESS) {
-                DWORD dataSize = sizeof(value);
-                if (RegQueryValueExW(hKey,
-                                     L"AppsUseLightTheme",
-                                     nullptr,
-                                     nullptr,
-                                     reinterpret_cast<LPBYTE>(&value),
-                                     &dataSize)
-                    == ERROR_SUCCESS) {
-                    RegCloseKey(hKey);
-                    return value == 0; // 0 means dark mode
-                }
-                RegCloseKey(hKey);
-            }
-        });
-        if (isDark()) {
+        if (isDarkMode()) {
             applyDarkPalette();
         } else {
             qApp->setPalette(QPalette());
@@ -113,6 +107,73 @@ void ThemeManager::applyTheme()
     } else {
         applyLightPalette();
     }
+
+    if constexpr (CURRENT_PLATFORM == PlatformEnum::Windows) {
+        updateAllWindows();
+    }
+}
+
+void ThemeManager::updateAllWindows()
+{
+    for (QWidget *widget : QApplication::topLevelWidgets()) {
+        applyThemeToWindow(widget);
+    }
+}
+
+void ThemeManager::applyThemeToWindow(QWidget *widget)
+{
+#ifdef Q_OS_WIN
+    if (widget && widget->isWindow()) {
+        HWND hwnd = reinterpret_cast<HWND>(widget->winId());
+        const DWORD DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+        BOOL useDark = isDarkMode() ? TRUE : FALSE;
+        DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDark, sizeof(useDark));
+    }
+#else
+    std::ignore = widget;
+#endif
+}
+
+bool ThemeManager::isDarkMode() const
+{
+    const auto theme = getConfig().general.getTheme();
+    if (theme == ThemeEnum::Dark) {
+        return true;
+    }
+    if (theme == ThemeEnum::Light) {
+        return false;
+    }
+
+#ifdef Q_OS_WIN
+    DWORD value = 1; // Default to light mode
+    HKEY hKey;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                      L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                      0,
+                      KEY_READ,
+                      &hKey)
+        == ERROR_SUCCESS) {
+        DWORD dataSize = sizeof(value);
+        if (RegQueryValueExW(hKey,
+                             L"AppsUseLightTheme",
+                             nullptr,
+                             nullptr,
+                             reinterpret_cast<LPBYTE>(&value),
+                             &dataSize)
+            == ERROR_SUCCESS) {
+            RegCloseKey(hKey);
+            return value == 0; // 0 means dark mode
+        }
+        RegCloseKey(hKey);
+    }
+    return false;
+#else
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    return qApp->styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+#else
+    return qApp->palette().windowText().color().value() > qApp->palette().window().color().value();
+#endif
+#endif
 }
 
 void ThemeManager::applyDarkPalette()

--- a/src/mainwindow/ThemeManager.h
+++ b/src/mainwindow/ThemeManager.h
@@ -21,9 +21,14 @@ public:
 
 public:
     bool nativeEventFilter(const QByteArray &eventType, void *message, qintptr *result) override;
+    bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
     void applyTheme();
     void applyDarkPalette();
     void applyLightPalette();
+
+    void updateAllWindows();
+    void applyThemeToWindow(QWidget *widget);
+    NODISCARD bool isDarkMode() const;
 };

--- a/src/viewers/AnsiViewWindow.cpp
+++ b/src/viewers/AnsiViewWindow.cpp
@@ -10,6 +10,7 @@
 
 #include <tuple>
 
+#include <QDesktopServices>
 #include <QDialog>
 #include <QStyle>
 #include <QTextBrowser>
@@ -30,8 +31,10 @@ AnsiViewWindow::AnsiViewWindow(const QString &program,
 
     auto &view = deref(m_view);
     setAnsiText(&view, message);
-    view.setOpenExternalLinks(true);
+    view.setOpenExternalLinks(false);
     view.setTextInteractionFlags(Qt::TextBrowserInteraction);
+
+    connect(&view, &QTextBrowser::anchorClicked, [](const QUrl &url) { QDesktopServices::openUrl(url); });
 
     // REVISIT: Restore geometry from config?
     setGeometry(QStyle::alignedRect(Qt::LeftToRight,

--- a/src/viewers/AnsiViewWindow.cpp
+++ b/src/viewers/AnsiViewWindow.cpp
@@ -34,7 +34,9 @@ AnsiViewWindow::AnsiViewWindow(const QString &program,
     view.setOpenExternalLinks(false);
     view.setTextInteractionFlags(Qt::TextBrowserInteraction);
 
-    connect(&view, &QTextBrowser::anchorClicked, [](const QUrl &url) { QDesktopServices::openUrl(url); });
+    connect(&view, &QTextBrowser::anchorClicked, [](const QUrl &url) {
+        QDesktopServices::openUrl(url);
+    });
 
     // REVISIT: Restore geometry from config?
     setGeometry(QStyle::alignedRect(Qt::LeftToRight,


### PR DESCRIPTION
This change restores the logic to apply dark title bars on Windows 11 and earlier, integrated into the new ThemeManager. It also addresses user reports that links in the ANSI viewer were opening in the same page in WebAssembly builds by explicitly routing them through QDesktopServices.

---
*PR created automatically by Jules for task [12920131885295983034](https://jules.google.com/task/12920131885295983034) started by @nschimme*