### PR TITLE
Refactor interaction handling and simplify magnification logic

### DIFF
--- a/src/display/Infomarks.cpp
+++ b/src/display/Infomarks.cpp
@@ -325,10 +325,8 @@ void MapCanvas::paintSelectedInfomarks()
             sel.for_each([this, &batch](const InfomarkHandle &marker) {
                 drawInfomark(batch, marker, m_currentLayer, {}, Colors::red);
             });
-            if (m_activeInteraction
-                && std::holds_alternative<InfomarkSelectionMove>(*m_activeInteraction)) {
-                const glm::vec2 offset = std::get<InfomarkSelectionMove>(*m_activeInteraction)
-                                             .pos.to_vec2();
+            if (auto *const move = getInfomarkSelectionMove()) {
+                const glm::vec2 offset = move->pos.to_vec2();
                 sel.for_each([this, &batch, &offset](const InfomarkHandle &marker) {
                     drawInfomark(batch, marker, m_currentLayer, offset, Colors::yellow);
                 });

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -241,18 +241,57 @@ public:
     NODISCARD MouseSel getSel2() const { return getMouseSel(m_sel2); }
 
 public:
-    NODISCARD bool hasRoomSelectionMove() const
+    NODISCARD const AltDragState *getAltDragState() const
     {
-        return m_activeInteraction && std::holds_alternative<RoomSelMove>(*m_activeInteraction);
+        return m_activeInteraction ? std::get_if<AltDragState>(&*m_activeInteraction) : nullptr;
     }
-    NODISCARD bool hasInfomarkSelectionMove() const
+    NODISCARD AltDragState *getAltDragState()
     {
-        return m_activeInteraction
-               && std::holds_alternative<InfomarkSelectionMove>(*m_activeInteraction);
+        return m_activeInteraction ? std::get_if<AltDragState>(&*m_activeInteraction) : nullptr;
     }
-    NODISCARD bool hasAreaSelection() const
+
+    NODISCARD const DragState *getDragState() const
     {
-        return m_activeInteraction
-               && std::holds_alternative<AreaSelectionState>(*m_activeInteraction);
+        return m_activeInteraction ? std::get_if<DragState>(&*m_activeInteraction) : nullptr;
     }
+    NODISCARD DragState *getDragState()
+    {
+        return m_activeInteraction ? std::get_if<DragState>(&*m_activeInteraction) : nullptr;
+    }
+
+    NODISCARD const RoomSelMove *getRoomSelMove() const
+    {
+        return m_activeInteraction ? std::get_if<RoomSelMove>(&*m_activeInteraction) : nullptr;
+    }
+    NODISCARD RoomSelMove *getRoomSelMove()
+    {
+        return m_activeInteraction ? std::get_if<RoomSelMove>(&*m_activeInteraction) : nullptr;
+    }
+
+    NODISCARD const InfomarkSelectionMove *getInfomarkSelectionMove() const
+    {
+        return m_activeInteraction ? std::get_if<InfomarkSelectionMove>(&*m_activeInteraction)
+                                   : nullptr;
+    }
+    NODISCARD InfomarkSelectionMove *getInfomarkSelectionMove()
+    {
+        return m_activeInteraction ? std::get_if<InfomarkSelectionMove>(&*m_activeInteraction)
+                                   : nullptr;
+    }
+
+    NODISCARD const AreaSelectionState *getAreaSelectionState() const
+    {
+        return m_activeInteraction ? std::get_if<AreaSelectionState>(&*m_activeInteraction)
+                                   : nullptr;
+    }
+    NODISCARD AreaSelectionState *getAreaSelectionState()
+    {
+        return m_activeInteraction ? std::get_if<AreaSelectionState>(&*m_activeInteraction)
+                                   : nullptr;
+    }
+
+public:
+    NODISCARD bool hasRoomSelectionMove() const { return getRoomSelMove() != nullptr; }
+    NODISCARD bool hasInfomarkSelectionMove() const { return getInfomarkSelectionMove() != nullptr; }
+    NODISCARD bool hasAreaSelection() const { return getAreaSelectionState() != nullptr; }
 };

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -292,6 +292,9 @@ public:
 
 public:
     NODISCARD bool hasRoomSelectionMove() const { return getRoomSelMove() != nullptr; }
-    NODISCARD bool hasInfomarkSelectionMove() const { return getInfomarkSelectionMove() != nullptr; }
+    NODISCARD bool hasInfomarkSelectionMove() const
+    {
+        return getInfomarkSelectionMove() != nullptr;
+    }
     NODISCARD bool hasAreaSelection() const { return getAreaSelectionState() != nullptr; }
 };

--- a/src/display/RoomSelections.cpp
+++ b/src/display/RoomSelections.cpp
@@ -125,9 +125,8 @@ void MapCanvas::paintSelectedRoom(RoomSelFakeGL &gl, const RawRoom &room)
     gl.resetMatrix();
 
     const float marginPixels = MapScreen::DEFAULT_MARGIN_PIXELS;
-    const bool isMoving = hasRoomSelectionMove();
 
-    if (!isMoving && !m_mapScreen.isRoomVisible(roomPos, marginPixels / 2.f)) {
+    if (!hasRoomSelectionMove() && !m_mapScreen.isRoomVisible(roomPos, marginPixels / 2.f)) {
         const glm::vec3 roomCenter = roomPos.to_vec3() + glm::vec3{0.5f, 0.5f, 0.f};
         const auto dot = DistantObjectTransform::construct(roomCenter, m_mapScreen, marginPixels);
         gl.glTranslatef(dot.offset.x, dot.offset.y, dot.offset.z);
@@ -155,8 +154,7 @@ void MapCanvas::paintSelectedRoom(RoomSelFakeGL &gl, const RawRoom &room)
         gl.resetMatrix();
     }
 
-    if (auto *const move = m_activeInteraction ? std::get_if<RoomSelMove>(&*m_activeInteraction)
-                                               : nullptr) {
+    if (auto *const move = getRoomSelMove()) {
         gl.resetMatrix();
         const auto &relativeOffset = move->pos;
         gl.glTranslatef(x + relativeOffset.x, y + relativeOffset.y, z);

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -322,20 +322,15 @@ bool MapCanvas::event(QEvent *const event)
                 deltaFactor += value;
             } else {
                 // On other platforms, it's typically the cumulative scale factor (1.0 at start).
-                if (nativeEvent->isBeginEvent()) {
-                    m_magnificationState.emplace(MagnificationState{1.f});
+                if (!m_magnificationState) {
+                    m_magnificationState.emplace(
+                        MagnificationState{nativeEvent->isBeginEvent() ? 1.f : value});
                 }
 
-                if (m_magnificationState
-                    && std::abs(m_magnificationState->lastValue) > GESTURE_EPSILON) {
+                if (std::abs(m_magnificationState->lastValue) > GESTURE_EPSILON) {
                     deltaFactor = value / m_magnificationState->lastValue;
                 }
-
-                if (!m_magnificationState) {
-                    m_magnificationState.emplace(MagnificationState{value});
-                } else {
-                    m_magnificationState->lastValue = value;
-                }
+                m_magnificationState->lastValue = value;
 
                 if (nativeEvent->isEndEvent()) {
                     m_magnificationState.reset();
@@ -625,9 +620,7 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
     }
     const auto xy = *optXy;
 
-    if (auto *const altDragState = m_activeInteraction
-                                       ? std::get_if<AltDragState>(&*m_activeInteraction)
-                                       : nullptr) {
+    if (auto *const altDragState = getAltDragState()) {
         // The user released the Alt key mid-drag.
         if (!((event->modifiers() & Qt::ALT) != 0u)) {
             setCursor(altDragState->originalCursor);
@@ -710,9 +703,8 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
     switch (m_canvasMouseMode) {
     case CanvasMouseModeEnum::SELECT_INFOMARKS:
         if (hasLeftButton && hasSel1() && hasSel2()) {
-            if (hasInfomarkSelectionMove()) {
-                std::get<InfomarkSelectionMove>(*m_activeInteraction).pos = getSel2().pos
-                                                                            - getSel1().pos;
+            if (auto *const move = getInfomarkSelectionMove()) {
+                move->pos = getSel2().pos - getSel1().pos;
                 setCursor(Qt::ClosedHandCursor);
 
             } else {
@@ -730,9 +722,7 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
         break;
     case CanvasMouseModeEnum::MOVE:
         if (hasLeftButton && m_mouseLeftPressed) {
-            if (auto *const dragState = m_activeInteraction
-                                            ? std::get_if<DragState>(&*m_activeInteraction)
-                                            : nullptr) {
+            if (auto *const dragState = getDragState()) {
                 const glm::vec3 currWorldPos = unproject_clamped(xy, dragState->startViewProj);
                 const glm::vec2 delta = glm::vec2(currWorldPos - dragState->startWorldPos);
 
@@ -751,7 +741,7 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
 
     case CanvasMouseModeEnum::SELECT_ROOMS:
         if (hasLeftButton) {
-            if (hasRoomSelectionMove() && hasSel1() && hasSel2()) {
+            if (auto *const move = getRoomSelMove(); move && hasSel1() && hasSel2()) {
                 auto &map = this->m_data;
                 auto isMovable = [&map](RoomSelection &sel, const Coordinate &offset) -> bool {
                     sel.removeMissing(map);
@@ -760,8 +750,8 @@ void MapCanvas::mouseMoveEvent(QMouseEvent *const event)
 
                 const auto diff = getSel2().pos.truncate() - getSel1().pos.truncate();
                 const auto wrongPlace = !isMovable(deref(m_roomSelection), Coordinate{diff, 0});
-                std::get<RoomSelMove>(*m_activeInteraction).pos = diff;
-                std::get<RoomSelMove>(*m_activeInteraction).wrongPlace = wrongPlace;
+                move->pos = diff;
+                move->wrongPlace = wrongPlace;
 
                 setCursor(wrongPlace ? Qt::ForbiddenCursor : Qt::ClosedHandCursor);
             } else {
@@ -817,9 +807,7 @@ void MapCanvas::mouseReleaseEvent(QMouseEvent *const event)
     }
     const auto xy = *optXy;
 
-    if (auto *const altDragState = m_activeInteraction
-                                       ? std::get_if<AltDragState>(&*m_activeInteraction)
-                                       : nullptr) {
+    if (auto *const altDragState = getAltDragState()) {
         setCursor(altDragState->originalCursor);
         m_activeInteraction.reset();
         event->accept();
@@ -838,8 +826,8 @@ void MapCanvas::mouseReleaseEvent(QMouseEvent *const event)
         setCursor(Qt::ArrowCursor);
         if (m_mouseLeftPressed) {
             m_mouseLeftPressed = false;
-            if (hasInfomarkSelectionMove()) {
-                const auto pos_copy = std::get<InfomarkSelectionMove>(*m_activeInteraction).pos;
+            if (auto *const move = getInfomarkSelectionMove()) {
+                const auto pos_copy = move->pos;
                 m_activeInteraction.reset();
                 if (m_infoMarkSelection != nullptr) {
                     const auto offset = Coordinate{(pos_copy * INFOMARK_SCALE).truncate(), 0};
@@ -922,9 +910,9 @@ void MapCanvas::mouseReleaseEvent(QMouseEvent *const event)
         if (m_mouseLeftPressed) {
             m_mouseLeftPressed = false;
 
-            if (hasRoomSelectionMove()) {
-                const auto pos = std::get<RoomSelMove>(*m_activeInteraction).pos;
-                const bool wrongPlace = std::get<RoomSelMove>(*m_activeInteraction).wrongPlace;
+            if (auto *const move = getRoomSelMove()) {
+                const auto pos = move->pos;
+                const bool wrongPlace = move->wrongPlace;
                 m_activeInteraction.reset();
                 if (!wrongPlace && (m_roomSelection != nullptr)) {
                     const Coordinate moverel{pos, 0};


### PR DESCRIPTION
I have addressed the code review comments by refactoring the interaction handling and simplifying the magnification gesture logic.

Key changes:
1.  **Centralized Interaction State Helpers**: Added `getAltDragState()`, `getDragState()`, `getRoomSelMove()`, `getInfomarkSelectionMove()`, and `getAreaSelectionState()` to `MapCanvasInputState`. These methods provide type-safe access to the current interaction state, significantly reducing `std::get_if` and `std::get` boilerplate throughout the codebase.
2.  **Simplified Magnification Logic**: Refactored the magnification gesture handling in `MapCanvas::event` to eliminate redundant state checks and provide a clearer initialization/update path for `m_magnificationState`.
3.  **`paintSelectedRoom` Cleanup**: Removed the redundant `isMoving` local variable in `paintSelectedRoom` and replaced it with a direct call to `hasRoomSelectionMove()`, as requested.

The changes have been verified through successful builds and by running the `TestGlobal` and `TestMap` test suites.

---
*PR created automatically by Jules for task [14439743994290145303](https://jules.google.com/task/14439743994290145303) started by @nschimme*