### PR TITLE
Improve UboManager safety and integration

### DIFF
--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -220,7 +220,7 @@ void OpenGL::resetNamedColorsBuffer()
 void OpenGL::initializeRenderer(const float devicePixelRatio)
 {
     setDevicePixelRatio(devicePixelRatio);
-    getFunctions().setUboManager(&m_uboManager);
+    getFunctions().setUboManager(m_uboManager);
 
     // REVISIT: Move this somewhere else?
     GLint maxSamples = 0;

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -65,6 +65,7 @@ public:
     {
         if (isInvalid(block)) {
             const auto &func = m_rebuildFunctions[block];
+            assert(func && "UBO block is invalid and no rebuild function is registered");
             if (func) {
                 func(gl);
                 // The rebuild function is expected to call update() which marks it valid.
@@ -103,6 +104,10 @@ public:
     void bind(Legacy::Functions &gl, Legacy::SharedVboEnum block)
     {
         updateIfInvalid(gl, block);
+
+        if (isInvalid(block)) {
+            return;
+        }
 
         const auto sharedVbo = gl.getSharedVbos().get(block);
         Legacy::VBO &vbo = deref(sharedVbo);

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -341,13 +341,14 @@ FBO &Functions::getFBO()
     return deref(m_fbo);
 }
 
-void Functions::setUboManager(UboManager *manager)
+void Functions::setUboManager(UboManager &manager)
 {
-    m_uboManager = manager;
+    m_uboManager = &manager;
 }
 
 UboManager &Functions::getUboManager()
 {
+    assert(m_uboManager != nullptr && "UboManager accessed before being set");
     return deref(m_uboManager);
 }
 

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -313,7 +313,7 @@ public:
 
     NODISCARD FBO &getFBO();
 
-    void setUboManager(UboManager *manager);
+    void setUboManager(UboManager &manager);
     NODISCARD UboManager &getUboManager();
 
 private:


### PR DESCRIPTION
This change addresses safety concerns in the UBO management logic. 
It ensures that uninitialized UBOs are not bound to the GPU and that developer errors (like missing rebuild functions or early access to the UboManager) are caught early with assertions. 
It also improves the API by using a reference-based setter for the UboManager, making it clearer that a valid instance is required.

---
*PR created automatically by Jules for task [18437877276167088834](https://jules.google.com/task/18437877276167088834) started by @nschimme*

## Summary by Sourcery

Improve safety and robustness of UBO management and its integration with legacy OpenGL functions.

Bug Fixes:
- Prevent binding or using invalid/uninitialized UBO blocks when no rebuild function is registered.
- Avoid operating on UBOs that remain invalid after an attempted rebuild.

Enhancements:
- Add assertions to catch missing UBO rebuild functions and early access to the UboManager during development.
- Change the legacy Functions API to accept a UboManager by reference, clarifying that a valid instance must be provided and stored.