### PR TITLE
Refactor FrameManager and MapCanvas to address review comments

### DIFF
--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -32,7 +32,7 @@ void FrameManager::registerCallback(const Signal2Lifetime &lifetime, AnimationCa
 
 bool FrameManager::needsHeartbeat() const
 {
-    if (m_animating || m_dirty) {
+    if (m_dirty) {
         return true;
     }
 
@@ -95,23 +95,9 @@ std::optional<FrameManager::Frame> FrameManager::beginFrame()
     return Frame(*this);
 }
 
-void FrameManager::setAnimating(bool value)
-{
-    if (m_animating == value) {
-        return;
-    }
-
-    m_animating = value;
-
-    if (m_animating && !m_heartbeatTimer.isActive()) {
-        onHeartbeat();
-    }
-}
-
 void FrameManager::onHeartbeat()
 {
     if (!needsHeartbeat()) {
-        m_animating = false;
         m_heartbeatTimer.stop();
         return;
     }

--- a/src/display/FrameManager.h
+++ b/src/display/FrameManager.h
@@ -22,9 +22,8 @@ class QOpenGLWindow;
  *
  * FrameManager provides:
  * 1. Pacing: Ensures the application doesn't exceed the target FPS limit.
- * 2. Delta Time: Calculates accurate time between frames for smooth animations.
- * 3. Heartbeat: Automatically requests new frames while animations are active.
- * 4. Dirty Tracking: Skips redundant renders when nothing has changed.
+ * 2. Heartbeat: Automatically requests new frames while animations are active.
+ * 3. Dirty Tracking: Skips redundant renders when nothing has changed.
  *
  * It uses a "start-to-start" interval pacing approach, which ensures the target
  * frame rate is hit regardless of how long each frame takes to render (as long

--- a/src/display/FrameManager.h
+++ b/src/display/FrameManager.h
@@ -51,7 +51,6 @@ private:
     Signal2Lifetime m_configLifetime;
     QTimer m_heartbeatTimer;
     QOpenGLWindow &m_window;
-    bool m_animating = false;
     bool m_dirty = true;
 
     friend class TestFrameManager;
@@ -106,11 +105,6 @@ private:
      * Does not set the dirty flag.
      */
     void requestFrame();
-
-    /**
-     * @brief Enable or disable continuous background animation.
-     */
-    void setAnimating(bool value);
 
     /**
      * @brief Check if any registered animations or heartbeat are active.

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -787,7 +787,6 @@ void MapCanvas::paintGL()
 {
     auto frame = m_frameManager.beginFrame();
     if (!frame) {
-        qDebug() << "Frame update skipped";
         return;
     }
 


### PR DESCRIPTION
This change addresses two points from a code review:
1. It removes the noisy `qDebug() << "Frame update skipped";` from `MapCanvas::paintGL`.
2. It simplifies `FrameManager` by removing the unused `m_animating` state and the `setAnimating` method, as the heartbeat is now sufficiently driven by the dirty flag and registered animation callbacks.

---
*PR created automatically by Jules for task [11779383216689648170](https://jules.google.com/task/11779383216689648170) started by @nschimme*