### PR TITLE
Fix Windows Theme switching and Window persistence

### DIFF
--- a/src/mainwindow/ThemeManager.cpp
+++ b/src/mainwindow/ThemeManager.cpp
@@ -135,7 +135,13 @@ void ThemeManager::applyThemeToWindow(QWidget *widget)
         DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDark, sizeof(useDark));
 
         // Trigger a frame change to refresh the title bar
-        SetWindowPos(hwnd, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+        SetWindowPos(hwnd,
+                     nullptr,
+                     0,
+                     0,
+                     0,
+                     0,
+                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
     }
 #else
     std::ignore = widget;

--- a/src/mainwindow/ThemeManager.cpp
+++ b/src/mainwindow/ThemeManager.cpp
@@ -8,6 +8,7 @@
 
 #include <QApplication>
 #include <QPalette>
+#include <QStyle>
 #include <QStyleHints>
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
@@ -96,11 +97,15 @@ void ThemeManager::applyTheme()
             applyDarkPalette();
         } else {
             qApp->setPalette(QPalette());
-            qApp->setStyle("Fusion");
+            if (qApp->style()->objectName().toLower() != "fusion") {
+                qApp->setStyle("Fusion");
+            }
         }
 #else
         qApp->setPalette(QPalette());
-        qApp->setStyle("Fusion");
+        if (qApp->style()->objectName().toLower() != "fusion") {
+            qApp->setStyle("Fusion");
+        }
 #endif
     } else if (theme == ThemeEnum::Dark) {
         applyDarkPalette();
@@ -128,6 +133,9 @@ void ThemeManager::applyThemeToWindow(QWidget *widget)
         const DWORD DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
         BOOL useDark = isDarkMode() ? TRUE : FALSE;
         DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDark, sizeof(useDark));
+
+        // Trigger a frame change to refresh the title bar
+        SetWindowPos(hwnd, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
     }
 #else
     std::ignore = widget;
@@ -195,7 +203,9 @@ void ThemeManager::applyDarkPalette()
     dark.setColor(QPalette::Disabled, QPalette::ButtonText, Qt::darkGray);
 
     qApp->setPalette(dark);
-    qApp->setStyle("Fusion");
+    if (qApp->style()->objectName().toLower() != "fusion") {
+        qApp->setStyle("Fusion");
+    }
 }
 
 void ThemeManager::applyLightPalette()
@@ -217,5 +227,7 @@ void ThemeManager::applyLightPalette()
     light.setColor(QPalette::Disabled, QPalette::ButtonText, Qt::gray);
 
     qApp->setPalette(light);
-    qApp->setStyle("Fusion");
+    if (qApp->style()->objectName().toLower() != "fusion") {
+        qApp->setStyle("Fusion");
+    }
 }

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -290,6 +290,14 @@ MainWindow::MainWindow()
         setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
     }
 
+    connect(m_mapData,
+            &MapData::sig_checkMapConsistency,
+            this,
+            &MainWindow::slot_checkMapConsistency);
+    connect(m_mapData, &MapData::sig_generateBaseMap, this, &MainWindow::slot_generateBaseMap);
+
+    readSettings();
+
     showStatusBarAct->setChecked(getConfig().general.showStatusBar);
     slot_setShowStatusBar();
 
@@ -301,13 +309,7 @@ MainWindow::MainWindow()
         slot_setShowMenuBar();
     }
 
-    connect(m_mapData,
-            &MapData::sig_checkMapConsistency,
-            this,
-            &MainWindow::slot_checkMapConsistency);
-    connect(m_mapData, &MapData::sig_generateBaseMap, this, &MainWindow::slot_generateBaseMap);
-
-    readSettings();
+    show();
 }
 
 void MainWindow::startServices()
@@ -372,12 +374,13 @@ void MainWindow::readSettings()
                                         size(),
                                         qApp->primaryScreen()->availableGeometry()));
 
+        setConfig().general.firstRun = false;
     } else {
-        if (!restoreState(settings.windowState)) {
-            qWarning() << "Unable to restore toolbars and dockwidgets state";
-        }
         if (!restoreGeometry(settings.windowGeometry)) {
             qWarning() << "Unable to restore window geometry";
+        }
+        if (!restoreState(settings.windowState)) {
+            qWarning() << "Unable to restore toolbars and dockwidgets state";
         }
         raise();
 
@@ -389,7 +392,9 @@ void MainWindow::readSettings()
 void MainWindow::writeSettings()
 {
     auto &savedConfig = setConfig().general;
-    savedConfig.windowGeometry = saveGeometry();
+    if (!isMinimized()) {
+        savedConfig.windowGeometry = saveGeometry();
+    }
     savedConfig.windowState = saveState();
 }
 
@@ -1313,7 +1318,6 @@ void MainWindow::slot_setShowStatusBar()
     const bool showStatusBar = this->showStatusBarAct->isChecked();
     statusBar()->setVisible(showStatusBar);
     setConfig().general.showStatusBar = showStatusBar;
-    show();
 }
 
 void MainWindow::slot_setShowScrollBars()
@@ -1321,14 +1325,12 @@ void MainWindow::slot_setShowScrollBars()
     const bool showScrollBars = this->showScrollBarsAct->isChecked();
     setConfig().general.showScrollBars = showScrollBars;
     m_mapWindow->updateScrollBars();
-    show();
 }
 
 void MainWindow::slot_setShowMenuBar()
 {
     const bool showMenuBar = this->showMenuBarAct->isChecked();
     setConfig().general.showMenuBar = showMenuBar;
-    show();
 
     m_dockDialogAdventure->setMouseTracking(!showMenuBar);
     m_dockDialogClient->setMouseTracking(!showMenuBar);


### PR DESCRIPTION
This change addresses several UI issues on Windows:
1. Map freezing during theme switch: Caused by widget recreation when re-applying the 'Fusion' style. Added a guard to only set the style if it's not already Fusion.
2. Title bar remaining white in dark mode: Added a Win32 frame change notification to force a redraw of the non-client area.
3. Window position lost on restart:
    - Ensured 'firstRun' flag is cleared after the initial centering logic.
    - Reordered geometry/state restoration to the recommended Qt sequence.
    - Prevented overwriting valid geometry when the application is closed while minimized.
4. UI Flicker: Removed redundant show() calls in main window slots and moved the initial show() to the end of the constructor.

---
*PR created automatically by Jules for task [1552533465679808608](https://jules.google.com/task/1552533465679808608) started by @nschimme*