### PR TITLE
Address weather system and particle rendering review comments

### DIFF
--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -61,16 +61,15 @@ GLWeather::GLWeather(OpenGL &gl,
     m_moonIntensityStart = m_targetMoonIntensity;
 
     auto lerpCurrentIntensities = [this]() {
-        float t = (m_animationManager.getElapsedTime() - m_weatherTransitionStartTime)
-                  / TRANSITION_DURATION;
-        float factor = std::clamp(t, 0.0f, 1.0f);
-        m_rainIntensityStart = my_lerp(m_rainIntensityStart, m_targetRainIntensity, factor);
-        m_snowIntensityStart = my_lerp(m_snowIntensityStart, m_targetSnowIntensity, factor);
-        m_cloudsIntensityStart = my_lerp(m_cloudsIntensityStart, m_targetCloudsIntensity, factor);
-        m_fogIntensityStart = my_lerp(m_fogIntensityStart, m_targetFogIntensity, factor);
-        m_precipitationTypeStart = my_lerp(m_precipitationTypeStart,
-                                           m_targetPrecipitationType,
-                                           factor);
+        applyTransition(m_weatherTransitionStartTime, m_rainIntensityStart, m_targetRainIntensity);
+        applyTransition(m_weatherTransitionStartTime, m_snowIntensityStart, m_targetSnowIntensity);
+        applyTransition(m_weatherTransitionStartTime,
+                        m_cloudsIntensityStart,
+                        m_targetCloudsIntensity);
+        applyTransition(m_weatherTransitionStartTime, m_fogIntensityStart, m_targetFogIntensity);
+        applyTransition(m_weatherTransitionStartTime,
+                        m_precipitationTypeStart,
+                        m_targetPrecipitationType);
     };
 
     m_observer.sig2_weatherChanged
@@ -97,13 +96,12 @@ GLWeather::GLWeather(OpenGL &gl,
             return;
         }
 
-        float t = (m_animationManager.getElapsedTime() - m_timeOfDayTransitionStartTime)
-                  / TRANSITION_DURATION;
-        float factor = std::clamp(t, 0.0f, 1.0f);
-        m_timeOfDayIntensityStart = my_lerp(m_timeOfDayIntensityStart,
-                                            m_targetTimeOfDayIntensity,
-                                            factor);
-        m_moonIntensityStart = my_lerp(m_moonIntensityStart, m_targetMoonIntensity, factor);
+        applyTransition(m_timeOfDayTransitionStartTime,
+                        m_timeOfDayIntensityStart,
+                        m_targetTimeOfDayIntensity);
+        applyTransition(m_timeOfDayTransitionStartTime,
+                        m_moonIntensityStart,
+                        m_targetMoonIntensity);
 
         m_oldTimeOfDay = m_currentTimeOfDay;
         m_currentTimeOfDay = timeOfDay;
@@ -119,13 +117,12 @@ GLWeather::GLWeather(OpenGL &gl,
             if (visibility == m_moonVisibility) {
                 return;
             }
-            float t = (m_animationManager.getElapsedTime() - m_timeOfDayTransitionStartTime)
-                      / TRANSITION_DURATION;
-            float factor = std::clamp(t, 0.0f, 1.0f);
-            m_moonIntensityStart = my_lerp(m_moonIntensityStart, m_targetMoonIntensity, factor);
-            m_timeOfDayIntensityStart = my_lerp(m_timeOfDayIntensityStart,
-                                                m_targetTimeOfDayIntensity,
-                                                factor);
+            applyTransition(m_timeOfDayTransitionStartTime,
+                            m_moonIntensityStart,
+                            m_targetMoonIntensity);
+            applyTransition(m_timeOfDayTransitionStartTime,
+                            m_timeOfDayIntensityStart,
+                            m_targetTimeOfDayIntensity);
 
             m_moonVisibility = visibility;
             m_targetMoonIntensity = (visibility == MumeMoonVisibilityEnum::BRIGHT) ? 1.0f : 0.0f;
@@ -143,12 +140,9 @@ GLWeather::GLWeather(OpenGL &gl,
     };
 
     auto onTimeOfDaySettingChanged = [this]() {
-        float t = (m_animationManager.getElapsedTime() - m_timeOfDayTransitionStartTime)
-                  / TRANSITION_DURATION;
-        float factor = std::clamp(t, 0.0f, 1.0f);
-        m_timeOfDayIntensityStart = my_lerp(m_timeOfDayIntensityStart,
-                                            m_targetTimeOfDayIntensity,
-                                            factor);
+        applyTransition(m_timeOfDayTransitionStartTime,
+                        m_timeOfDayIntensityStart,
+                        m_targetTimeOfDayIntensity);
 
         updateTargets();
         m_timeOfDayTransitionStartTime = m_animationManager.getElapsedTime();
@@ -346,6 +340,13 @@ void GLWeather::invalidateCamera()
 void GLWeather::invalidateWeather()
 {
     m_gl.getUboManager().invalidate(Legacy::SharedVboEnum::WeatherBlock);
+}
+
+void GLWeather::applyTransition(float startTime, float &startVal, float targetVal)
+{
+    float t = (m_animationManager.getElapsedTime() - startTime) / TRANSITION_DURATION;
+    float factor = std::clamp(t, 0.0f, 1.0f);
+    startVal = my_lerp(startVal, targetVal, factor);
 }
 
 void GLWeather::initMeshes()

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -112,4 +112,6 @@ private:
     NODISCARD GLRenderState::Uniforms::Weather::Camera getCameraData(
         const glm::mat4 &viewProj, const Coordinate &playerPos) const;
     void populateWeatherParams(GLRenderState::Uniforms::Weather::Params &params) const;
+
+    void applyTransition(float startTime, float &startVal, float targetVal);
 };

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -149,17 +149,53 @@ ParticleRenderMesh::ParticleRenderMesh(SharedFunctions shared_functions,
 
 ParticleRenderMesh::~ParticleRenderMesh() = default;
 
-void ParticleRenderMesh::init() {}
+void ParticleRenderMesh::init()
+{
+    if (m_initialized) {
+        return;
+    }
+
+    for (int i = 0; i < 2; ++i) {
+        m_functions.glBindVertexArray(m_vaos[i].get());
+        m_functions.glBindBuffer(GL_ARRAY_BUFFER, m_simulation.getParticleVbo(i).get());
+        m_functions.enableAttrib(0,
+                                 2,
+                                 GL_FLOAT,
+                                 GL_FALSE,
+                                 sizeof(WeatherParticleVert),
+                                 reinterpret_cast<void *>(offsetof(WeatherParticleVert, pos)));
+        m_functions.glVertexAttribDivisor(0, 1);
+        m_functions.enableAttrib(1,
+                                 1,
+                                 GL_FLOAT,
+                                 GL_FALSE,
+                                 sizeof(WeatherParticleVert),
+                                 reinterpret_cast<void *>(offsetof(WeatherParticleVert, life)));
+        m_functions.glVertexAttribDivisor(1, 1);
+    }
+    m_functions.glBindVertexArray(0);
+    m_functions.glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    m_initialized = true;
+}
 
 void ParticleRenderMesh::virt_reset()
 {
     for (int i = 0; i < 2; ++i) {
         m_vaos[i].reset();
     }
+    m_initialized = false;
+}
+
+bool ParticleRenderMesh::virt_isEmpty() const
+{
+    return m_simulation.virt_isEmpty() || !m_initialized;
 }
 
 void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
 {
+    init();
+
     // The particle count is determined by the max intensity in the UBO.
     // However, since we don't have direct access to the UBO data here without re-parsing,
     // we use a reasonable maximum and let the shader discard if necessary,
@@ -175,27 +211,8 @@ void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
     const uint32_t bufferIdx = m_simulation.getCurrentBuffer();
 
     m_functions.glBindVertexArray(m_vaos[bufferIdx].get());
-
-    m_functions.glBindBuffer(GL_ARRAY_BUFFER, m_simulation.getParticleVbo(bufferIdx).get());
-    m_functions.enableAttrib(0,
-                             2,
-                             GL_FLOAT,
-                             GL_FALSE,
-                             sizeof(WeatherParticleVert),
-                             reinterpret_cast<void *>(offsetof(WeatherParticleVert, pos)));
-    m_functions.glVertexAttribDivisor(0, 1);
-    m_functions.enableAttrib(1,
-                             1,
-                             GL_FLOAT,
-                             GL_FALSE,
-                             sizeof(WeatherParticleVert),
-                             reinterpret_cast<void *>(offsetof(WeatherParticleVert, life)));
-    m_functions.glVertexAttribDivisor(1, 1);
-
     m_functions.glDrawArraysInstanced(GL_TRIANGLE_STRIP, 0, 4, count);
-
     m_functions.glBindVertexArray(0);
-    m_functions.glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/WeatherMeshes.h
+++ b/src/opengl/legacy/WeatherMeshes.h
@@ -56,8 +56,10 @@ private:
     void init();
     void virt_clear() override {}
     void virt_reset() override;
-    NODISCARD bool virt_isEmpty() const override { return !m_initialized; }
     void virt_render(const GLRenderState &renderState) override;
+
+public:
+    NODISCARD bool virt_isEmpty() const override { return !m_initialized; }
 
 public:
     NODISCARD uint32_t getCurrentBuffer() const { return m_currentBuffer; }
@@ -74,6 +76,7 @@ private:
     const ParticleSimulationMesh &m_simulation;
 
     VAO m_vaos[2];
+    bool m_initialized = false;
 
 public:
     explicit ParticleRenderMesh(SharedFunctions shared_functions,
@@ -85,7 +88,7 @@ private:
     void init();
     void virt_clear() override {}
     void virt_reset() override;
-    NODISCARD bool virt_isEmpty() const override { return false; }
+    NODISCARD bool virt_isEmpty() const override;
     void virt_render(const GLRenderState &renderState) override;
 };
 

--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -5,7 +5,7 @@ precision highp float;
 
 layout(std140) uniform NamedColorsBlock
 {
-    vec4 uNamedColors[32];
+    vec4 uNamedColors[MAX_NAMED_COLORS];
 };
 
 layout(std140) uniform CameraBlock

--- a/src/resources/shaders/legacy/weather/timeofday/frag.glsl
+++ b/src/resources/shaders/legacy/weather/timeofday/frag.glsl
@@ -5,7 +5,7 @@ precision highp float;
 
 layout(std140) uniform NamedColorsBlock
 {
-    vec4 uNamedColors[32];
+    vec4 uNamedColors[MAX_NAMED_COLORS];
 };
 
 layout(std140) uniform TimeBlock


### PR DESCRIPTION
This PR addresses several issues raised in a code review:
- Extracted a transition helper in GLWeather to reduce code duplication for weather, fog, and time-of-day transitions.
- Updated weather shaders (atmosphere and timeofday) to use MAX_NAMED_COLORS instead of a hard-coded array size, preventing potential out-of-bounds access.
- Refactored ParticleRenderMesh to pre-configure VAOs in init() and improved virt_isEmpty() to accurately reflect initialization and simulation state.
- Fixed a private access issue in ParticleSimulationMesh::virt_isEmpty().

---
*PR created automatically by Jules for task [12940635532026092730](https://jules.google.com/task/12940635532026092730) started by @nschimme*

## Summary by Sourcery

Refine weather transitions and particle rendering to reduce duplication, align with shader configuration limits, and better reflect initialization and simulation state.

Bug Fixes:
- Prevent potential out-of-bounds access in weather shaders by using MAX_NAMED_COLORS for the named color array size.
- Ensure ParticleRenderMesh::virt_isEmpty reflects both render mesh initialization and underlying simulation emptiness.
- Fix access level for ParticleSimulationMesh::virt_isEmpty so it can be queried externally.

Enhancements:
- Extract a reusable transition helper in GLWeather to unify weather, fog, and time-of-day interpolation logic.
- Preconfigure particle rendering VAOs during ParticleRenderMesh initialization and reuse them on render instead of re-binding attributes each frame.