### PR TITLE
Enhance UboManager with shadow copies and partial updates

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -416,6 +416,8 @@ set(mmapper_SRCS
     opengl/OpenGL.cpp
     opengl/OpenGL.h
     opengl/UboManager.h
+    opengl/Weather.cpp
+    opengl/Weather.h
     opengl/OpenGLConfig.cpp
     opengl/OpenGLConfig.h
     opengl/OpenGLTypes.cpp
@@ -444,10 +446,14 @@ set(mmapper_SRCS
     opengl/legacy/Shaders.h
     opengl/legacy/SimpleMesh.cpp
     opengl/legacy/SimpleMesh.h
+    opengl/legacy/TFO.cpp
+    opengl/legacy/TFO.h
     opengl/legacy/VAO.cpp
     opengl/legacy/VAO.h
     opengl/legacy/VBO.cpp
     opengl/legacy/VBO.h
+    opengl/legacy/WeatherMeshes.cpp
+    opengl/legacy/WeatherMeshes.h
     parser/Abbrev.cpp
     parser/Abbrev.h
     parser/AbstractParser-Actions.cpp

--- a/src/clock/mumeclock.cpp
+++ b/src/clock/mumeclock.cpp
@@ -322,7 +322,7 @@ void MumeClock::parseWeather(const MumeTimeEnum time, int64_t secsSinceEpoch)
         }
     }
 
-    updateObserver(moment);
+    updateObserver(moment, secsSinceEpoch);
 }
 
 void MumeClock::parseClockTime(const QString &clockTime)
@@ -401,7 +401,11 @@ void MumeClock::setLastSyncEpoch(int64_t epoch)
 
 MumeClockPrecisionEnum MumeClock::getPrecision()
 {
-    const int64_t secsSinceEpoch = QDateTime::QDateTime::currentSecsSinceEpoch();
+    return getPrecision(QDateTime::currentSecsSinceEpoch());
+}
+
+MumeClockPrecisionEnum MumeClock::getPrecision(const int64_t secsSinceEpoch)
+{
     if (m_precision >= MumeClockPrecisionEnum::HOUR
         && secsSinceEpoch - m_lastSyncEpoch > ONE_RL_DAY_IN_SECONDS) {
         m_precision = MumeClockPrecisionEnum::DAY;
@@ -501,13 +505,21 @@ int MumeClock::getMumeWeekday(const QString &weekdayName)
 
 void MumeClock::slot_tick()
 {
-    const MumeMoment moment = getMumeMoment();
+    const int64_t now = QDateTime::currentSecsSinceEpoch();
+    const MumeMoment moment = MumeMoment::sinceMumeEpoch(now - m_mumeStartEpoch);
     m_observer.observeTick(moment);
-    updateObserver(moment);
+    updateObserver(moment, now);
 }
 
-void MumeClock::updateObserver(const MumeMoment &moment)
+void MumeClock::updateObserver(const MumeMoment &moment, const int64_t now)
 {
+    // Do not propagate clock-based signals to the observer unless we have at least
+    // hour precision. This prevents inaccurate weather/lighting effects when the
+    // clock is not yet synchronized.
+    if (getPrecision(now) < MumeClockPrecisionEnum::HOUR) {
+        return;
+    }
+
     const auto timeOfDay = moment.toTimeOfDay();
     if (timeOfDay != m_timeOfDay) {
         m_timeOfDay = timeOfDay;

--- a/src/clock/mumeclock.h
+++ b/src/clock/mumeclock.h
@@ -107,6 +107,7 @@ public:
 
     // REVISIT: This can't be const because it logs.
     NODISCARD MumeClockPrecisionEnum getPrecision();
+    NODISCARD MumeClockPrecisionEnum getPrecision(int64_t secsSinceEpoch);
 
     NODISCARD QString toMumeTime(const MumeMoment &moment) const;
     NODISCARD QString toCountdown(const MumeMoment &moment) const;
@@ -158,7 +159,7 @@ protected:
 
 private:
     void onUserGmcp(const GmcpMessage &msg);
-    void updateObserver(const MumeMoment &moment);
+    void updateObserver(const MumeMoment &moment, int64_t now);
 
 signals:
     void sig_log(const QString &, const QString &);

--- a/src/clock/mumeclockwidget.cpp
+++ b/src/clock/mumeclockwidget.cpp
@@ -41,11 +41,12 @@ MumeClockWidget::MumeClockWidget(GameObserver &observer, MumeClock &clock, QWidg
     observer.sig2_tick.connect(m_lifetime,
                                [this](const MumeMoment &moment) { updateCountdown(moment); });
 
-    updateTime(observer.getTimeOfDay());
-    updateMoonPhase(observer.getMoonPhase());
-    updateMoonVisibility(observer.getMoonVisibility());
-    updateSeason(observer.getSeason());
-    updateCountdown(clock.getMumeMoment());
+    auto moment = m_clock.getMumeMoment();
+    updateTime(moment.toTimeOfDay());
+    updateMoonPhase(moment.moonPhase());
+    updateMoonVisibility(moment.moonVisibility());
+    updateSeason(moment.toSeason());
+    updateCountdown(moment);
 }
 
 MumeClockWidget::~MumeClockWidget() = default;

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -298,6 +298,9 @@ ConstString KEY_THEME = "Theme";
 ConstString KEY_TLS_ENCRYPTION = "TLS encryption";
 ConstString KEY_USE_INTERNAL_EDITOR = "Use internal editor";
 ConstString KEY_USE_TRILINEAR_FILTERING = "Use trilinear filtering";
+ConstString KEY_WEATHER_ATMOSPHERE_INTENSITY = "weather.atmosphereIntensity";
+ConstString KEY_WEATHER_PRECIPITATION_INTENSITY = "weather.precipitationIntensity";
+ConstString KEY_WEATHER_TIME_OF_DAY_INTENSITY = "weather.todIntensity";
 ConstString KEY_WINDOW_GEOMETRY = "Window Geometry";
 ConstString KEY_WINDOW_STATE = "Window State";
 ConstString KEY_BELL_AUDIBLE = "Bell audible";
@@ -662,6 +665,14 @@ void Configuration::CanvasSettings::read(const QSettings &conf)
     advanced.verticalAngle.set(conf.value(KEY_3D_VERTICAL_ANGLE, 450).toInt());
     advanced.horizontalAngle.set(conf.value(KEY_3D_HORIZONTAL_ANGLE, 0).toInt());
     advanced.layerHeight.set(conf.value(KEY_3D_LAYER_HEIGHT, 15).toInt());
+
+    weatherAtmosphereIntensity.set(conf.value(KEY_WEATHER_ATMOSPHERE_INTENSITY, 50).toInt());
+    weatherPrecipitationIntensity.set(conf.value(KEY_WEATHER_PRECIPITATION_INTENSITY, 50).toInt());
+    weatherTimeOfDayIntensity.set(conf.value(KEY_WEATHER_TIME_OF_DAY_INTENSITY, 50).toInt());
+
+    weatherAtmosphereIntensity.clamp(0, 100);
+    weatherPrecipitationIntensity.clamp(0, 100);
+    weatherTimeOfDayIntensity.clamp(0, 100);
 }
 
 void Configuration::AccountSettings::read(const QSettings &conf)
@@ -859,6 +870,10 @@ void Configuration::CanvasSettings::write(QSettings &conf) const
     conf.setValue(KEY_3D_VERTICAL_ANGLE, advanced.verticalAngle.get());
     conf.setValue(KEY_3D_HORIZONTAL_ANGLE, advanced.horizontalAngle.get());
     conf.setValue(KEY_3D_LAYER_HEIGHT, advanced.layerHeight.get());
+
+    conf.setValue(KEY_WEATHER_ATMOSPHERE_INTENSITY, weatherAtmosphereIntensity.get());
+    conf.setValue(KEY_WEATHER_PRECIPITATION_INTENSITY, weatherPrecipitationIntensity.get());
+    conf.setValue(KEY_WEATHER_TIME_OF_DAY_INTENSITY, weatherTimeOfDayIntensity.get());
 }
 
 void Configuration::AccountSettings::write(QSettings &conf) const

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -184,6 +184,10 @@ public:
 
         MMapper::Array<int, 3> mapRadius{100, 100, 100};
 
+        NamedConfig<int> weatherAtmosphereIntensity{"WEATHER_ATMOSPHERE_INTENSITY", 50};
+        NamedConfig<int> weatherPrecipitationIntensity{"WEATHER_PRECIPITATION_INTENSITY", 50};
+        NamedConfig<int> weatherTimeOfDayIntensity{"WEATHER_TIME_OF_DAY_INTENSITY", 50};
+
         struct NODISCARD Advanced final
         {
             NamedConfig<bool> use3D{"MMAPPER_3D", true};

--- a/src/configuration/configuration.h
+++ b/src/configuration/configuration.h
@@ -193,7 +193,7 @@ public:
             NamedConfig<bool> use3D{"MMAPPER_3D", true};
             NamedConfig<bool> autoTilt{"MMAPPER_AUTO_TILT", true};
             NamedConfig<bool> printPerfStats{"MMAPPER_GL_PERFSTATS", IS_DEBUG_BUILD};
-            FixedPoint<0> maximumFps{4, 300, 60};
+            FixedPoint<0> maximumFps{4, 240, 60};
 
             // 5..90 degrees
             FixedPoint<1> fov{50, 900, 765};

--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -9,10 +9,19 @@
 
 #include <QOpenGLWindow>
 
-FrameManager::FrameManager(QOpenGLWindow &window, QObject *parent)
+FrameManager::FrameManager(QOpenGLWindow &window,
+                           Legacy::UboManager &uboManager,
+                           QObject *parent)
     : QObject(parent)
     , m_window(window)
+    , m_uboManager(uboManager)
 {
+    m_uboManager.registerRebuildFunction(Legacy::SharedVboEnum::TimeBlock,
+                                         [this](Legacy::Functions &gl) {
+                                             m_uboManager.update<Legacy::SharedVboEnum::TimeBlock>(
+                                                 gl, m_frameData);
+                                         });
+
     updateMinFrameTime();
     setConfig().canvas.advanced.maximumFps.registerChangeCallback(m_configLifetime, [this]() {
         updateMinFrameTime();
@@ -27,9 +36,7 @@ FrameManager::FrameManager(QOpenGLWindow &window, QObject *parent)
 
 FrameManager::~FrameManager()
 {
-    if (m_uboManager) {
-        m_uboManager->unregisterRebuildFunction(Legacy::SharedVboEnum::TimeBlock);
-    }
+    m_uboManager.unregisterRebuildFunction(Legacy::SharedVboEnum::TimeBlock);
 }
 
 void FrameManager::registerCallback(const Signal2Lifetime &lifetime, AnimationCallback callback)
@@ -37,14 +44,6 @@ void FrameManager::registerCallback(const Signal2Lifetime &lifetime, AnimationCa
     m_callbacks.push_back({lifetime.getObj(), std::move(callback)});
 }
 
-void FrameManager::init(Legacy::UboManager &uboManager)
-{
-    m_uboManager = &uboManager;
-    m_uboManager
-        ->registerRebuildFunction(Legacy::SharedVboEnum::TimeBlock, [this](Legacy::Functions &gl) {
-            m_uboManager->update<Legacy::SharedVboEnum::TimeBlock>(gl, m_frameData);
-        });
-}
 
 bool FrameManager::needsHeartbeat()
 {
@@ -137,8 +136,8 @@ std::optional<FrameManager::Frame> FrameManager::beginFrame()
     m_elapsedTime += lastFrameDeltaTime;
     m_frameData.time = glm::vec4(m_elapsedTime, lastFrameDeltaTime, 0.0f, 0.0f);
 
-    if (lastFrameDeltaTime > 0.0f && m_uboManager != nullptr) {
-        m_uboManager->invalidate(Legacy::SharedVboEnum::TimeBlock);
+    if (lastFrameDeltaTime > 0.0f) {
+        m_uboManager.invalidate(Legacy::SharedVboEnum::TimeBlock);
     }
 
     return Frame(*this);

--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -42,9 +42,8 @@ void FrameManager::init(Legacy::UboManager &uboManager)
     m_uboManager = &uboManager;
     m_uboManager->registerRebuildFunction(Legacy::SharedVboEnum::TimeBlock,
                                           [this](Legacy::Functions &gl) {
-                                              m_uboManager->update(gl,
-                                                                   Legacy::SharedVboEnum::TimeBlock,
-                                                                   m_frameData);
+                                              m_uboManager->update<Legacy::SharedVboEnum::TimeBlock>(
+                                                  gl, m_frameData);
                                           });
 }
 

--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -25,6 +25,13 @@ FrameManager::FrameManager(QOpenGLWindow &window, QObject *parent)
     requestFrame();
 }
 
+FrameManager::~FrameManager()
+{
+    if (m_uboManager) {
+        m_uboManager->unregisterRebuildFunction(Legacy::SharedVboEnum::TimeBlock);
+    }
+}
+
 void FrameManager::registerCallback(const Signal2Lifetime &lifetime, AnimationCallback callback)
 {
     m_callbacks.push_back({lifetime.getObj(), std::move(callback)});

--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -132,7 +132,8 @@ std::optional<FrameManager::Frame> FrameManager::beginFrame()
     m_elapsedTime += lastFrameDeltaTime;
     m_frameData.time = glm::vec4(m_elapsedTime, lastFrameDeltaTime, 0.0f, 0.0f);
 
-    if (m_uboManager && lastFrameDeltaTime > 0.0f) {
+    if (lastFrameDeltaTime > 0.0f) {
+        assert(m_uboManager && "FrameManager::beginFrame: m_uboManager is not initialized");
         m_uboManager->invalidate(Legacy::SharedVboEnum::TimeBlock);
     }
 

--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -40,11 +40,10 @@ void FrameManager::registerCallback(const Signal2Lifetime &lifetime, AnimationCa
 void FrameManager::init(Legacy::UboManager &uboManager)
 {
     m_uboManager = &uboManager;
-    m_uboManager->registerRebuildFunction(Legacy::SharedVboEnum::TimeBlock,
-                                          [this](Legacy::Functions &gl) {
-                                              m_uboManager->update<Legacy::SharedVboEnum::TimeBlock>(
-                                                  gl, m_frameData);
-                                          });
+    m_uboManager
+        ->registerRebuildFunction(Legacy::SharedVboEnum::TimeBlock, [this](Legacy::Functions &gl) {
+            m_uboManager->update<Legacy::SharedVboEnum::TimeBlock>(gl, m_frameData);
+        });
 }
 
 bool FrameManager::needsHeartbeat()

--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -30,6 +30,17 @@ void FrameManager::registerCallback(const Signal2Lifetime &lifetime, AnimationCa
     m_callbacks.push_back({lifetime.getObj(), std::move(callback)});
 }
 
+void FrameManager::init(Legacy::UboManager &uboManager)
+{
+    m_uboManager = &uboManager;
+    m_uboManager->registerRebuildFunction(Legacy::SharedVboEnum::TimeBlock,
+                                          [this](Legacy::Functions &gl) {
+                                              m_uboManager->update(gl,
+                                                                   Legacy::SharedVboEnum::TimeBlock,
+                                                                   m_frameData);
+                                          });
+}
+
 bool FrameManager::needsHeartbeat()
 {
     // NOTE:
@@ -105,8 +116,32 @@ std::optional<FrameManager::Frame> FrameManager::beginFrame()
     }
     m_dirty = false;
 
+    // Calculate delta time
+    float deltaTime = 0.0f;
+    if (hasLastUpdate) {
+        const auto elapsed = now - m_lastUpdateTime;
+        deltaTime = std::chrono::duration<float>(elapsed).count();
+    }
     m_lastUpdateTime = now;
+
+    // Cap deltaTime for simulation to match map movement during dragging and avoid quantization jitter.
+    // Cap at 1.0s to avoid huge jumps after window focus loss or lag, while supporting low FPS.
+    auto lastFrameDeltaTime = std::min(deltaTime, 1.0f);
+
+    // Refresh internal struct for UBO
+    m_elapsedTime += lastFrameDeltaTime;
+    m_frameData.time = glm::vec4(m_elapsedTime, lastFrameDeltaTime, 0.0f, 0.0f);
+
+    if (m_uboManager && lastFrameDeltaTime > 0.0f) {
+        m_uboManager->invalidate(Legacy::SharedVboEnum::TimeBlock);
+    }
+
     return Frame(*this);
+}
+
+float FrameManager::getElapsedTime() const
+{
+    return m_elapsedTime;
 }
 
 void FrameManager::onHeartbeat()

--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -16,7 +16,7 @@ FrameManager::FrameManager(QOpenGLWindow &window, Legacy::UboManager &uboManager
 {
     m_uboManager
         .registerRebuildFunction(Legacy::SharedVboEnum::TimeBlock, [this](Legacy::Functions &gl) {
-            m_uboManager.update<Legacy::SharedVboEnum::TimeBlock>(gl, m_frameData);
+            m_uboManager.sync<Legacy::SharedVboEnum::TimeBlock>(gl);
         });
 
     updateMinFrameTime();
@@ -130,7 +130,8 @@ std::optional<FrameManager::Frame> FrameManager::beginFrame()
 
     // Refresh internal struct for UBO
     m_elapsedTime += lastFrameDeltaTime;
-    m_frameData.time = glm::vec4(m_elapsedTime, lastFrameDeltaTime, 0.0f, 0.0f);
+    auto &timeBlock = m_uboManager.get<Legacy::SharedVboEnum::TimeBlock>();
+    timeBlock.time = glm::vec4(m_elapsedTime, lastFrameDeltaTime, 0.0f, 0.0f);
 
     if (lastFrameDeltaTime > 0.0f) {
         m_uboManager.invalidate(Legacy::SharedVboEnum::TimeBlock);

--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -9,18 +9,15 @@
 
 #include <QOpenGLWindow>
 
-FrameManager::FrameManager(QOpenGLWindow &window,
-                           Legacy::UboManager &uboManager,
-                           QObject *parent)
+FrameManager::FrameManager(QOpenGLWindow &window, Legacy::UboManager &uboManager, QObject *parent)
     : QObject(parent)
     , m_window(window)
     , m_uboManager(uboManager)
 {
-    m_uboManager.registerRebuildFunction(Legacy::SharedVboEnum::TimeBlock,
-                                         [this](Legacy::Functions &gl) {
-                                             m_uboManager.update<Legacy::SharedVboEnum::TimeBlock>(
-                                                 gl, m_frameData);
-                                         });
+    m_uboManager
+        .registerRebuildFunction(Legacy::SharedVboEnum::TimeBlock, [this](Legacy::Functions &gl) {
+            m_uboManager.update<Legacy::SharedVboEnum::TimeBlock>(gl, m_frameData);
+        });
 
     updateMinFrameTime();
     setConfig().canvas.advanced.maximumFps.registerChangeCallback(m_configLifetime, [this]() {
@@ -43,7 +40,6 @@ void FrameManager::registerCallback(const Signal2Lifetime &lifetime, AnimationCa
 {
     m_callbacks.push_back({lifetime.getObj(), std::move(callback)});
 }
-
 
 bool FrameManager::needsHeartbeat()
 {

--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -14,10 +14,10 @@ FrameManager::FrameManager(QOpenGLWindow &window, Legacy::UboManager &uboManager
     , m_window(window)
     , m_uboManager(uboManager)
 {
-    m_uboManager
-        .registerRebuildFunction(Legacy::SharedVboEnum::TimeBlock, [this](Legacy::Functions &gl) {
-            m_uboManager.sync<Legacy::SharedVboEnum::TimeBlock>(gl);
-        });
+    m_uboManager.registerRebuildFunction(Legacy::SharedVboEnum::TimeBlock,
+                                         [this](Legacy::Functions &gl) {
+                                             m_uboManager.sync<Legacy::SharedVboEnum::TimeBlock>(gl);
+                                         });
 
     updateMinFrameTime();
     setConfig().canvas.advanced.maximumFps.registerChangeCallback(m_configLifetime, [this]() {

--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -139,8 +139,7 @@ std::optional<FrameManager::Frame> FrameManager::beginFrame()
     m_elapsedTime += lastFrameDeltaTime;
     m_frameData.time = glm::vec4(m_elapsedTime, lastFrameDeltaTime, 0.0f, 0.0f);
 
-    if (lastFrameDeltaTime > 0.0f) {
-        assert(m_uboManager && "FrameManager::beginFrame: m_uboManager is not initialized");
+    if (lastFrameDeltaTime > 0.0f && m_uboManager != nullptr) {
         m_uboManager->invalidate(Legacy::SharedVboEnum::TimeBlock);
     }
 

--- a/src/display/FrameManager.cpp
+++ b/src/display/FrameManager.cpp
@@ -112,7 +112,7 @@ std::optional<FrameManager::Frame> FrameManager::beginFrame()
     // Throttle: check if enough time has passed since the start of the last successful frame.
     if (hasLastUpdate) {
         const auto elapsed = now - m_lastUpdateTime;
-        if (elapsed + getJitterTolerance() < m_minFrameTime) {
+        if (elapsed < m_minFrameTime) {
             return std::nullopt;
         }
     }
@@ -161,23 +161,8 @@ void FrameManager::onHeartbeat()
     m_window.update();
 
     if (needsHeartbeat()) {
-        // We always schedule a fallback heartbeat in case window update is ignored.
-        // recordFramePainted will later refine this with a more accurate delay if a paint occurs.
-        const auto delayMs = std::chrono::duration_cast<std::chrono::milliseconds>(m_minFrameTime)
-                                 .count();
-        m_heartbeatTimer.start(static_cast<int>(delayMs));
+        requestFrame();
     }
-}
-
-std::chrono::nanoseconds FrameManager::getJitterTolerance() const
-{
-    // Use 25% of the frame time as jitter tolerance, but cap it at 8ms and also m_minFrameTime.
-    // This ensures we are "ready early" for VSync at 60Hz (4ms) while avoiding
-    // over-rendering at very high frame rates where the 8ms cap could effectively
-    // disable the rate limit.
-    const auto tolerance = m_minFrameTime / 4;
-    return std::min(
-        {tolerance, m_minFrameTime, std::chrono::nanoseconds(std::chrono::milliseconds(8))});
 }
 
 std::chrono::nanoseconds FrameManager::getTimeUntilNextFrame() const
@@ -188,11 +173,10 @@ std::chrono::nanoseconds FrameManager::getTimeUntilNextFrame() const
 
     const auto now = std::chrono::steady_clock::now();
     const auto elapsed = now - m_lastUpdateTime;
-    const auto tolerance = getJitterTolerance();
-    if (elapsed + tolerance >= m_minFrameTime) {
+    if (elapsed >= m_minFrameTime) {
         return std::chrono::nanoseconds::zero();
     }
-    return m_minFrameTime - (elapsed + tolerance);
+    return m_minFrameTime - elapsed;
 }
 
 void FrameManager::recordFramePainted()
@@ -214,20 +198,20 @@ void FrameManager::requestFrame()
         m_window.update();
         // Start a fallback timer in case window update is ignored.
         if (needsHeartbeat()) {
-            const auto delayMs
-                = std::chrono::duration_cast<std::chrono::milliseconds>(m_minFrameTime).count();
-            m_heartbeatTimer.start(static_cast<int>(delayMs));
+            const int delayMs = static_cast<int>(
+                std::chrono::ceil<std::chrono::milliseconds>(m_minFrameTime).count());
+            m_heartbeatTimer.start(delayMs);
         }
     } else {
         // Start or restart the timer with the accurate delay.
         const int finalDelay = static_cast<int>(
-            std::chrono::duration_cast<std::chrono::milliseconds>(delay).count());
+            std::chrono::ceil<std::chrono::milliseconds>(delay).count());
 
         // Only restart the timer if it's not active or if the new delay is significantly different.
         // This avoids hammering the timer during high-frequency input like mouse moves.
         if (!m_heartbeatTimer.isActive()
             || std::abs(m_heartbeatTimer.remainingTime() - finalDelay) > 1) {
-            m_heartbeatTimer.start(std::max(1, finalDelay));
+            m_heartbeatTimer.start(finalDelay);
         }
     }
 }

--- a/src/display/FrameManager.h
+++ b/src/display/FrameManager.h
@@ -5,6 +5,7 @@
 #include "../global/RAII.h"
 #include "../global/RuleOf5.h"
 #include "../global/Signal2.h"
+#include "../opengl/UboManager.h"
 
 #include <chrono>
 #include <functional>
@@ -60,6 +61,9 @@ private:
     QTimer m_heartbeatTimer;
     QOpenGLWindow &m_window;
     bool m_dirty = true;
+    float m_elapsedTime = 0.0f;
+    Legacy::UboManager *m_uboManager = nullptr; // TODO: reference
+    GLRenderState::Uniforms::Weather::Frame m_frameData;
 
     friend class TestFrameManager;
 
@@ -88,6 +92,10 @@ public:
 public:
     explicit FrameManager(QOpenGLWindow &window, QObject *parent = nullptr);
     DELETE_CTORS_AND_ASSIGN_OPS(FrameManager);
+
+public:
+    void init(Legacy::UboManager &uboManager);
+    NODISCARD float getElapsedTime() const;
 
 public:
     /**

--- a/src/display/FrameManager.h
+++ b/src/display/FrameManager.h
@@ -63,7 +63,7 @@ private:
     bool m_dirty = true;
     float m_elapsedTime = 0.0f;
     Legacy::UboManager *m_uboManager = nullptr; // TODO: reference
-    GLRenderState::Uniforms::Time m_frameData;
+    Legacy::TimeBlock m_frameData;
 
 public:
     /**
@@ -95,7 +95,7 @@ public:
 public:
     void init(Legacy::UboManager &uboManager);
     NODISCARD float getElapsedTime() const;
-    NODISCARD const GLRenderState::Uniforms::Time &getFrameData() const { return m_frameData; }
+    NODISCARD const Legacy::TimeBlock &getFrameData() const { return m_frameData; }
 
 public:
     /**

--- a/src/display/FrameManager.h
+++ b/src/display/FrameManager.h
@@ -91,11 +91,13 @@ public:
 
 public:
     explicit FrameManager(QOpenGLWindow &window, QObject *parent = nullptr);
+    ~FrameManager() override;
     DELETE_CTORS_AND_ASSIGN_OPS(FrameManager);
 
 public:
     void init(Legacy::UboManager &uboManager);
     NODISCARD float getElapsedTime() const;
+    NODISCARD const GLRenderState::Uniforms::Weather::Frame &getFrameData() const { return m_frameData; }
 
 public:
     /**

--- a/src/display/FrameManager.h
+++ b/src/display/FrameManager.h
@@ -63,9 +63,7 @@ private:
     bool m_dirty = true;
     float m_elapsedTime = 0.0f;
     Legacy::UboManager *m_uboManager = nullptr; // TODO: reference
-    GLRenderState::Uniforms::Weather::Frame m_frameData;
-
-    friend class TestFrameManager;
+    GLRenderState::Uniforms::Time m_frameData;
 
 public:
     /**
@@ -97,7 +95,7 @@ public:
 public:
     void init(Legacy::UboManager &uboManager);
     NODISCARD float getElapsedTime() const;
-    NODISCARD const GLRenderState::Uniforms::Weather::Frame &getFrameData() const { return m_frameData; }
+    NODISCARD const GLRenderState::Uniforms::Time &getFrameData() const { return m_frameData; }
 
 public:
     /**

--- a/src/display/FrameManager.h
+++ b/src/display/FrameManager.h
@@ -62,7 +62,7 @@ private:
     QOpenGLWindow &m_window;
     bool m_dirty = true;
     float m_elapsedTime = 0.0f;
-    Legacy::UboManager *m_uboManager = nullptr; // TODO: reference
+    Legacy::UboManager &m_uboManager;
     Legacy::TimeBlock m_frameData;
 
 public:
@@ -88,12 +88,13 @@ public:
     };
 
 public:
-    explicit FrameManager(QOpenGLWindow &window, QObject *parent = nullptr);
+    explicit FrameManager(QOpenGLWindow &window,
+                          Legacy::UboManager &uboManager,
+                          QObject *parent = nullptr);
     ~FrameManager() override;
     DELETE_CTORS_AND_ASSIGN_OPS(FrameManager);
 
 public:
-    void init(Legacy::UboManager &uboManager);
     NODISCARD float getElapsedTime() const;
     NODISCARD const Legacy::TimeBlock &getFrameData() const { return m_frameData; }
 

--- a/src/display/FrameManager.h
+++ b/src/display/FrameManager.h
@@ -130,7 +130,6 @@ private:
     void recordFramePainted();
     void updateMinFrameTime();
     void cleanupExpiredCallbacks();
-    NODISCARD std::chrono::nanoseconds getJitterTolerance() const;
     NODISCARD std::chrono::nanoseconds getTimeUntilNextFrame() const;
 
 private slots:

--- a/src/display/FrameManager.h
+++ b/src/display/FrameManager.h
@@ -63,7 +63,6 @@ private:
     bool m_dirty = true;
     float m_elapsedTime = 0.0f;
     Legacy::UboManager &m_uboManager;
-    Legacy::TimeBlock m_frameData;
 
 public:
     /**
@@ -96,7 +95,6 @@ public:
 
 public:
     NODISCARD float getElapsedTime() const;
-    NODISCARD const Legacy::TimeBlock &getFrameData() const { return m_frameData; }
 
 public:
     /**

--- a/src/display/MapCanvasData.cpp
+++ b/src/display/MapCanvasData.cpp
@@ -34,24 +34,22 @@ MapCanvasViewport::~MapCanvasViewport() = default;
 
 const glm::mat4 &MapCanvasViewport::getViewProj() const
 {
-    if (m_viewProjDirty) {
-        const int w = width();
-        const int h = height();
-        if (w > 0 && h > 0) {
-            const float zoomScale = getTotalScaleFactor();
-            const auto size = glm::ivec2(w, h);
-            m_viewProj = (!m_viewportConfig.use3D)
-                             ? ProjectionUtils::calculateViewProjOld(getScroll(),
-                                                                     size,
-                                                                     zoomScale,
-                                                                     getCurrentLayer())
-                             : ProjectionUtils::calculateViewProj(m_viewportConfig,
-                                                                  getScroll(),
-                                                                  size,
-                                                                  zoomScale,
-                                                                  getCurrentLayer());
-            m_viewProjDirty = false;
-        }
+    const int w = width();
+    const int h = height();
+    if (m_viewProjDirty && w > 0 && h > 0) {
+        const float zoomScale = getTotalScaleFactor();
+        const auto size = glm::ivec2(w, h);
+        m_viewProj = (!m_viewportConfig.use3D)
+                         ? ProjectionUtils::calculateViewProjOld(getScroll(),
+                                                                 size,
+                                                                 zoomScale,
+                                                                 getCurrentLayer())
+                         : ProjectionUtils::calculateViewProj(m_viewportConfig,
+                                                              getScroll(),
+                                                              size,
+                                                              zoomScale,
+                                                              getCurrentLayer());
+        m_viewProjDirty = false;
     }
     return m_viewProj;
 }

--- a/src/display/MapCanvasData.cpp
+++ b/src/display/MapCanvasData.cpp
@@ -30,6 +30,8 @@ MapCanvasInputState::MapCanvasInputState(PrespammedPath &prespammedPath)
 
 MapCanvasInputState::~MapCanvasInputState() = default;
 
+MapCanvasViewport::~MapCanvasViewport() = default;
+
 const glm::mat4 &MapCanvasViewport::getViewProj() const
 {
     if (m_viewProjDirty) {

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -111,7 +111,7 @@ public:
         : m_window{window}
     {}
 
-    virtual ~MapCanvasViewport() = default;
+    virtual ~MapCanvasViewport();
 
 protected:
     virtual void onViewProjDirty() const {}

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -94,6 +94,10 @@ struct NODISCARD MapCanvasViewport
 private:
     QWindow &m_window;
 
+protected:
+    mutable int m_lastWidth = 0;
+    mutable int m_lastHeight = 0;
+
 private:
     mutable glm::mat4 m_viewProj{1.f};
     glm::vec2 m_scroll{0.f};
@@ -106,6 +110,11 @@ public:
     explicit MapCanvasViewport(QWindow &window)
         : m_window{window}
     {}
+
+    virtual ~MapCanvasViewport() = default;
+
+protected:
+    virtual void onViewProjDirty() const {}
 
 public:
     NODISCARD auto width() const { return m_window.width(); }
@@ -137,16 +146,21 @@ public:
         }
     }
 
-    void markViewProjDirty() { m_viewProjDirty = true; }
+    void markViewProjDirty()
+    {
+        m_viewProjDirty = true;
+        onViewProjDirty();
+    }
     void setViewportConfig(const ViewportConfig &config)
     {
         m_viewportConfig = config;
-        m_viewProjDirty = true;
+        markViewProjDirty();
     }
     void setMvpExtern(const glm::mat4 &mvp) const
     {
         m_viewProj = mvp;
         m_viewProjDirty = false;
+        onViewProjDirty();
     }
 
     NODISCARD const glm::mat4 &getViewProj() const;

--- a/src/display/MapCanvasData.h
+++ b/src/display/MapCanvasData.h
@@ -100,11 +100,11 @@ protected:
 
 private:
     mutable glm::mat4 m_viewProj{1.f};
+    mutable bool m_viewProjDirty = true;
     glm::vec2 m_scroll{0.f};
     ScaleFactor m_scaleFactor;
     int m_currentLayer = 0;
     ViewportConfig m_viewportConfig;
-    mutable bool m_viewProjDirty = true;
 
 public:
     explicit MapCanvasViewport(QWindow &window)
@@ -126,7 +126,7 @@ public:
     {
         if (m_scroll != scroll) {
             m_scroll = scroll;
-            m_viewProjDirty = true;
+            markViewProjDirty();
         }
     }
 
@@ -134,7 +134,7 @@ public:
     void setScaleFactor(const ScaleFactor &scaleFactor)
     {
         m_scaleFactor = scaleFactor;
-        m_viewProjDirty = true;
+        markViewProjDirty();
     }
 
     NODISCARD int getCurrentLayer() const { return m_currentLayer; }
@@ -142,7 +142,7 @@ public:
     {
         if (m_currentLayer != layer) {
             m_currentLayer = layer;
-            m_viewProjDirty = true;
+            markViewProjDirty();
         }
     }
 

--- a/src/display/ProjectionUtils.cpp
+++ b/src/display/ProjectionUtils.cpp
@@ -110,7 +110,6 @@ glm::mat4 calculateViewProjOld(const glm::vec2 &scrollPos,
                                const int /*currentLayer*/)
 {
     constexpr float FIXED_VIEW_DISTANCE = 60.f;
-    constexpr float ROOM_Z_SCALE = 7.f;
     constexpr auto baseSize = static_cast<float>(ProjectionUtils::BASESIZE);
 
     const float swp = zoomScale * baseSize / static_cast<float>(size.x);

--- a/src/display/ProjectionUtils.h
+++ b/src/display/ProjectionUtils.h
@@ -21,6 +21,7 @@ struct ViewportConfig
 namespace ProjectionUtils {
 
 static constexpr const int BASESIZE = 528; // REVISIT: Why this size? 16*33 isn't special.
+constexpr float ROOM_Z_SCALE = 7.f;
 
 /**
  * @brief Calculate the pitch (vertical angle) in degrees, accounting for auto-tilt if enabled.

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -493,7 +493,7 @@ void MapCanvas::initTextures()
     {
         // weather noise is 256
         QImage noiseImage = createTileableValueNoiseImage(256);
-        textures.noise = MMTexture::alloc(std::vector<QImage>{noiseImage});
+        textures.noise = MMTexture::alloc(std::vector<QImage>{noiseImage}, true);
     }
 
     // char images are 256

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -368,23 +368,60 @@ NODISCARD static std::vector<QImage> createDottedWallImages(const ExitDirEnum di
     return images;
 }
 
-NODISCARD static QImage createTileableNoiseImage(int size)
+NODISCARD static QImage createTileableValueNoiseImage(int size)
 {
     QImage img(size, size, QImage::Format_RGBA8888);
 
-    // Note: We use high-frequency white noise here because smoothed "value noise"
-    // looks too blocky when scaled by the atmosphere shaders.
+    // Constants 127.1/311.7 provide high-frequency distribution to prevent Moire patterns
     auto hash = [](float x, float y) -> float {
         float dot = x * 127.1f + y * 311.7f;
         float fract = std::sin(dot) * 43758.5453123f;
         return fract - std::floor(fract);
     };
 
+    auto lerp = [](float a, float b, float t) -> float { return a + t * (b - a); };
+
+    // Perlin's quintic curve ($6t^5-15t^4+10t^3$) ensures smooth C2 continuity at grid boundaries
+    auto smooth = [](float t) -> float { return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f); };
+
     for (int y = 0; y < size; ++y) {
+        // scanLine avoids QImage's internal per-pixel coordinate-to-pointer overhead
         uchar *line = img.scanLine(y);
+
         for (int x = 0; x < size; ++x) {
-            float v = hash(static_cast<float>(x), static_cast<float>(y));
+            float xx = static_cast<float>(x);
+            float yy = static_cast<float>(y);
+
+            float ix = std::floor(xx);
+            float iy = std::floor(yy);
+            float fx = xx - ix;
+            float fy = yy - iy;
+
+            float sx = smooth(fx);
+            float sy = smooth(fy);
+
+            // Double modulo ensures positive wrapping for seamless tiling
+            auto get_wrapped_hash = [&](int i, int j) {
+                float wi = static_cast<float>((i % size + size) % size);
+                float wj = static_cast<float>((j % size + size) % size);
+                return hash(wi, wj);
+            };
+
+            int iix = static_cast<int>(ix);
+            int iiy = static_cast<int>(iy);
+
+            // Fetch corners for bilinear interpolation
+            float a = get_wrapped_hash(iix, iiy);
+            float b = get_wrapped_hash(iix + 1, iiy);
+            float c = get_wrapped_hash(iix, iiy + 1);
+            float d = get_wrapped_hash(iix + 1, iiy + 1);
+
+            float v = lerp(lerp(a, b, sx), lerp(c, d, sx), sy);
+
+            // Casting to uchar provides implicit floor and branchless clamping
             uchar val = static_cast<uchar>(std::clamp(v * 255.0f, 0.0f, 255.0f));
+
+            // Direct pointer offset for RGBA8888 interleaved memory
             int offset = x * 4;
             line[offset] = val;     // R
             line[offset + 1] = val; // G
@@ -450,7 +487,7 @@ void MapCanvas::initTextures()
     }
     {
         // weather noise is 256
-        QImage noiseImage = createTileableNoiseImage(256);
+        QImage noiseImage = createTileableValueNoiseImage(256);
         textures.noise = MMTexture::alloc(std::vector<QImage>{noiseImage}, true);
     }
 

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -8,12 +8,14 @@
 #include "../global/thread_utils.h"
 #include "../global/utils.h"
 #include "../opengl/OpenGLTypes.h"
+#include "../opengl/Weather.h"
 #include "Filenames.h"
 #include "RoadIndex.h"
 #include "mapcanvas.h"
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <map>
 #include <stdexcept>
 #include <string_view>
@@ -151,8 +153,10 @@ MMTexture::MMTexture(Badge<MMTexture>, const QString &name)
     tex.setMinMagFilters(QOpenGLTexture::Filter::LinearMipMapLinear, QOpenGLTexture::Filter::Linear);
 }
 
-MMTexture::MMTexture(Badge<MMTexture>, std::vector<QImage> images)
+MMTexture::MMTexture(Badge<MMTexture>, std::vector<QImage> images, bool forbidUpdates)
     : m_qt_texture{QOpenGLTexture::Target2D}
+    , m_id{INVALID_MM_TEXTURE_ID}
+    , m_forbidUpdates{forbidUpdates}
     , m_sourceData{std::make_unique<SourceData>(std::move(images))}
 {
     if (m_sourceData->m_images.empty()) {
@@ -364,6 +368,71 @@ NODISCARD static std::vector<QImage> createDottedWallImages(const ExitDirEnum di
     return images;
 }
 
+NODISCARD static QImage createTileableValueNoiseImage(int size)
+{
+    QImage img(size, size, QImage::Format_RGBA8888);
+
+    // Constants 127.1/311.7 provide high-frequency distribution to prevent Moire patterns
+    auto hash = [](float x, float y) -> float {
+        float dot = x * 127.1f + y * 311.7f;
+        float fract = std::sin(dot) * 43758.5453123f;
+        return fract - std::floor(fract);
+    };
+
+    auto lerp = [](float a, float b, float t) -> float { return a + t * (b - a); };
+
+    // Perlin's quintic curve ($6t^5-15t^4+10t^3$) ensures smooth C2 continuity at grid boundaries
+    auto smooth = [](float t) -> float { return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f); };
+
+    for (int y = 0; y < size; ++y) {
+        // scanLine avoids QImage's internal per-pixel coordinate-to-pointer overhead
+        uchar *line = img.scanLine(y);
+
+        for (int x = 0; x < size; ++x) {
+            float xx = static_cast<float>(x);
+            float yy = static_cast<float>(y);
+
+            float ix = std::floor(xx);
+            float iy = std::floor(yy);
+            float fx = xx - ix;
+            float fy = yy - iy;
+
+            float sx = smooth(fx);
+            float sy = smooth(fy);
+
+            // Double modulo ensures positive wrapping for seamless tiling
+            auto get_wrapped_hash = [&](int i, int j) {
+                float wi = static_cast<float>((i % size + size) % size);
+                float wj = static_cast<float>((j % size + size) % size);
+                return hash(wi, wj);
+            };
+
+            int iix = static_cast<int>(ix);
+            int iiy = static_cast<int>(iy);
+
+            // Fetch corners for bilinear interpolation
+            float a = get_wrapped_hash(iix, iiy);
+            float b = get_wrapped_hash(iix + 1, iiy);
+            float c = get_wrapped_hash(iix, iiy + 1);
+            float d = get_wrapped_hash(iix + 1, iiy + 1);
+
+            float v = lerp(lerp(a, b, sx), lerp(c, d, sx), sy);
+
+            // Casting to uchar provides implicit floor and branchless clamping
+            uchar val = static_cast<uchar>(std::clamp(v * 255.0f, 0.0f, 255.0f));
+
+            // Direct pointer offset for RGBA8888 interleaved memory
+            int offset = x * 4;
+            line[offset] = val;     // R
+            line[offset + 1] = val; // G
+            line[offset + 2] = val; // B
+            line[offset + 3] = 255; // A
+        }
+    }
+
+    return img;
+}
+
 template<typename Type>
 static void appendAll(std::vector<SharedMMTexture> &v, Type &&thing)
 {
@@ -415,6 +484,11 @@ void MapCanvas::initTextures()
         QImage whitePixel(1, 1, QImage::Format_RGBA8888);
         whitePixel.fill(Qt::white);
         textures.white_pixel = MMTexture::alloc(std::vector<QImage>{whitePixel});
+    }
+    {
+        // weather noise is 256
+        QImage noiseImage = createTileableValueNoiseImage(256);
+        textures.noise = MMTexture::alloc(std::vector<QImage>{noiseImage});
     }
 
     // char images are 256

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -384,31 +384,36 @@ NODISCARD static QImage createTileableValueNoiseImage(int size)
     // Perlin's quintic curve ($6t^5-15t^4+10t^3$) ensures smooth C2 continuity at grid boundaries
     auto smooth = [](float t) -> float { return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f); };
 
+    // The noise pattern will repeat every 'period' lattice points.
+    // For a 256x256 image, a period of 16 means each lattice cell is 16x16 pixels.
+    const int period = 16;
+    const float scale = static_cast<float>(period) / static_cast<float>(size);
+
     for (int y = 0; y < size; ++y) {
         // scanLine avoids QImage's internal per-pixel coordinate-to-pointer overhead
         uchar *line = img.scanLine(y);
 
         for (int x = 0; x < size; ++x) {
-            float xx = static_cast<float>(x);
-            float yy = static_cast<float>(y);
+            float xx = static_cast<float>(x) * scale;
+            float yy = static_cast<float>(y) * scale;
 
-            float ix = std::floor(xx);
-            float iy = std::floor(yy);
-            float fx = xx - ix;
-            float fy = yy - iy;
+            float ix_f = std::floor(xx);
+            float iy_f = std::floor(yy);
+            float fx = xx - ix_f;
+            float fy = yy - iy_f;
 
             float sx = smooth(fx);
             float sy = smooth(fy);
 
+            int iix = static_cast<int>(ix_f);
+            int iiy = static_cast<int>(iy_f);
+
             // Double modulo ensures positive wrapping for seamless tiling
             auto get_wrapped_hash = [&](int i, int j) {
-                float wi = static_cast<float>((i % size + size) % size);
-                float wj = static_cast<float>((j % size + size) % size);
+                float wi = static_cast<float>((i % period + period) % period);
+                float wj = static_cast<float>((j % period + period) % period);
                 return hash(wi, wj);
             };
-
-            int iix = static_cast<int>(ix);
-            int iiy = static_cast<int>(iy);
 
             // Fetch corners for bilinear interpolation
             float a = get_wrapped_hash(iix, iiy);

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -483,12 +483,12 @@ void MapCanvas::initTextures()
         // 1x1
         QImage whitePixel(1, 1, QImage::Format_RGBA8888);
         whitePixel.fill(Qt::white);
-        textures.white_pixel = MMTexture::alloc(std::vector<QImage>{whitePixel});
+        textures.white_pixel = MMTexture::alloc(std::vector<QImage>{whitePixel}, true);
     }
     {
         // weather noise is 256
         QImage noiseImage = createTileableValueNoiseImage(256);
-        textures.noise = MMTexture::alloc(std::vector<QImage>{noiseImage}, true);
+        textures.noise = MMTexture::alloc(std::vector<QImage>{noiseImage}, false);
     }
 
     // char images are 256

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -368,65 +368,23 @@ NODISCARD static std::vector<QImage> createDottedWallImages(const ExitDirEnum di
     return images;
 }
 
-NODISCARD static QImage createTileableValueNoiseImage(int size)
+NODISCARD static QImage createTileableNoiseImage(int size)
 {
     QImage img(size, size, QImage::Format_RGBA8888);
 
-    // Constants 127.1/311.7 provide high-frequency distribution to prevent Moire patterns
+    // Note: We use high-frequency white noise here because smoothed "value noise"
+    // looks too blocky when scaled by the atmosphere shaders.
     auto hash = [](float x, float y) -> float {
         float dot = x * 127.1f + y * 311.7f;
         float fract = std::sin(dot) * 43758.5453123f;
         return fract - std::floor(fract);
     };
 
-    auto lerp = [](float a, float b, float t) -> float { return a + t * (b - a); };
-
-    // Perlin's quintic curve ($6t^5-15t^4+10t^3$) ensures smooth C2 continuity at grid boundaries
-    auto smooth = [](float t) -> float { return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f); };
-
-    // The noise pattern will repeat every 'period' lattice points.
-    // For a 256x256 image, a period of 16 means each lattice cell is 16x16 pixels.
-    const int period = 16;
-    const float scale = static_cast<float>(period) / static_cast<float>(size);
-
     for (int y = 0; y < size; ++y) {
-        // scanLine avoids QImage's internal per-pixel coordinate-to-pointer overhead
         uchar *line = img.scanLine(y);
-
         for (int x = 0; x < size; ++x) {
-            float xx = static_cast<float>(x) * scale;
-            float yy = static_cast<float>(y) * scale;
-
-            float ix_f = std::floor(xx);
-            float iy_f = std::floor(yy);
-            float fx = xx - ix_f;
-            float fy = yy - iy_f;
-
-            float sx = smooth(fx);
-            float sy = smooth(fy);
-
-            int iix = static_cast<int>(ix_f);
-            int iiy = static_cast<int>(iy_f);
-
-            // Double modulo ensures positive wrapping for seamless tiling
-            auto get_wrapped_hash = [&](int i, int j) {
-                float wi = static_cast<float>((i % period + period) % period);
-                float wj = static_cast<float>((j % period + period) % period);
-                return hash(wi, wj);
-            };
-
-            // Fetch corners for bilinear interpolation
-            float a = get_wrapped_hash(iix, iiy);
-            float b = get_wrapped_hash(iix + 1, iiy);
-            float c = get_wrapped_hash(iix, iiy + 1);
-            float d = get_wrapped_hash(iix + 1, iiy + 1);
-
-            float v = lerp(lerp(a, b, sx), lerp(c, d, sx), sy);
-
-            // Casting to uchar provides implicit floor and branchless clamping
+            float v = hash(static_cast<float>(x), static_cast<float>(y));
             uchar val = static_cast<uchar>(std::clamp(v * 255.0f, 0.0f, 255.0f));
-
-            // Direct pointer offset for RGBA8888 interleaved memory
             int offset = x * 4;
             line[offset] = val;     // R
             line[offset + 1] = val; // G
@@ -492,7 +450,7 @@ void MapCanvas::initTextures()
     }
     {
         // weather noise is 256
-        QImage noiseImage = createTileableValueNoiseImage(256);
+        QImage noiseImage = createTileableNoiseImage(256);
         textures.noise = MMTexture::alloc(std::vector<QImage>{noiseImage}, true);
     }
 

--- a/src/display/Textures.h
+++ b/src/display/Textures.h
@@ -50,9 +50,10 @@ public:
     {
         return std::make_shared<MMTexture>(Badge<MMTexture>{}, name);
     }
-    NODISCARD static std::shared_ptr<MMTexture> alloc(std::vector<QImage> images)
+    NODISCARD static std::shared_ptr<MMTexture> alloc(std::vector<QImage> images,
+                                                      bool forbidUpdates = false)
     {
-        return std::make_shared<MMTexture>(Badge<MMTexture>{}, std::move(images));
+        return std::make_shared<MMTexture>(Badge<MMTexture>{}, std::move(images), forbidUpdates);
     }
     NODISCARD static std::shared_ptr<MMTexture> alloc(
         const QOpenGLTexture::Target target,
@@ -65,7 +66,7 @@ public:
 public:
     MMTexture() = delete;
     MMTexture(Badge<MMTexture>, const QString &name);
-    MMTexture(Badge<MMTexture>, std::vector<QImage> images);
+    MMTexture(Badge<MMTexture>, std::vector<QImage> images, bool forbidUpdates = false);
     MMTexture(Badge<MMTexture>,
               const QOpenGLTexture::Target target,
               const std::function<void(QOpenGLTexture &)> &init,
@@ -180,7 +181,8 @@ using TextureArrayNESWUD = EnumIndexedArray<SharedMMTexture, ExitDirEnum, NUM_EX
     X(SharedMMTexture, room_sel_move_bad) \
     X(SharedMMTexture, room_sel_move_good) \
     X(SharedMMTexture, room_highlight) \
-    X(SharedMMTexture, white_pixel)
+    X(SharedMMTexture, white_pixel) \
+    X(SharedMMTexture, noise)
 
 struct NODISCARD MapCanvasTextures final
 {

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -79,6 +79,9 @@ MapCanvas::MapCanvas(MapData &mapData,
         return m_batches.remeshCookie.isPending() ? FrameManager::AnimationStatusEnum::Continue
                                                   : FrameManager::AnimationStatusEnum::Stop;
     });
+    connect(&m_data, &MapData::sig_onPositionChange, this, [this]() {
+        m_opengl.getUboManager().invalidate(Legacy::SharedVboEnum::CameraBlock);
+    });
     NonOwningPointer &pmc = primaryMapCanvas();
     if (pmc == nullptr) {
         pmc = this;

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -18,6 +18,7 @@
 #include "../map/roomid.h"
 #include "../mapdata/mapdata.h"
 #include "../mapdata/roomselection.h"
+#include "../observer/gameobserver.h"
 #include "InfomarkSelection.h"
 #include "MapCanvasData.h"
 #include "MapCanvasRoomDrawer.h"
@@ -57,6 +58,7 @@ NODISCARD static NonOwningPointer &primaryMapCanvas()
 }
 
 MapCanvas::MapCanvas(MapData &mapData,
+                     GameObserver &observer,
                      PrespammedPath &prespammedPath,
                      Mmapper2Group &groupManager,
                      QWindow *const parent)
@@ -64,18 +66,19 @@ MapCanvas::MapCanvas(MapData &mapData,
     , MapCanvasViewport{static_cast<QWindow &>(*this)}
     , MapCanvasInputState{prespammedPath}
     , m_mapScreen{static_cast<MapCanvasViewport &>(*this)}
+    , m_observer{observer}
     , m_opengl{}
     , m_glFont{m_opengl}
     , m_data{mapData}
     , m_groupManager{groupManager}
     , m_frameManager{static_cast<QOpenGLWindow &>(*this)}
+    , m_weather{m_opengl, m_data, m_textures, observer, m_frameManager}
 {
     syncViewportConfig();
     m_frameManager.registerCallback(m_lifetime, [this]() {
         return m_batches.remeshCookie.isPending() ? FrameManager::AnimationStatusEnum::Continue
                                                   : FrameManager::AnimationStatusEnum::Stop;
     });
-
     NonOwningPointer &pmc = primaryMapCanvas();
     if (pmc == nullptr) {
         pmc = this;

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -75,12 +75,10 @@ MapCanvas::MapCanvas(MapData &mapData,
     , m_weather{m_opengl, m_data, m_textures, observer, m_frameManager}
 {
     syncViewportConfig();
+
     m_frameManager.registerCallback(m_lifetime, [this]() {
         return m_batches.remeshCookie.isPending() ? FrameManager::AnimationStatusEnum::Continue
                                                   : FrameManager::AnimationStatusEnum::Stop;
-    });
-    connect(&m_data, &MapData::sig_onPositionChange, this, [this]() {
-        m_opengl.getUboManager().invalidate(Legacy::SharedVboEnum::CameraBlock);
     });
     NonOwningPointer &pmc = primaryMapCanvas();
     if (pmc == nullptr) {
@@ -1151,6 +1149,7 @@ void MapCanvas::onMovement()
 {
     const Coordinate &pos = m_data.tryGetPosition().value_or(Coordinate{});
     setCurrentLayer(pos.z);
+    getOpenGL().getUboManager().invalidate(Legacy::SharedVboEnum::CameraBlock);
     const glm::vec2 newScroll = pos.to_vec2() + glm::vec2{0.5f, 0.5f};
     if (!utils::isSameFloat(getScroll().x, newScroll.x)
         || !utils::isSameFloat(getScroll().y, newScroll.y)) {

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -71,7 +71,7 @@ MapCanvas::MapCanvas(MapData &mapData,
     , m_glFont{m_opengl}
     , m_data{mapData}
     , m_groupManager{groupManager}
-    , m_frameManager{static_cast<QOpenGLWindow &>(*this)}
+    , m_frameManager{static_cast<QOpenGLWindow &>(*this), m_opengl.getUboManager()}
     , m_weather{m_opengl, m_data, m_textures, observer, m_frameManager}
 {
     syncViewportConfig();

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -5,12 +5,15 @@
 // Author: Marek Krejza <krejza@gmail.com> (Caligor)
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
+#include "../clock/mumemoment.h"
 #include "../global/ChangeMonitor.h"
 #include "../global/Signal2.h"
+#include "../map/PromptFlags.h"
 #include "../mapdata/roomselection.h"
 #include "../opengl/Font.h"
 #include "../opengl/FontFormatFlags.h"
 #include "../opengl/OpenGL.h"
+#include "../opengl/Weather.h"
 #include "FrameManager.h"
 #include "Infomarks.h"
 #include "MapCanvasData.h"
@@ -18,12 +21,15 @@
 #include "Textures.h"
 
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <future>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
+#include <variant>
 #include <vector>
 
 #include <glm/glm.hpp>
@@ -37,6 +43,7 @@
 class CharacterBatch;
 class ConnectionSelection;
 class Coordinate;
+class GameObserver;
 class InfomarkSelection;
 class MapData;
 class Mmapper2Group;
@@ -128,6 +135,7 @@ private:
 
 private:
     MapScreen m_mapScreen;
+    GameObserver &m_observer;
     OpenGL m_opengl;
     GLFont m_glFont;
     Batches m_batches;
@@ -138,9 +146,11 @@ private:
     FrameManager m_frameManager;
     std::unique_ptr<QOpenGLDebugLogger> m_logger;
     Signal2Lifetime m_lifetime;
+    GLWeather m_weather;
 
 public:
     explicit MapCanvas(MapData &mapData,
+                       GameObserver &observer,
                        PrespammedPath &prespammedPath,
                        Mmapper2Group &groupManager,
                        QWindow *parent = nullptr);

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -136,7 +136,7 @@ private:
 private:
     MapScreen m_mapScreen;
     GameObserver &m_observer;
-    OpenGL m_opengl;
+    mutable OpenGL m_opengl;
     GLFont m_glFont;
     Batches m_batches;
     MapCanvasTextures m_textures;
@@ -188,6 +188,9 @@ private:
 private:
     void reportGLVersion();
     NODISCARD bool isBlacklistedDriver();
+
+protected:
+    void onViewProjDirty() const override;
 
 protected:
     void initializeGL() override;

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -18,6 +18,9 @@
 #include "../opengl/OpenGLConfig.h"
 #include "../opengl/OpenGLTypes.h"
 #include "../opengl/legacy/Meshes.h"
+#include "../opengl/legacy/TFO.h"
+#include "../opengl/legacy/VAO.h"
+#include "../opengl/legacy/VBO.h"
 #include "../src/global/SendToUser.h"
 #include "Connections.h"
 #include "MapCanvasConfig.h"
@@ -35,8 +38,10 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <future>
 #include <memory>
 #include <optional>
+#include <random>
 #include <sstream>
 #include <stdexcept>
 #include <unordered_map>
@@ -236,6 +241,7 @@ void MapCanvas::initializeGL()
     initLogger();
 
     gl.initializeRenderer(static_cast<float>(QPaintDevice::devicePixelRatioF()));
+    m_frameManager.init(gl.getUboManager());
 
     gl.getUboManager()
         .registerRebuildFunction(Legacy::SharedVboEnum::NamedColorsBlock,
@@ -501,11 +507,20 @@ void MapCanvas::actuallyPaintGL()
     if (m_data.isEmpty()) {
         getGLFont().renderTextCentered("No map loaded");
     } else {
+        // Update animation state
+        m_weather.update();
+
         paintMap();
         paintBatchedInfomarks();
         paintSelections();
         paintCharacters();
         paintDifferences();
+
+        const auto playerPos = m_data.tryGetPosition().value_or(Coordinate{0, 0, 0});
+        m_weather.prepare(getViewProj(), playerPos);
+        gl.getUboManager().bind(funcs, Legacy::SharedVboEnum::TimeBlock);
+
+        m_weather.render(m_opengl.getDefaultRenderState());
     }
 
     gl.releaseFbo();

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -363,7 +363,11 @@ void MapCanvas::setMvp(const glm::mat4 &viewProj)
 
 void MapCanvas::setViewportAndMvp(int width, int height)
 {
-    markViewProjDirty();
+    if (width != m_lastWidth || height != m_lastHeight) {
+        m_lastWidth = width;
+        m_lastHeight = height;
+        markViewProjDirty();
+    }
 
     auto &gl = getOpenGL();
     gl.glViewport(0, 0, width, height);
@@ -373,6 +377,11 @@ void MapCanvas::setViewportAndMvp(int width, int height)
     assert(size.y == height);
 
     gl.setProjectionMatrix(MapCanvasViewport::getViewProj());
+}
+
+void MapCanvas::onViewProjDirty() const
+{
+    m_opengl.getUboManager().invalidate(Legacy::SharedVboEnum::CameraBlock);
 }
 
 void MapCanvas::resizeGL(int width, int height)
@@ -516,8 +525,7 @@ void MapCanvas::actuallyPaintGL()
         paintCharacters();
         paintDifferences();
 
-        const auto playerPos = m_data.tryGetPosition().value_or(Coordinate{0, 0, 0});
-        m_weather.prepare(getViewProj(), playerPos);
+        m_weather.prepare();
         gl.getUboManager().bind(funcs, Legacy::SharedVboEnum::TimeBlock);
 
         m_weather.render(m_opengl.getDefaultRenderState());

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -252,14 +252,14 @@ void MapCanvas::initializeGL()
 
     gl.getUboManager().registerRebuildFunction(
         Legacy::SharedVboEnum::CameraBlock, [this](Legacy::Functions &funcs) {
+            auto &camera = funcs.getUboManager().get<Legacy::SharedVboEnum::CameraBlock>();
             const auto playerPosCoord = m_data.tryGetPosition().value_or(Coordinate{0, 0, 0});
-            Legacy::CameraBlock camera;
             camera.viewProj = getViewProj();
             camera.playerPos = glm::vec4(static_cast<float>(playerPosCoord.x),
                                          static_cast<float>(playerPosCoord.y),
                                          static_cast<float>(playerPosCoord.z),
                                          ProjectionUtils::ROOM_Z_SCALE);
-            funcs.getUboManager().update<Legacy::SharedVboEnum::CameraBlock>(funcs, camera);
+            funcs.getUboManager().sync<Legacy::SharedVboEnum::CameraBlock>(funcs);
         });
 
     updateMultisampling();

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -241,7 +241,6 @@ void MapCanvas::initializeGL()
     initLogger();
 
     gl.initializeRenderer(static_cast<float>(QPaintDevice::devicePixelRatioF()));
-    m_frameManager.init(gl.getUboManager());
 
     gl.getUboManager()
         .registerRebuildFunction(Legacy::SharedVboEnum::NamedColorsBlock,

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -247,22 +247,21 @@ void MapCanvas::initializeGL()
         .registerRebuildFunction(Legacy::SharedVboEnum::NamedColorsBlock,
                                  [](Legacy::Functions &funcs) {
                                      auto &uboManager = funcs.getUboManager();
-                                     uboManager.update(funcs,
-                                                       Legacy::SharedVboEnum::NamedColorsBlock,
-                                                       XNamedColor::getAllColorsAsVec4());
+                                     uboManager.update<Legacy::SharedVboEnum::NamedColorsBlock>(
+                                         funcs, XNamedColor::getAllColorsAsBlock());
                                  });
 
 
     gl.getUboManager().registerRebuildFunction(
         Legacy::SharedVboEnum::CameraBlock, [this](Legacy::Functions &funcs) {
             const auto playerPosCoord = m_data.tryGetPosition().value_or(Coordinate{0, 0, 0});
-            GLRenderState::Uniforms::Camera camera;
+            Legacy::CameraBlock camera;
             camera.viewProj = getViewProj();
             camera.playerPos = glm::vec4(static_cast<float>(playerPosCoord.x),
                                          static_cast<float>(playerPosCoord.y),
                                          static_cast<float>(playerPosCoord.z),
                                          ProjectionUtils::ROOM_Z_SCALE);
-            funcs.getUboManager().update(funcs, Legacy::SharedVboEnum::CameraBlock, camera);
+            funcs.getUboManager().update<Legacy::SharedVboEnum::CameraBlock>(funcs, camera);
         });
 
     updateMultisampling();

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -251,7 +251,6 @@ void MapCanvas::initializeGL()
                                          funcs, XNamedColor::getAllColorsAsBlock());
                                  });
 
-
     gl.getUboManager().registerRebuildFunction(
         Legacy::SharedVboEnum::CameraBlock, [this](Legacy::Functions &funcs) {
             const auto playerPosCoord = m_data.tryGetPosition().value_or(Coordinate{0, 0, 0});

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -252,6 +252,19 @@ void MapCanvas::initializeGL()
                                                        XNamedColor::getAllColorsAsVec4());
                                  });
 
+
+    gl.getUboManager().registerRebuildFunction(
+        Legacy::SharedVboEnum::CameraBlock, [this](Legacy::Functions &funcs) {
+            const auto playerPosCoord = m_data.tryGetPosition().value_or(Coordinate{0, 0, 0});
+            GLRenderState::Uniforms::Camera camera;
+            camera.viewProj = getViewProj();
+            camera.playerPos = glm::vec4(static_cast<float>(playerPosCoord.x),
+                                         static_cast<float>(playerPosCoord.y),
+                                         static_cast<float>(playerPosCoord.z),
+                                         ProjectionUtils::ROOM_Z_SCALE);
+            funcs.getUboManager().update(funcs, Legacy::SharedVboEnum::CameraBlock, camera);
+        });
+
     updateMultisampling();
 
     // REVISIT: should the font texture have the lowest ID?

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -23,7 +23,11 @@
 
 class QResizeEvent;
 
-MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QWidget *const parent)
+MapWindow::MapWindow(MapData &mapData,
+                     GameObserver &observer,
+                     PrespammedPath &pp,
+                     Mmapper2Group &gm,
+                     QWidget *const parent)
     : QWidget(parent)
 {
     m_gridLayout = mmqt::makeQPointer<QGridLayout>(this);
@@ -46,7 +50,7 @@ MapWindow::MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QW
 
     m_gridLayout->addWidget(m_horizontalScrollBar, 1, 0, 1, 1);
 
-    m_canvas = new MapCanvas(mapData, pp, gm);
+    m_canvas = new MapCanvas(mapData, observer, pp, gm);
     m_canvas->setMinimumSize(QSize(1280 / 4, 720 / 4));
     m_canvas->resize(QSize(1280, 720));
 

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -18,6 +18,7 @@
 #include <QtCore>
 #include <QtGlobal>
 
+class GameObserver;
 class MapCanvas;
 class MapData;
 class Mmapper2Group;
@@ -59,7 +60,11 @@ private:
     } m_knownMapSize;
 
 public:
-    explicit MapWindow(MapData &mapData, PrespammedPath &pp, Mmapper2Group &gm, QWidget *parent);
+    explicit MapWindow(MapData &mapData,
+                       GameObserver &observer,
+                       PrespammedPath &pp,
+                       Mmapper2Group &gm,
+                       QWidget *parent);
     ~MapWindow() final;
 
 public:

--- a/src/global/ConfigConsts.h
+++ b/src/global/ConfigConsts.h
@@ -4,6 +4,8 @@
 
 #include "macros.h"
 
+#include <cstddef>
+
 #ifndef NDEBUG
 static constexpr const bool IS_DEBUG_BUILD = true;
 #else
@@ -63,3 +65,5 @@ static inline constexpr const bool NO_AUDIO = true;
 #else
 static inline constexpr const bool NO_AUDIO = false;
 #endif
+
+static inline constexpr size_t MAX_NAMED_COLORS = 32;

--- a/src/global/ConfigConsts.h
+++ b/src/global/ConfigConsts.h
@@ -4,8 +4,6 @@
 
 #include "macros.h"
 
-#include <cstddef>
-
 #ifndef NDEBUG
 static constexpr const bool IS_DEBUG_BUILD = true;
 #else
@@ -65,5 +63,3 @@ static inline constexpr const bool NO_AUDIO = true;
 #else
 static inline constexpr const bool NO_AUDIO = false;
 #endif
-
-static inline constexpr size_t MAX_NAMED_COLORS = 32;

--- a/src/global/NamedColors.cpp
+++ b/src/global/NamedColors.cpp
@@ -3,6 +3,7 @@
 
 #include "NamedColors.h"
 
+#include "../opengl/UboBlocks.h"
 #include "EnumIndexedArray.h"
 
 #include <cassert>
@@ -17,13 +18,12 @@ struct NODISCARD GlobalData final
     using InitArray = EnumIndexedArray<bool, NamedColorEnum, NUM_NAMED_COLORS>;
     using Map = std::map<std::string, NamedColorEnum>;
     using NamesVector = std::vector<std::string>;
-    using Vec4Vector = std::vector<glm::vec4>;
 
 private:
     Map m_map;
     NamesVector m_names;
     ColorVector m_colors;
-    Vec4Vector m_vec4s;
+    Legacy::NamedColorsBlock m_colorsBlock;
     InitArray m_initialized;
 
 private:
@@ -33,7 +33,6 @@ public:
     GlobalData()
     {
         m_colors.resize(NUM_NAMED_COLORS);
-        m_vec4s.resize(MAX_NAMED_COLORS);
         m_names.resize(NUM_NAMED_COLORS);
 
         static const auto white = Colors::white;
@@ -46,7 +45,7 @@ public:
             const auto color = (id == NamedColorEnum::TRANSPARENT) ? transparent_black : white;
 
             m_colors[idx] = color;
-            m_vec4s[idx] = color.getVec4();
+            m_colorsBlock.colors[idx] = color.getVec4();
             m_names[idx] = name;
             m_map.emplace(name, id);
         };
@@ -83,7 +82,7 @@ public:
 
         const auto idx = getIndex(id);
         m_colors.at(idx) = c;
-        m_vec4s.at(idx) = c.getVec4();
+        m_colorsBlock.colors.at(idx) = c.getVec4();
         m_initialized.at(id) = true;
         return true;
     }
@@ -96,7 +95,7 @@ public:
 
     NODISCARD const std::vector<std::string> &getAllNames() const { return m_names; }
     NODISCARD const std::vector<Color> &getAllColors() const { return m_colors; }
-    NODISCARD const std::vector<glm::vec4> &getAllVec4s() const { return m_vec4s; }
+    NODISCARD const Legacy::NamedColorsBlock &getAllColorsAsBlock() const { return m_colorsBlock; }
 
 public:
     NODISCARD std::optional<NamedColorEnum> lookup(std::string_view name) const
@@ -156,7 +155,7 @@ const std::vector<Color> &XNamedColor::getAllColors()
     return getGlobalData().getAllColors();
 }
 
-const std::vector<glm::vec4> &XNamedColor::getAllColorsAsVec4()
+const Legacy::NamedColorsBlock &XNamedColor::getAllColorsAsBlock()
 {
-    return getGlobalData().getAllVec4s();
+    return getGlobalData().getAllColorsAsBlock();
 }

--- a/src/global/NamedColors.cpp
+++ b/src/global/NamedColors.cpp
@@ -58,6 +58,14 @@ public:
         init(NamedColorEnum::DEFAULT, ".default");
         m_initialized[NamedColorEnum::DEFAULT] = true;
         m_initialized[NamedColorEnum::TRANSPARENT] = true;
+
+        // Sane defaults for weather colors
+        std::ignore = setColor(NamedColorEnum::WEATHER_DAWN,
+                               Color(102, 76, 51, 25)); // 0.4, 0.3, 0.2, 0.1
+        std::ignore = setColor(NamedColorEnum::WEATHER_DUSK,
+                               Color(76, 51, 102, 51)); // 0.3, 0.2, 0.4, 0.2
+        std::ignore = setColor(NamedColorEnum::WEATHER_NIGHT,
+                               Color(13, 13, 51, 89)); // 0.05, 0.05, 0.2, 0.35
     }
 
 public:

--- a/src/global/NamedColors.cpp
+++ b/src/global/NamedColors.cpp
@@ -66,6 +66,8 @@ public:
                                Color(76, 51, 102, 51)); // 0.3, 0.2, 0.4, 0.2
         std::ignore = setColor(NamedColorEnum::WEATHER_NIGHT,
                                Color(13, 13, 51, 89)); // 0.05, 0.05, 0.2, 0.35
+        std::ignore = setColor(NamedColorEnum::WEATHER_NIGHT_MOON,
+                               Color(13, 13, 64, 77)); // 0.05, 0.05, 0.25, 0.3
     }
 
 public:

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -39,7 +39,10 @@
     X(WALL_COLOR_NOT_MAPPED, "wall-not-mapped") \
     X(WALL_COLOR_RANDOM, "wall-random") \
     X(WALL_COLOR_REGULAR_EXIT, "wall-regular-exit") \
-    X(WALL_COLOR_SPECIAL, "wall-special")
+    X(WALL_COLOR_SPECIAL, "wall-special") \
+    X(WEATHER_DAWN, "weather-dawn") \
+    X(WEATHER_DUSK, "weather-dusk") \
+    X(WEATHER_NIGHT, "weather-night")
 
 #define X_DECL(_id, _name) _id,
 enum class NODISCARD NamedColorEnum : uint8_t { DEFAULT = 0, XFOREACH_NAMED_COLOR_OPTIONS(X_DECL) };

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -42,7 +42,8 @@
     X(WALL_COLOR_SPECIAL, "wall-special") \
     X(WEATHER_DAWN, "weather-dawn") \
     X(WEATHER_DUSK, "weather-dusk") \
-    X(WEATHER_NIGHT, "weather-night")
+    X(WEATHER_NIGHT, "weather-night") \
+    X(WEATHER_NIGHT_MOON, "weather-night-moon")
 
 #define X_DECL(_id, _name) _id,
 enum class NODISCARD NamedColorEnum : uint8_t { DEFAULT = 0, XFOREACH_NAMED_COLOR_OPTIONS(X_DECL) };

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -9,6 +9,10 @@
 #include <string_view>
 #include <vector>
 
+namespace Legacy {
+struct NamedColorsBlock;
+}
+
 #undef TRANSPARENT // Bad dog, Microsoft; bad dog!!!
 
 // X(_id, _name)
@@ -105,6 +109,6 @@ public:
 
 public:
     NODISCARD static const std::vector<Color> &getAllColors();
-    NODISCARD static const std::vector<glm::vec4> &getAllColorsAsVec4();
+    NODISCARD static const Legacy::NamedColorsBlock &getAllColorsAsBlock();
     NODISCARD static const std::vector<std::string> &getAllNames();
 };

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -56,7 +56,7 @@ enum class NODISCARD NamedColorEnum : uint8_t { DEFAULT = 0, XFOREACH_NAMED_COLO
 static inline constexpr size_t NUM_NAMED_COLORS = XFOREACH_NAMED_COLOR_OPTIONS(X_COUNT) + 1;
 #undef X_COUNT
 
-#include "ConfigConsts.h"
+static inline constexpr size_t MAX_NAMED_COLORS = 32;
 static_assert(MAX_NAMED_COLORS >= NUM_NAMED_COLORS);
 
 // TODO: rename this, but to what? NamedColorHandle?

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -56,7 +56,7 @@ enum class NODISCARD NamedColorEnum : uint8_t { DEFAULT = 0, XFOREACH_NAMED_COLO
 static inline constexpr size_t NUM_NAMED_COLORS = XFOREACH_NAMED_COLOR_OPTIONS(X_COUNT) + 1;
 #undef X_COUNT
 
-static inline constexpr size_t MAX_NAMED_COLORS = 32;
+#include "ConfigConsts.h"
 static_assert(MAX_NAMED_COLORS >= NUM_NAMED_COLORS);
 
 // TODO: rename this, but to what? NamedColorHandle?

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -131,13 +131,18 @@ MainWindow::MainWindow()
     m_groupManager = new Mmapper2Group(this);
     m_groupManager->setObjectName("GroupManager");
 
-    m_mapWindow = new MapWindow(mapData, deref(m_prespammedPath), deref(m_groupManager), this);
+    m_gameObserver = std::make_unique<GameObserver>();
+
+    m_mapWindow = new MapWindow(mapData,
+                                deref(m_gameObserver),
+                                deref(m_prespammedPath),
+                                deref(m_groupManager),
+                                this);
     setCentralWidget(m_mapWindow);
 
     m_pathMachine = new Mmapper2PathMachine(mapData, this);
     m_pathMachine->setObjectName("Mmapper2PathMachine");
 
-    m_gameObserver = std::make_unique<GameObserver>();
     m_mediaLibrary = new MediaLibrary(this);
     m_adventureTracker = new AdventureTracker(deref(m_gameObserver), this);
     m_audioManager = new AudioManager(deref(m_mediaLibrary), deref(m_gameObserver), this);

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -20,6 +20,7 @@
 
 class FBO;
 class MapCanvas;
+class GLWeather;
 namespace Legacy {
 class Functions;
 } // namespace Legacy
@@ -44,6 +45,7 @@ public:
 
 public:
     NODISCARD const auto &getSharedFunctions(Badge<MapCanvas>) { return getSharedFunctions(); }
+    NODISCARD const auto &getSharedFunctions(Badge<GLWeather>) { return getSharedFunctions(); }
 
 public:
     /* must be called before any other functions */

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -247,6 +247,8 @@ struct NODISCARD GLRenderState final
         // Weather
         struct NODISCARD Weather final
         {
+            float currentPrecipitationIntensity = 0.0f;
+
             // CameraBlock (Binding 1, must match std140 layout in shaders)
             struct NODISCARD Camera final
             {

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -25,6 +25,12 @@
 #include <QOpenGLTexture>
 #include <qopengl.h>
 
+struct NODISCARD Viewport final
+{
+    glm::ivec2 offset{};
+    glm::ivec2 size{};
+};
+
 struct NODISCARD TexVert final
 {
     glm::vec3 tex{};
@@ -84,6 +90,17 @@ struct NODISCARD ColorVert final
     explicit ColorVert(const Color color_, const glm::vec3 &vert_)
         : color{color_}
         , vert{vert_}
+    {}
+};
+
+struct NODISCARD WeatherParticleVert final
+{
+    glm::vec2 pos{};
+    float life = 0.0f;
+
+    explicit WeatherParticleVert(const glm::vec2 &pos_, const float life_)
+        : pos{pos_}
+        , life{life_}
     {}
 };
 
@@ -153,6 +170,9 @@ enum class NODISCARD BlendModeEnum {
     /* This mode allows you to multiply by the painted color, in the range [0,1].
      * glEnable(GL_BLEND); glBlendFuncSeparate(GL_ZERO, GL_SRC_COLOR, GL_ZERO, GL_ONE); */
     MODULATE,
+    /* This mode uses MAX for alpha blending, useful for weather effects.
+     * glBlendEquationSeparate(GL_FUNC_ADD, GL_MAX); */
+    MAX_ALPHA,
 };
 
 enum class NODISCARD CullingEnum {
@@ -223,6 +243,32 @@ struct NODISCARD GLRenderState final
         // glEnable(TEXTURE_2D), or glEnable(TEXTURE_3D)
         Textures textures;
         std::optional<float> pointSize;
+
+        // Weather
+        struct NODISCARD Weather final
+        {
+            // CameraBlock (Binding 1, must match std140 layout in shaders)
+            struct NODISCARD Camera final
+            {
+                glm::mat4 viewProj{1.0f};  // 0-63
+                glm::vec4 playerPos{0.0f}; // 64-79 (xyz, w=zScale)
+            } camera;
+
+            // WeatherBlock (Binding 3, must match std140 layout in shaders)
+            struct NODISCARD Params final
+            {
+                glm::vec4 intensities{0.0f};      // 0-15
+                glm::vec4 targets{0.0f};          // 16-31
+                glm::vec4 timeOfDayIndices{0.0f}; // 32-47
+                glm::vec4 config{0.0f};           // 48-63
+            } params;
+
+            // TimeBlock (Binding 2, must match std140 layout in shaders)
+            struct NODISCARD Frame final
+            {
+                glm::vec4 time{0.0f}; // 0-15 (x=time, y=delta, zw=unused)
+            } frame;
+        } weather;
     };
 
     Uniforms uniforms;
@@ -402,12 +448,6 @@ public:
             mesh.render(rs);
         }
     }
-};
-
-struct NODISCARD Viewport final
-{
-    glm::ivec2 offset{};
-    glm::ivec2 size{};
 };
 
 static constexpr const size_t VERTS_PER_LINE = 2;

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -244,17 +244,25 @@ struct NODISCARD GLRenderState final
         Textures textures;
         std::optional<float> pointSize;
 
+        // REVISIT: The following aren't uniforms
+
+        // CameraBlock (Binding 1, must match std140 layout in shaders)
+        struct NODISCARD Camera final
+        {
+            glm::mat4 viewProj{1.0f};  // 0-63
+            glm::vec4 playerPos{0.0f}; // 64-79 (xyz, w=zScale)
+        } camera;
+
+        // TimeBlock (Binding 2, must match std140 layout in shaders)
+        struct NODISCARD Time final
+        {
+            glm::vec4 time{0.0f}; // 0-15 (x=time, y=delta, zw=unused)
+        } time;
+
         // Weather
         struct NODISCARD Weather final
         {
             float currentPrecipitationIntensity = 0.0f;
-
-            // CameraBlock (Binding 1, must match std140 layout in shaders)
-            struct NODISCARD Camera final
-            {
-                glm::mat4 viewProj{1.0f};  // 0-63
-                glm::vec4 playerPos{0.0f}; // 64-79 (xyz, w=zScale)
-            } camera;
 
             // WeatherBlock (Binding 3, must match std140 layout in shaders)
             struct NODISCARD Params final
@@ -265,11 +273,6 @@ struct NODISCARD GLRenderState final
                 glm::vec4 config{0.0f};           // 48-63
             } params;
 
-            // TimeBlock (Binding 2, must match std140 layout in shaders)
-            struct NODISCARD Frame final
-            {
-                glm::vec4 time{0.0f}; // 0-15 (x=time, y=delta, zw=unused)
-            } frame;
         } weather;
     };
 

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -243,37 +243,6 @@ struct NODISCARD GLRenderState final
         // glEnable(TEXTURE_2D), or glEnable(TEXTURE_3D)
         Textures textures;
         std::optional<float> pointSize;
-
-        // REVISIT: The following aren't uniforms
-
-        // CameraBlock (Binding 1, must match std140 layout in shaders)
-        struct NODISCARD Camera final
-        {
-            glm::mat4 viewProj{1.0f};  // 0-63
-            glm::vec4 playerPos{0.0f}; // 64-79 (xyz, w=zScale)
-        } camera;
-
-        // TimeBlock (Binding 2, must match std140 layout in shaders)
-        struct NODISCARD Time final
-        {
-            glm::vec4 time{0.0f}; // 0-15 (x=time, y=delta, zw=unused)
-        } time;
-
-        // Weather
-        struct NODISCARD Weather final
-        {
-            float currentPrecipitationIntensity = 0.0f;
-
-            // WeatherBlock (Binding 3, must match std140 layout in shaders)
-            struct NODISCARD Params final
-            {
-                glm::vec4 intensities{0.0f};      // 0-15
-                glm::vec4 targets{0.0f};          // 16-31
-                glm::vec4 timeOfDayIndices{0.0f}; // 32-47
-                glm::vec4 config{0.0f};           // 48-63
-            } params;
-
-        } weather;
     };
 
     Uniforms uniforms;

--- a/src/opengl/UboBlocks.h
+++ b/src/opengl/UboBlocks.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
-#include "../global/NamedColors.h"
+#include "../global/ConfigConsts.h"
 #include "../global/utils.h"
 
 #include <array>
@@ -27,9 +27,7 @@ namespace Legacy {
 enum class NODISCARD SharedVboEnum : uint8_t { XFOREACH_SHARED_VBO(X_ENUM) NUM_BLOCKS };
 #undef X_ENUM
 
-#define X_COUNT_VBO(element, name) +1
-static constexpr size_t NUM_SHARED_VBOS = 0 XFOREACH_SHARED_VBO(X_COUNT_VBO);
-#undef X_COUNT_VBO
+static constexpr size_t NUM_SHARED_VBOS = static_cast<size_t>(SharedVboEnum::NUM_BLOCKS);
 
 /**
  * @brief Memory layout for the Camera uniform block.

--- a/src/opengl/UboBlocks.h
+++ b/src/opengl/UboBlocks.h
@@ -60,10 +60,10 @@ struct NODISCARD TimeBlock final
  */
 struct NODISCARD WeatherBlock final
 {
-    glm::vec4 intensities{0.0f};      // 0-15
-    glm::vec4 targets{0.0f};          // 16-31
-    glm::vec4 timeOfDayIndices{0.0f}; // 32-47
-    glm::vec4 config{0.0f};           // 48-63
+    glm::vec4 intensities{0.0f}; // 0-15: rain, snow, clouds, fog (starts)
+    glm::vec4 targets{0.0f};     // 16-31: rain, snow, clouds, fog (targets)
+    glm::vec4 timeOfDay{0.0f};   // 32-47: startIdx, targetIdx, todStart, todTarget
+    glm::vec4 config{0.0f};      // 48-63: weatherStartTime, todStartTime, duration, unused
 };
 
 /**

--- a/src/opengl/UboBlocks.h
+++ b/src/opengl/UboBlocks.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
-#include "../global/ConfigConsts.h"
+#include "../global/NamedColors.h"
 #include "../global/utils.h"
 
 #include <array>
@@ -28,6 +28,12 @@ enum class NODISCARD SharedVboEnum : uint8_t { XFOREACH_SHARED_VBO(X_ENUM) NUM_B
 #undef X_ENUM
 
 static constexpr size_t NUM_SHARED_VBOS = static_cast<size_t>(SharedVboEnum::NUM_BLOCKS);
+
+inline constexpr const char *const SharedVboNames[] = {
+#define X_NAME(EnumName, StringName) StringName,
+    XFOREACH_SHARED_VBO(X_NAME)
+#undef X_NAME
+};
 
 /**
  * @brief Memory layout for the Camera uniform block.
@@ -72,25 +78,13 @@ struct NODISCARD NamedColorsBlock final
 template<SharedVboEnum Block>
 struct BlockType;
 
-template<>
-struct BlockType<SharedVboEnum::NamedColorsBlock>
-{
-    using type = NamedColorsBlock;
-};
-template<>
-struct BlockType<SharedVboEnum::CameraBlock>
-{
-    using type = CameraBlock;
-};
-template<>
-struct BlockType<SharedVboEnum::TimeBlock>
-{
-    using type = TimeBlock;
-};
-template<>
-struct BlockType<SharedVboEnum::WeatherBlock>
-{
-    using type = WeatherBlock;
-};
+#define X_TYPE(EnumName, StringName) \
+    template<> \
+    struct BlockType<SharedVboEnum::EnumName> \
+    { \
+        using type = EnumName; \
+    };
+XFOREACH_SHARED_VBO(X_TYPE)
+#undef X_TYPE
 
 } // namespace Legacy

--- a/src/opengl/UboBlocks.h
+++ b/src/opengl/UboBlocks.h
@@ -4,9 +4,11 @@
 
 #include "../global/NamedColors.h"
 #include "../global/utils.h"
-#include <glm/glm.hpp>
+
 #include <array>
 #include <cstdint>
+
+#include <glm/glm.hpp>
 
 namespace Legacy {
 
@@ -22,10 +24,7 @@ namespace Legacy {
     X(WeatherBlock, "WeatherBlock")
 
 #define X_ENUM(element, name) element,
-enum class NODISCARD SharedVboEnum : uint8_t {
-    XFOREACH_SHARED_VBO(X_ENUM)
-    NUM_BLOCKS
-};
+enum class NODISCARD SharedVboEnum : uint8_t { XFOREACH_SHARED_VBO(X_ENUM) NUM_BLOCKS };
 #undef X_ENUM
 
 #define X_COUNT_VBO(element, name) +1

--- a/src/opengl/UboBlocks.h
+++ b/src/opengl/UboBlocks.h
@@ -1,0 +1,99 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "../global/NamedColors.h"
+#include "../global/utils.h"
+#include <glm/glm.hpp>
+#include <array>
+#include <cstdint>
+
+namespace Legacy {
+
+// X(EnumName, GL_String_Name)
+/**
+ * Note: SharedVboEnum values are implicitly used as UBO binding indices.
+ * They must be 0-based and contiguous.
+ */
+#define XFOREACH_SHARED_VBO(X) \
+    X(NamedColorsBlock, "NamedColorsBlock") \
+    X(CameraBlock, "CameraBlock") \
+    X(TimeBlock, "TimeBlock") \
+    X(WeatherBlock, "WeatherBlock")
+
+#define X_ENUM(element, name) element,
+enum class NODISCARD SharedVboEnum : uint8_t {
+    XFOREACH_SHARED_VBO(X_ENUM)
+    NUM_BLOCKS
+};
+#undef X_ENUM
+
+#define X_COUNT_VBO(element, name) +1
+static constexpr size_t NUM_SHARED_VBOS = 0 XFOREACH_SHARED_VBO(X_COUNT_VBO);
+#undef X_COUNT_VBO
+
+/**
+ * @brief Memory layout for the Camera uniform block.
+ * Must match CameraBlock in shaders (std140 layout).
+ */
+struct NODISCARD CameraBlock final
+{
+    glm::mat4 viewProj{1.0f};  // 0-63
+    glm::vec4 playerPos{0.0f}; // 64-79 (xyz, w=zScale)
+};
+
+/**
+ * @brief Memory layout for the Time uniform block.
+ * Must match TimeBlock in shaders (std140 layout).
+ */
+struct NODISCARD TimeBlock final
+{
+    glm::vec4 time{0.0f}; // 0-15 (x=time, y=delta, zw=unused)
+};
+
+/**
+ * @brief Memory layout for the Weather uniform block.
+ * Must match WeatherBlock in shaders (std140 layout).
+ */
+struct NODISCARD WeatherBlock final
+{
+    glm::vec4 intensities{0.0f};      // 0-15
+    glm::vec4 targets{0.0f};          // 16-31
+    glm::vec4 timeOfDayIndices{0.0f}; // 32-47
+    glm::vec4 config{0.0f};           // 48-63
+};
+
+/**
+ * @brief Memory layout for the NamedColors uniform block.
+ * Must match NamedColorsBlock in shaders (std140 layout).
+ */
+struct NODISCARD NamedColorsBlock final
+{
+    std::array<glm::vec4, MAX_NAMED_COLORS> colors{};
+};
+
+template<SharedVboEnum Block>
+struct BlockType;
+
+template<>
+struct BlockType<SharedVboEnum::NamedColorsBlock>
+{
+    using type = NamedColorsBlock;
+};
+template<>
+struct BlockType<SharedVboEnum::CameraBlock>
+{
+    using type = CameraBlock;
+};
+template<>
+struct BlockType<SharedVboEnum::TimeBlock>
+{
+    using type = TimeBlock;
+};
+template<>
+struct BlockType<SharedVboEnum::WeatherBlock>
+{
+    using type = WeatherBlock;
+};
+
+} // namespace Legacy

--- a/src/opengl/UboBlocks.h
+++ b/src/opengl/UboBlocks.h
@@ -7,6 +7,9 @@
 
 #include <array>
 #include <cstdint>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 
 #include <glm/glm.hpp>
 
@@ -86,5 +89,27 @@ struct BlockType;
     };
 XFOREACH_SHARED_VBO(X_TYPE)
 #undef X_TYPE
+
+#define X_ASSERT(EnumName, StringName) \
+    static_assert(std::is_standard_layout_v<EnumName>, \
+                  "UBO block " #EnumName " must have standard layout for offset calculations"); \
+    static_assert(std::is_trivially_copyable_v<EnumName>, \
+                  "UBO block " #EnumName " must be trivially copyable for buffer uploads");
+XFOREACH_SHARED_VBO(X_ASSERT)
+#undef X_ASSERT
+
+using SharedVboBlocksTuple = std::tuple<
+#define X_TUPLE(EnumName, StringName) EnumName,
+    XFOREACH_SHARED_VBO(X_TUPLE)
+#undef X_TUPLE
+        std::nullptr_t // Dummy trailing element to handle the trailing comma
+    >;
+
+// Helper to remove the trailing nullptr_t and get a clean tuple of blocks
+template<typename T, std::size_t... Is>
+auto StripLastImpl(std::index_sequence<Is...>) -> std::tuple<std::tuple_element_t<Is, T>...>;
+
+using SharedVboBlocks = decltype(StripLastImpl<SharedVboBlocksTuple>(
+    std::make_index_sequence<static_cast<std::size_t>(SharedVboEnum::NUM_BLOCKS)>{}));
 
 } // namespace Legacy

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -6,6 +6,7 @@
 #include "../global/RuleOf5.h"
 #include "../global/logging.h"
 #include "../global/utils.h"
+#include "UboBlocks.h"
 #include "legacy/Legacy.h"
 #include "legacy/VBO.h"
 
@@ -145,6 +146,16 @@ public:
         Legacy::VBO &vbo = getOrCreateVbo(gl, block);
         gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW);
         return bind_internal(gl, block, vbo.get());
+    }
+
+    /**
+     * @brief Type-safe upload to a UBO.
+     * Enforces the correct data structure for the given block identifier.
+     */
+    template<Legacy::SharedVboEnum Block>
+    GLuint update(Legacy::Functions &gl, const typename Legacy::BlockType<Block>::type &data)
+    {
+        return update(gl, Block, data);
     }
 
     /**

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -189,6 +189,34 @@ public:
     }
 
     /**
+     * @brief Syncs multiple specific fields of a block to the GPU in a single bind.
+     * @param gl       Legacy functions.
+     * @param members  Pointers to the members in the block struct.
+     */
+    template<Legacy::SharedVboEnum Block, typename T, typename... Us>
+    void syncFields(Legacy::Functions &gl, Us T::*... members)
+    {
+        using BlockType = typename Legacy::BlockType<Block>::type;
+        static_assert(std::is_same_v<T, BlockType>, "Members must belong to the correct block type");
+
+        const auto &blockData = get<Block>();
+        Legacy::VBO &vbo = getOrCreateVbo(gl, Block);
+        gl.glBindBuffer(GL_UNIFORM_BUFFER, vbo.get());
+
+        (gl.glBufferSubData(GL_UNIFORM_BUFFER,
+                            static_cast<GLintptr>(reinterpret_cast<std::uintptr_t>(&(blockData.*members))
+                                                  - reinterpret_cast<std::uintptr_t>(&blockData)),
+                            static_cast<GLsizeiptr>(sizeof(Us)),
+                            &(blockData.*members)),
+         ...);
+
+        gl.glBindBuffer(GL_UNIFORM_BUFFER, 0);
+
+        // Ensure it's bound to the correct point.
+        bind_internal(gl, Block, vbo.get());
+    }
+
+    /**
      * @brief Syncs a specific field of a block to the GPU.
      * @param gl      Legacy functions.
      * @param member  Pointer to the member in the block struct.
@@ -196,24 +224,7 @@ public:
     template<Legacy::SharedVboEnum Block, typename T, typename U>
     void syncField(Legacy::Functions &gl, U T::*member)
     {
-        using BlockType = typename Legacy::BlockType<Block>::type;
-        static_assert(std::is_same_v<T, BlockType>, "Member must belong to the correct block type");
-
-        const auto &blockData = get<Block>();
-        const auto offset = reinterpret_cast<std::uintptr_t>(&(blockData.*member))
-                            - reinterpret_cast<std::uintptr_t>(&blockData);
-        const auto size = sizeof(U);
-
-        Legacy::VBO &vbo = getOrCreateVbo(gl, Block);
-        gl.glBindBuffer(GL_UNIFORM_BUFFER, vbo.get());
-        gl.glBufferSubData(GL_UNIFORM_BUFFER,
-                           static_cast<GLintptr>(offset),
-                           static_cast<GLsizeiptr>(size),
-                           &(blockData.*member));
-        gl.glBindBuffer(GL_UNIFORM_BUFFER, 0);
-
-        // Ensure it's bound to the correct point.
-        bind_internal(gl, Block, vbo.get());
+        syncFields<Block>(gl, member);
     }
 
     /**

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <functional>
 #include <optional>
+#include <tuple>
 #include <type_traits>
 #include <vector>
 
@@ -37,6 +38,24 @@ public:
     DELETE_CTORS_AND_ASSIGN_OPS(UboManager);
 
 public:
+    /**
+     * @brief Accesses the CPU-side shadow copy of a UBO block by its enum.
+     */
+    template<Legacy::SharedVboEnum Block>
+    typename Legacy::BlockType<Block>::type &get()
+    {
+        return std::get<typename Legacy::BlockType<Block>::type>(m_shadowBlocks);
+    }
+
+    /**
+     * @brief Accesses the CPU-side shadow copy of a UBO block by its enum (const).
+     */
+    template<Legacy::SharedVboEnum Block>
+    const typename Legacy::BlockType<Block>::type &get() const
+    {
+        return std::get<typename Legacy::BlockType<Block>::type>(m_shadowBlocks);
+    }
+
     /**
      * @brief Marks a UBO block as dirty by resetting its bound state.
      */
@@ -151,11 +170,50 @@ public:
     /**
      * @brief Type-safe upload to a UBO.
      * Enforces the correct data structure for the given block identifier.
+     * Also updates the shadow copy.
      */
     template<Legacy::SharedVboEnum Block>
     GLuint update(Legacy::Functions &gl, const typename Legacy::BlockType<Block>::type &data)
     {
+        get<Block>() = data;
         return update(gl, Block, data);
+    }
+
+    /**
+     * @brief Syncs the entire shadow copy of a block to the GPU.
+     */
+    template<Legacy::SharedVboEnum Block>
+    GLuint sync(Legacy::Functions &gl)
+    {
+        return update(gl, Block, get<Block>());
+    }
+
+    /**
+     * @brief Syncs a specific field of a block to the GPU.
+     * @param gl      Legacy functions.
+     * @param member  Pointer to the member in the block struct.
+     */
+    template<Legacy::SharedVboEnum Block, typename T, typename U>
+    void syncField(Legacy::Functions &gl, U T::*member)
+    {
+        using BlockType = typename Legacy::BlockType<Block>::type;
+        static_assert(std::is_same_v<T, BlockType>, "Member must belong to the correct block type");
+
+        const auto &blockData = get<Block>();
+        const auto offset = reinterpret_cast<std::uintptr_t>(&(blockData.*member))
+                            - reinterpret_cast<std::uintptr_t>(&blockData);
+        const auto size = sizeof(U);
+
+        Legacy::VBO &vbo = getOrCreateVbo(gl, Block);
+        gl.glBindBuffer(GL_UNIFORM_BUFFER, vbo.get());
+        gl.glBufferSubData(GL_UNIFORM_BUFFER,
+                           static_cast<GLintptr>(offset),
+                           static_cast<GLsizeiptr>(size),
+                           &(blockData.*member));
+        gl.glBindBuffer(GL_UNIFORM_BUFFER, 0);
+
+        // Ensure it's bound to the correct point.
+        bind_internal(gl, Block, vbo.get());
     }
 
     /**
@@ -216,6 +274,10 @@ private:
 private:
     EnumIndexedArray<RebuildFunction, Legacy::SharedVboEnum> m_rebuildFunctions;
     EnumIndexedArray<std::optional<GLuint>, Legacy::SharedVboEnum> m_boundBuffers;
+
+    // Tuple of all block types for shadow storage.
+    std::tuple<Legacy::NamedColorsBlock, Legacy::CameraBlock, Legacy::TimeBlock, Legacy::WeatherBlock>
+        m_shadowBlocks;
 };
 
 } // namespace Legacy

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -71,6 +71,14 @@ public:
     }
 
     /**
+     * @brief Unregisters a rebuild function for a UBO block.
+     */
+    void unregisterRebuildFunction(Legacy::SharedVboEnum block)
+    {
+        m_rebuildFunctions[block] = nullptr;
+    }
+
+    /**
      * @brief Checks if a UBO block is currently dirty/invalid.
      */
     bool isInvalid(Legacy::SharedVboEnum block) const { return !m_boundBuffers[block].has_value(); }

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -198,6 +198,8 @@ public:
     {
         using BlockType = typename Legacy::BlockType<Block>::type;
         static_assert(std::is_same_v<T, BlockType>, "Members must belong to the correct block type");
+        static_assert(std::is_standard_layout_v<BlockType>,
+                      "Block type must have standard layout for offset calculation");
 
         const auto &blockData = get<Block>();
         Legacy::VBO &vbo = getOrCreateVbo(gl, Block);
@@ -288,8 +290,7 @@ private:
     EnumIndexedArray<std::optional<GLuint>, Legacy::SharedVboEnum> m_boundBuffers;
 
     // Tuple of all block types for shadow storage.
-    std::tuple<Legacy::NamedColorsBlock, Legacy::CameraBlock, Legacy::TimeBlock, Legacy::WeatherBlock>
-        m_shadowBlocks;
+    Legacy::SharedVboBlocks m_shadowBlocks;
 };
 
 } // namespace Legacy

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -51,13 +51,21 @@ public:
 
     /**
      * @brief Registers a function that can rebuild the UBO data.
+     *
+     * @param block           UBO block identifier.
+     * @param func            Function used to rebuild the UBO data.
+     * @param allowOverwrite  If false (default), overwriting an existing rebuild function
+     *                        will trigger a debug assertion. Set to true only when an
+     *                        overwrite is intentional.
      */
-    void registerRebuildFunction(Legacy::SharedVboEnum block, RebuildFunction func)
+    void registerRebuildFunction(Legacy::SharedVboEnum block,
+                                 RebuildFunction func,
+                                 bool allowOverwrite = false)
     {
         if (m_rebuildFunctions[block]) {
-            MMLOG_WARNING() << "UboManager::registerRebuildFunction: overwriting existing "
-                               "rebuild function for UBO block "
-                            << static_cast<int>(block);
+            assert(allowOverwrite
+                   && "UboManager::registerRebuildFunction: overwriting existing "
+                      "rebuild function for UBO block");
         }
         m_rebuildFunctions[block] = std::move(func);
     }

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -194,7 +194,7 @@ public:
      * @param members  Pointers to the members in the block struct.
      */
     template<Legacy::SharedVboEnum Block, typename T, typename... Us>
-    void syncFields(Legacy::Functions &gl, Us T::*... members)
+    void syncFields(Legacy::Functions &gl, Us T::*...members)
     {
         using BlockType = typename Legacy::BlockType<Block>::type;
         static_assert(std::is_same_v<T, BlockType>, "Members must belong to the correct block type");
@@ -204,8 +204,9 @@ public:
         gl.glBindBuffer(GL_UNIFORM_BUFFER, vbo.get());
 
         (gl.glBufferSubData(GL_UNIFORM_BUFFER,
-                            static_cast<GLintptr>(reinterpret_cast<std::uintptr_t>(&(blockData.*members))
-                                                  - reinterpret_cast<std::uintptr_t>(&blockData)),
+                            static_cast<GLintptr>(
+                                reinterpret_cast<std::uintptr_t>(&(blockData.*members))
+                                - reinterpret_cast<std::uintptr_t>(&blockData)),
                             static_cast<GLsizeiptr>(sizeof(Us)),
                             &(blockData.*members)),
          ...);

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -95,9 +95,11 @@ public:
 
         const auto &func = m_rebuildFunctions[block];
         if (!func) {
-            MMLOG_ERROR() << "UboManager::updateIfInvalid: UBO block " << static_cast<int>(block)
-                          << " is invalid and no rebuild function is registered";
-            throw std::runtime_error("UBO block is invalid and no rebuild function is registered");
+            const char *name = Legacy::Functions::getUniformBlockName(block);
+            MMLOG_ERROR() << "UboManager::updateIfInvalid: UBO block '" << name
+                          << "' is invalid and no rebuild function is registered";
+            throw std::runtime_error("UBO block '" + std::string(name)
+                                     + "' is invalid and no rebuild function is registered");
         }
 
         func(gl);
@@ -106,10 +108,12 @@ public:
             return *bound;
         }
 
+        const char *name = Legacy::Functions::getUniformBlockName(block);
         MMLOG_ERROR() << "UboManager::updateIfInvalid: rebuild function failed to call "
-                         "update() for block "
-                      << static_cast<int>(block);
-        throw std::runtime_error("Rebuild function must call update()");
+                         "update() for block '"
+                      << name << "'";
+        throw std::runtime_error("Rebuild function for block '" + std::string(name)
+                                 + "' failed to call update()");
     }
 
     /**

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -94,20 +94,22 @@ public:
         }
 
         const auto &func = m_rebuildFunctions[block];
-        assert(func && "UBO block is invalid and no rebuild function is registered");
-        if (func) {
-            func(gl);
-
-            if (const auto bound = m_boundBuffers[block]) {
-                return *bound;
-            }
-
-            MMLOG_ERROR() << "UboManager::updateIfInvalid: rebuild function failed to call "
-                             "update() for block "
-                          << static_cast<int>(block);
-            assert(false && "Rebuild function must call update()");
+        if (!func) {
+            MMLOG_ERROR() << "UboManager::updateIfInvalid: UBO block " << static_cast<int>(block)
+                          << " is invalid and no rebuild function is registered";
+            throw std::runtime_error("UBO block is invalid and no rebuild function is registered");
         }
-        return 0;
+
+        func(gl);
+
+        if (const auto bound = m_boundBuffers[block]) {
+            return *bound;
+        }
+
+        MMLOG_ERROR() << "UboManager::updateIfInvalid: rebuild function failed to call "
+                         "update() for block "
+                      << static_cast<int>(block);
+        throw std::runtime_error("Rebuild function must call update()");
     }
 
     /**

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -64,33 +64,34 @@ GLWeather::GLWeather(OpenGL &gl,
     m_currentTimeOfDay = m_observer.getTimeOfDay();
     m_gameTimeOfDayIntensity = (m_currentTimeOfDay == MumeTimeEnum::DAY) ? 0.0f : 1.0f;
 
+    auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+    const NamedColorEnum targetColorIdx = getCurrentColorIdx();
+
+    weather.timeOfDay.x = static_cast<float>(targetColorIdx); // startIdx
+    weather.timeOfDay.y = static_cast<float>(targetColorIdx); // targetIdx
+    weather.timeOfDay.z = m_gameTimeOfDayIntensity;          // todStart
+    weather.timeOfDay.w = m_gameTimeOfDayIntensity;          // todTarget
+
+    weather.intensities = glm::vec4(m_gameRainIntensity,
+                                    m_gameSnowIntensity,
+                                    m_gameCloudsIntensity,
+                                    m_gameFogIntensity);
+
     updateTargets();
+    weather.intensities = weather.targets;
 
-    m_startColorIdx = m_targetColorIdx = getCurrentColorIdx();
-
-    m_timeOfDayIntensityStart = m_targetTimeOfDayIntensity;
-    m_rainIntensityStart = m_targetRainIntensity;
-    m_snowIntensityStart = m_targetSnowIntensity;
-    m_cloudsIntensityStart = m_targetCloudsIntensity;
-    m_fogIntensityStart = m_targetFogIntensity;
-    m_precipitationTypeStart = m_targetPrecipitationType;
+    weather.config.x = -2.0f; // weatherStartTime
+    weather.config.y = -2.0f; // todStartTime
+    weather.config.z = WeatherConstants::TRANSITION_DURATION;
 
     auto startWeatherTransitions = [this]() {
-        const bool startingFromNice = (m_currentRainIntensity <= 0.0f
-                                       && m_currentSnowIntensity <= 0.0f);
+        auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
 
-        startTransitions(m_weatherTransitionStartTime,
-                         TransitionPair<float>{m_rainIntensityStart, m_targetRainIntensity},
-                         TransitionPair<float>{m_snowIntensityStart, m_targetSnowIntensity},
-                         TransitionPair<float>{m_cloudsIntensityStart, m_targetCloudsIntensity},
-                         TransitionPair<float>{m_fogIntensityStart, m_targetFogIntensity},
-                         TransitionPair<float>{m_precipitationTypeStart, m_targetPrecipitationType});
-
-        if (startingFromNice) {
-            // If we are starting from clear skies, snap the precipitation type to the target
-            // immediately so we don't see a mix (e.g. rain turning into snow) during the fade-in.
-            m_precipitationTypeStart = m_targetPrecipitationType;
-        }
+        startTransitions(weather.config.x,
+                         TransitionPair<float>{weather.intensities.x, weather.targets.x},
+                         TransitionPair<float>{weather.intensities.y, weather.targets.y},
+                         TransitionPair<float>{weather.intensities.z, weather.targets.z},
+                         TransitionPair<float>{weather.intensities.w, weather.targets.w});
     };
 
     m_observer.sig2_weatherChanged.connect(m_lifetime,
@@ -98,7 +99,17 @@ GLWeather::GLWeather(OpenGL &gl,
                                                startWeatherTransitions();
                                                updateFromGame();
                                                updateTargets();
-                                               invalidateWeather();
+
+                                               auto &funcs = deref(
+                                                   m_gl.getSharedFunctions(Badge<GLWeather>{}));
+                                               auto &ubo = m_gl.getUboManager();
+                                               ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(
+                                                   funcs, &Legacy::WeatherBlock::config);
+                                               ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(
+                                                   funcs, &Legacy::WeatherBlock::intensities);
+                                               ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(
+                                                   funcs, &Legacy::WeatherBlock::targets);
+
                                                m_animationManager.requestUpdate();
                                            });
 
@@ -106,15 +117,28 @@ GLWeather::GLWeather(OpenGL &gl,
         startWeatherTransitions();
         updateFromGame();
         updateTargets();
-        invalidateWeather();
+
+        auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
+        auto &ubo = m_gl.getUboManager();
+        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
+        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
+                                                          &Legacy::WeatherBlock::intensities);
+        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::targets);
+
         m_animationManager.requestUpdate();
     });
 
     auto startTimeOfDayTransitions = [this]() {
-        startTransitions(m_timeOfDayTransitionStartTime,
-                         TransitionPair<float>{m_timeOfDayIntensityStart,
-                                               m_targetTimeOfDayIntensity},
-                         TransitionPair<NamedColorEnum>{m_startColorIdx, m_targetColorIdx});
+        auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+        auto startColor = static_cast<NamedColorEnum>(static_cast<int>(weather.timeOfDay.x));
+        auto targetColor = static_cast<NamedColorEnum>(static_cast<int>(weather.timeOfDay.y));
+
+        startTransitions(weather.config.y,
+                         TransitionPair<float>{weather.timeOfDay.z, weather.timeOfDay.w},
+                         TransitionPair<NamedColorEnum>{startColor, targetColor});
+
+        weather.timeOfDay.x = static_cast<float>(startColor);
+        weather.timeOfDay.y = static_cast<float>(targetColor);
     };
 
     m_observer.sig2_timeOfDayChanged
@@ -128,9 +152,16 @@ GLWeather::GLWeather(OpenGL &gl,
             m_currentTimeOfDay = timeOfDay;
             m_gameTimeOfDayIntensity = (timeOfDay == MumeTimeEnum::DAY) ? 0.0f : 1.0f;
             updateTargets();
-            m_targetColorIdx = getCurrentColorIdx();
 
-            invalidateWeather();
+            auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+            weather.timeOfDay.y = static_cast<float>(getCurrentColorIdx());
+
+            auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
+            auto &ubo = m_gl.getUboManager();
+            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
+            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
+                                                              &Legacy::WeatherBlock::timeOfDay);
+
             m_animationManager.requestUpdate();
         });
 
@@ -143,16 +174,33 @@ GLWeather::GLWeather(OpenGL &gl,
                                                       startTimeOfDayTransitions();
 
                                                       m_moonVisibility = visibility;
-                                                      m_targetColorIdx = getCurrentColorIdx();
+                                                      auto &weather = m_gl.getUboManager().get<
+                                                          Legacy::SharedVboEnum::WeatherBlock>();
+                                                      weather.timeOfDay.y
+                                                          = static_cast<float>(getCurrentColorIdx());
 
-                                                      invalidateWeather();
+                                                      auto &funcs = deref(
+                                                          m_gl.getSharedFunctions(Badge<GLWeather>{}));
+                                                      auto &ubo = m_gl.getUboManager();
+                                                      ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(
+                                                          funcs, &Legacy::WeatherBlock::config);
+                                                      ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(
+                                                          funcs, &Legacy::WeatherBlock::timeOfDay);
+
                                                       m_animationManager.requestUpdate();
                                                   });
 
     auto onSettingChanged = [this, startWeatherTransitions]() {
         startWeatherTransitions();
         updateTargets();
-        invalidateWeather();
+
+        auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
+        auto &ubo = m_gl.getUboManager();
+        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
+        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
+                                                          &Legacy::WeatherBlock::intensities);
+        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::targets);
+
         m_animationManager.requestUpdate();
     };
 
@@ -160,7 +208,12 @@ GLWeather::GLWeather(OpenGL &gl,
         startTimeOfDayTransitions();
 
         updateTargets();
-        invalidateWeather();
+
+        auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
+        auto &ubo = m_gl.getUboManager();
+        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
+        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::timeOfDay);
+
         m_animationManager.requestUpdate();
     };
 
@@ -178,9 +231,7 @@ GLWeather::GLWeather(OpenGL &gl,
 
     m_gl.getUboManager().registerRebuildFunction(
         Legacy::SharedVboEnum::WeatherBlock, [this](Legacy::Functions &funcs) {
-            Legacy::WeatherBlock params;
-            populateWeatherParams(params);
-            m_gl.getUboManager().update<Legacy::SharedVboEnum::WeatherBlock>(funcs, params);
+            m_gl.getUboManager().sync<Legacy::SharedVboEnum::WeatherBlock>(funcs);
         });
 }
 
@@ -239,43 +290,45 @@ void GLWeather::updateFromGame()
 void GLWeather::updateTargets()
 {
     const auto &canvasSettings = getConfig().canvas;
-    m_targetRainIntensity = m_gameRainIntensity
-                            * (static_cast<float>(canvasSettings.weatherPrecipitationIntensity.get())
-                               / 50.0f);
-    m_targetSnowIntensity = m_gameSnowIntensity
-                            * (static_cast<float>(canvasSettings.weatherPrecipitationIntensity.get())
-                               / 50.0f);
-    m_targetCloudsIntensity = m_gameCloudsIntensity
-                              * (static_cast<float>(canvasSettings.weatherAtmosphereIntensity.get())
-                                 / 50.0f);
-    m_targetFogIntensity = m_gameFogIntensity
-                           * (static_cast<float>(canvasSettings.weatherAtmosphereIntensity.get())
-                              / 50.0f);
-    m_targetTimeOfDayIntensity = m_gameTimeOfDayIntensity
-                                 * (static_cast<float>(
-                                        canvasSettings.weatherTimeOfDayIntensity.get())
-                                    / 50.0f);
-    m_targetPrecipitationType = m_gamePrecipitationType;
+    auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+
+    weather.targets.x = m_gameRainIntensity
+                        * (static_cast<float>(canvasSettings.weatherPrecipitationIntensity.get())
+                           / 50.0f);
+    weather.targets.y = m_gameSnowIntensity
+                        * (static_cast<float>(canvasSettings.weatherPrecipitationIntensity.get())
+                           / 50.0f);
+    weather.targets.z = m_gameCloudsIntensity
+                        * (static_cast<float>(canvasSettings.weatherAtmosphereIntensity.get())
+                           / 50.0f);
+    weather.targets.w = m_gameFogIntensity
+                        * (static_cast<float>(canvasSettings.weatherAtmosphereIntensity.get())
+                           / 50.0f);
+    weather.timeOfDay.w = m_gameTimeOfDayIntensity
+                          * (static_cast<float>(canvasSettings.weatherTimeOfDayIntensity.get())
+                             / 50.0f);
 }
 
 void GLWeather::update()
 {
-    m_currentRainIntensity = applyTransition(m_weatherTransitionStartTime,
-                                             m_rainIntensityStart,
-                                             m_targetRainIntensity);
-    m_currentSnowIntensity = applyTransition(m_weatherTransitionStartTime,
-                                             m_snowIntensityStart,
-                                             m_targetSnowIntensity);
-    m_currentCloudsIntensity = applyTransition(m_weatherTransitionStartTime,
-                                               m_cloudsIntensityStart,
-                                               m_targetCloudsIntensity);
-    m_currentFogIntensity = applyTransition(m_weatherTransitionStartTime,
-                                            m_fogIntensityStart,
-                                            m_targetFogIntensity);
+    const auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
 
-    m_currentTimeOfDayIntensity = applyTransition(m_timeOfDayTransitionStartTime,
-                                                  m_timeOfDayIntensityStart,
-                                                  m_targetTimeOfDayIntensity);
+    m_currentRainIntensity = applyTransition(weather.config.x,
+                                             weather.intensities.x,
+                                             weather.targets.x);
+    m_currentSnowIntensity = applyTransition(weather.config.x,
+                                             weather.intensities.y,
+                                             weather.targets.y);
+    m_currentCloudsIntensity = applyTransition(weather.config.x,
+                                               weather.intensities.z,
+                                               weather.targets.z);
+    m_currentFogIntensity = applyTransition(weather.config.x,
+                                            weather.intensities.w,
+                                            weather.targets.w);
+
+    m_currentTimeOfDayIntensity = applyTransition(weather.config.y,
+                                                  weather.timeOfDay.z,
+                                                  weather.timeOfDay.w);
 }
 
 bool GLWeather::isAnimating() const
@@ -288,9 +341,11 @@ bool GLWeather::isAnimating() const
 bool GLWeather::isTransitioning() const
 {
     const float animTime = m_animationManager.getElapsedTime();
-    const bool weatherTransitioning = (animTime - m_weatherTransitionStartTime
+    const auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+
+    const bool weatherTransitioning = (animTime - weather.config.x
                                        < WeatherConstants::TRANSITION_DURATION);
-    const bool timeOfDayTransitioning = (animTime - m_timeOfDayTransitionStartTime
+    const bool timeOfDayTransitioning = (animTime - weather.config.y
                                          < WeatherConstants::TRANSITION_DURATION);
     return weatherTransitioning || timeOfDayTransitioning;
 }
@@ -312,33 +367,6 @@ NamedColorEnum GLWeather::getCurrentColorIdx() const
         return NamedColorEnum::TRANSPARENT;
     }
     return NamedColorEnum::TRANSPARENT;
-}
-
-void GLWeather::populateWeatherParams(Legacy::WeatherBlock &params) const
-{
-    params.intensities = glm::vec4(std::max(m_rainIntensityStart, m_snowIntensityStart),
-                                   m_cloudsIntensityStart,
-                                   m_fogIntensityStart,
-                                   m_precipitationTypeStart);
-
-    params.targets = glm::vec4(std::max(m_targetRainIntensity, m_targetSnowIntensity),
-                               m_targetCloudsIntensity,
-                               m_targetFogIntensity,
-                               m_targetPrecipitationType);
-
-    params.timeOfDayIndices.x = static_cast<float>(m_startColorIdx);
-    params.timeOfDayIndices.y = static_cast<float>(m_targetColorIdx);
-    params.timeOfDayIndices.z = m_timeOfDayIntensityStart;
-    params.timeOfDayIndices.w = m_targetTimeOfDayIntensity;
-
-    params.config.x = m_weatherTransitionStartTime;
-    params.config.y = m_timeOfDayTransitionStartTime;
-    params.config.z = WeatherConstants::TRANSITION_DURATION;
-}
-
-void GLWeather::invalidateWeather()
-{
-    m_gl.getUboManager().invalidate(Legacy::SharedVboEnum::WeatherBlock);
 }
 
 float GLWeather::applyTransition(const float startTime,
@@ -374,8 +402,7 @@ template void GLWeather::startTransitions(float &startTime,
                                           TransitionPair<float> p1,
                                           TransitionPair<float> p2,
                                           TransitionPair<float> p3,
-                                          TransitionPair<float> p4,
-                                          TransitionPair<float> p5);
+                                          TransitionPair<float> p4);
 
 template void GLWeather::startTransitions(float &startTime,
                                           TransitionPair<float> p1,
@@ -431,7 +458,8 @@ void GLWeather::render(const GLRenderState &rs)
                                   .withDepthFunction(std::nullopt);
 
     // TimeOfDay
-    if (m_currentTimeOfDay != MumeTimeEnum::DAY || m_startColorIdx != NamedColorEnum::TRANSPARENT
+    const auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+    if (m_currentTimeOfDay != MumeTimeEnum::DAY || weather.timeOfDay.x != static_cast<float>(NamedColorEnum::TRANSPARENT)
         || m_currentTimeOfDayIntensity > 0.0f) {
         if (m_timeOfDay) {
             m_timeOfDay.render(atmosphereRs);

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -23,7 +23,7 @@ constexpr float TRANSITION_DURATION = 2.0f;
 constexpr float ROOM_Z_SCALE = 7.f;
 
 template<typename T>
-T my_lerp(T a, T b, float t)
+T lerp(T a, T b, float t)
 {
     return a + t * (b - a);
 }
@@ -61,15 +61,21 @@ GLWeather::GLWeather(OpenGL &gl,
     m_moonIntensityStart = m_targetMoonIntensity;
 
     auto lerpCurrentIntensities = [this]() {
-        applyTransition(m_weatherTransitionStartTime, m_rainIntensityStart, m_targetRainIntensity);
-        applyTransition(m_weatherTransitionStartTime, m_snowIntensityStart, m_targetSnowIntensity);
-        applyTransition(m_weatherTransitionStartTime,
-                        m_cloudsIntensityStart,
-                        m_targetCloudsIntensity);
-        applyTransition(m_weatherTransitionStartTime, m_fogIntensityStart, m_targetFogIntensity);
-        applyTransition(m_weatherTransitionStartTime,
-                        m_precipitationTypeStart,
-                        m_targetPrecipitationType);
+        m_rainIntensityStart = applyTransition(m_weatherTransitionStartTime,
+                                               m_rainIntensityStart,
+                                               m_targetRainIntensity);
+        m_snowIntensityStart = applyTransition(m_weatherTransitionStartTime,
+                                               m_snowIntensityStart,
+                                               m_targetSnowIntensity);
+        m_cloudsIntensityStart = applyTransition(m_weatherTransitionStartTime,
+                                                 m_cloudsIntensityStart,
+                                                 m_targetCloudsIntensity);
+        m_fogIntensityStart = applyTransition(m_weatherTransitionStartTime,
+                                              m_fogIntensityStart,
+                                              m_targetFogIntensity);
+        m_precipitationTypeStart = applyTransition(m_weatherTransitionStartTime,
+                                                   m_precipitationTypeStart,
+                                                   m_targetPrecipitationType);
     };
 
     m_observer.sig2_weatherChanged
@@ -96,12 +102,12 @@ GLWeather::GLWeather(OpenGL &gl,
             return;
         }
 
-        applyTransition(m_timeOfDayTransitionStartTime,
-                        m_timeOfDayIntensityStart,
-                        m_targetTimeOfDayIntensity);
-        applyTransition(m_timeOfDayTransitionStartTime,
-                        m_moonIntensityStart,
-                        m_targetMoonIntensity);
+        m_timeOfDayIntensityStart = applyTransition(m_timeOfDayTransitionStartTime,
+                                                    m_timeOfDayIntensityStart,
+                                                    m_targetTimeOfDayIntensity);
+        m_moonIntensityStart = applyTransition(m_timeOfDayTransitionStartTime,
+                                               m_moonIntensityStart,
+                                               m_targetMoonIntensity);
 
         m_oldTimeOfDay = m_currentTimeOfDay;
         m_currentTimeOfDay = timeOfDay;
@@ -117,12 +123,12 @@ GLWeather::GLWeather(OpenGL &gl,
             if (visibility == m_moonVisibility) {
                 return;
             }
-            applyTransition(m_timeOfDayTransitionStartTime,
-                            m_moonIntensityStart,
-                            m_targetMoonIntensity);
-            applyTransition(m_timeOfDayTransitionStartTime,
-                            m_timeOfDayIntensityStart,
-                            m_targetTimeOfDayIntensity);
+            m_moonIntensityStart = applyTransition(m_timeOfDayTransitionStartTime,
+                                                   m_moonIntensityStart,
+                                                   m_targetMoonIntensity);
+            m_timeOfDayIntensityStart = applyTransition(m_timeOfDayTransitionStartTime,
+                                                        m_timeOfDayIntensityStart,
+                                                        m_targetTimeOfDayIntensity);
 
             m_moonVisibility = visibility;
             m_targetMoonIntensity = (visibility == MumeMoonVisibilityEnum::BRIGHT) ? 1.0f : 0.0f;
@@ -140,9 +146,9 @@ GLWeather::GLWeather(OpenGL &gl,
     };
 
     auto onTimeOfDaySettingChanged = [this]() {
-        applyTransition(m_timeOfDayTransitionStartTime,
-                        m_timeOfDayIntensityStart,
-                        m_targetTimeOfDayIntensity);
+        m_timeOfDayIntensityStart = applyTransition(m_timeOfDayTransitionStartTime,
+                                                    m_timeOfDayIntensityStart,
+                                                    m_targetTimeOfDayIntensity);
 
         updateTargets();
         m_timeOfDayTransitionStartTime = m_animationManager.getElapsedTime();
@@ -165,7 +171,7 @@ GLWeather::GLWeather(OpenGL &gl,
     m_gl.getUboManager().registerRebuildFunction(
         Legacy::SharedVboEnum::CameraBlock, [this](Legacy::Functions &glFuncs) {
             const auto playerPosCoord = m_data.tryGetPosition().value_or(Coordinate{0, 0, 0});
-            auto cameraData = getCameraData(m_lastViewProj, playerPosCoord);
+            auto cameraData = getCameraData(glFuncs.getProjectionMatrix(), playerPosCoord);
             m_gl.getUboManager().update(glFuncs, Legacy::SharedVboEnum::CameraBlock, cameraData);
         });
 
@@ -227,7 +233,6 @@ void GLWeather::updateFromGame()
 void GLWeather::updateTargets()
 {
     const auto &canvasSettings = getConfig().canvas;
-    // Map 0-100 slider to 0.0-2.0 multiplier, with 50 as neutral.
     m_targetRainIntensity = m_gameRainIntensity
                             * (static_cast<float>(canvasSettings.weatherPrecipitationIntensity.get())
                                / 50.0f);
@@ -248,22 +253,22 @@ void GLWeather::updateTargets()
 
 void GLWeather::update()
 {
-    updateTargets();
+    m_currentRainIntensity = applyTransition(m_weatherTransitionStartTime,
+                                             m_rainIntensityStart,
+                                             m_targetRainIntensity);
+    m_currentSnowIntensity = applyTransition(m_weatherTransitionStartTime,
+                                             m_snowIntensityStart,
+                                             m_targetSnowIntensity);
+    m_currentCloudsIntensity = applyTransition(m_weatherTransitionStartTime,
+                                               m_cloudsIntensityStart,
+                                               m_targetCloudsIntensity);
+    m_currentFogIntensity = applyTransition(m_weatherTransitionStartTime,
+                                            m_fogIntensityStart,
+                                            m_targetFogIntensity);
 
-    const float animTime = m_animationManager.getElapsedTime();
-
-    float wt = std::clamp((animTime - m_weatherTransitionStartTime) / TRANSITION_DURATION,
-                          0.0f,
-                          1.0f);
-    m_currentRainIntensity = my_lerp(m_rainIntensityStart, m_targetRainIntensity, wt);
-    m_currentSnowIntensity = my_lerp(m_snowIntensityStart, m_targetSnowIntensity, wt);
-    m_currentCloudsIntensity = my_lerp(m_cloudsIntensityStart, m_targetCloudsIntensity, wt);
-    m_currentFogIntensity = my_lerp(m_fogIntensityStart, m_targetFogIntensity, wt);
-
-    float tt = std::clamp((animTime - m_timeOfDayTransitionStartTime) / TRANSITION_DURATION,
-                          0.0f,
-                          1.0f);
-    m_currentTimeOfDayIntensity = my_lerp(m_timeOfDayIntensityStart, m_targetTimeOfDayIntensity, tt);
+    m_currentTimeOfDayIntensity = applyTransition(m_timeOfDayTransitionStartTime,
+                                                  m_timeOfDayIntensityStart,
+                                                  m_targetTimeOfDayIntensity);
 }
 
 bool GLWeather::isAnimating() const
@@ -333,21 +338,18 @@ void GLWeather::populateWeatherParams(GLRenderState::Uniforms::Weather::Params &
     params.config.z = TRANSITION_DURATION;
 }
 
-void GLWeather::invalidateCamera()
-{
-    m_gl.getUboManager().invalidate(Legacy::SharedVboEnum::CameraBlock);
-}
-
 void GLWeather::invalidateWeather()
 {
     m_gl.getUboManager().invalidate(Legacy::SharedVboEnum::WeatherBlock);
 }
 
-void GLWeather::applyTransition(float startTime, float &startVal, float targetVal)
+float GLWeather::applyTransition(const float startTime,
+                                 const float startVal,
+                                 const float targetVal) const
 {
-    float t = (m_animationManager.getElapsedTime() - startTime) / TRANSITION_DURATION;
-    float factor = std::clamp(t, 0.0f, 1.0f);
-    startVal = my_lerp(startVal, targetVal, factor);
+    const float t = (m_animationManager.getElapsedTime() - startTime) / TRANSITION_DURATION;
+    const float factor = std::clamp(t, 0.0f, 1.0f);
+    return lerp(startVal, targetVal, factor);
 }
 
 void GLWeather::initMeshes()
@@ -369,15 +371,9 @@ void GLWeather::initMeshes()
     }
 }
 
-void GLWeather::prepare(const glm::mat4 &viewProj, const Coordinate &playerPos)
+void GLWeather::prepare()
 {
     initMeshes();
-
-    if (viewProj != m_lastViewProj || playerPos != m_lastPlayerPos) {
-        m_lastViewProj = viewProj;
-        m_lastPlayerPos = playerPos;
-        invalidateCamera();
-    }
 
     auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
     m_gl.getUboManager().bind(funcs, Legacy::SharedVboEnum::CameraBlock);

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -29,6 +29,26 @@ T lerp(T a, T b, float t)
 
 } // namespace
 
+/**
+ * Weather transition authority documentation:
+ *
+ * Transitions (weather intensities, fog, time-of-day) are driven by a shared
+ * duration constant (WeatherConstants::TRANSITION_DURATION).
+ *
+ * The CPU (GLWeather::update/applyTransition) calculates interpolated values
+ * each frame. These CPU-side values are primarily used for high-level logic,
+ * such as:
+ * - Pruning: Skipping rendering of atmosphere/particles when intensities are zero.
+ * - Thinning: Scaling the number of particle instances based on intensity for performance.
+ * - Pacing: Determining if FrameManager heartbeat should continue.
+ *
+ * The GPU (shaders) is authoritative for the visual transition curves.
+ * By passing start/target pairs and start times to the shaders, the GPU
+ * performs per-pixel (or per-vertex) interpolation using its own clocks.
+ * This ensures perfectly smooth visuals even if the CPU frame rate is low
+ * or inconsistent, while avoiding constant UBO re-uploads for animation state.
+ */
+
 GLWeather::GLWeather(OpenGL &gl,
                      MapData &mapData,
                      const MapCanvasTextures &textures,
@@ -58,12 +78,21 @@ GLWeather::GLWeather(OpenGL &gl,
     m_precipitationTypeStart = m_targetPrecipitationType;
 
     auto startWeatherTransitions = [this]() {
+        const bool startingFromNice = (m_currentRainIntensity <= 0.0f
+                                       && m_currentSnowIntensity <= 0.0f);
+
         startTransitions(m_weatherTransitionStartTime,
                          TransitionPair<float>{m_rainIntensityStart, m_targetRainIntensity},
                          TransitionPair<float>{m_snowIntensityStart, m_targetSnowIntensity},
                          TransitionPair<float>{m_cloudsIntensityStart, m_targetCloudsIntensity},
                          TransitionPair<float>{m_fogIntensityStart, m_targetFogIntensity},
                          TransitionPair<float>{m_precipitationTypeStart, m_targetPrecipitationType});
+
+        if (startingFromNice) {
+            // If we are starting from clear skies, snap the precipitation type to the target
+            // immediately so we don't see a mix (e.g. rain turning into snow) during the fade-in.
+            m_precipitationTypeStart = m_targetPrecipitationType;
+        }
     };
 
     m_observer.sig2_weatherChanged.connect(m_lifetime,
@@ -144,7 +173,7 @@ GLWeather::GLWeather(OpenGL &gl,
     setConfig().canvas.weatherTimeOfDayIntensity.registerChangeCallback(m_lifetime,
                                                                         onTimeOfDaySettingChanged);
 
-    m_animationManager.registerCallback(m_signalLifetime, [this]() {
+    m_animationManager.registerCallback(m_lifetime, [this]() {
         return isAnimating() ? FrameManager::AnimationStatusEnum::Continue
                              : FrameManager::AnimationStatusEnum::Stop;
     });
@@ -179,14 +208,14 @@ void GLWeather::updateFromGame()
     m_gameSnowIntensity = 0.0f;
     m_gameCloudsIntensity = 0.0f;
     m_gameFogIntensity = 0.0f;
-    // Default to rain (0), will be overridden by SNOW
-    m_gamePrecipitationType = 0.0f;
 
     switch (w) {
     case PromptWeatherEnum::NICE:
+        // Preserve m_gamePrecipitationType so it stays at its last value while fading out.
         break;
     case PromptWeatherEnum::CLOUDS:
         m_gameCloudsIntensity = 0.5f;
+        // Also preserve type here, as there's no precipitation.
         break;
     case PromptWeatherEnum::RAIN:
         m_gameCloudsIntensity = 0.8f;

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -164,7 +164,11 @@ GLWeather::GLWeather(OpenGL &gl,
         });
 }
 
-GLWeather::~GLWeather() = default;
+GLWeather::~GLWeather()
+{
+    m_gl.getUboManager().unregisterRebuildFunction(Legacy::SharedVboEnum::CameraBlock);
+    m_gl.getUboManager().unregisterRebuildFunction(Legacy::SharedVboEnum::WeatherBlock);
+}
 
 void GLWeather::updateFromGame()
 {
@@ -176,7 +180,7 @@ void GLWeather::updateFromGame()
     m_gameCloudsIntensity = 0.0f;
     m_gameFogIntensity = 0.0f;
     // Default to rain (0), will be overridden by SNOW
-    m_targetPrecipitationType = 0.0f;
+    m_gamePrecipitationType = 0.0f;
 
     switch (w) {
     case PromptWeatherEnum::NICE:
@@ -187,17 +191,17 @@ void GLWeather::updateFromGame()
     case PromptWeatherEnum::RAIN:
         m_gameCloudsIntensity = 0.8f;
         m_gameRainIntensity = 0.5f;
-        m_targetPrecipitationType = 0.0f;
+        m_gamePrecipitationType = 0.0f;
         break;
     case PromptWeatherEnum::HEAVY_RAIN:
         m_gameCloudsIntensity = 1.0f;
         m_gameRainIntensity = 1.0f;
-        m_targetPrecipitationType = 0.0f;
+        m_gamePrecipitationType = 0.0f;
         break;
     case PromptWeatherEnum::SNOW:
         m_gameCloudsIntensity = 0.8f;
         m_gameSnowIntensity = 0.8f;
-        m_targetPrecipitationType = 1.0f;
+        m_gamePrecipitationType = 1.0f;
         break;
     }
 
@@ -232,6 +236,7 @@ void GLWeather::updateTargets()
                                  * (static_cast<float>(
                                         canvasSettings.weatherTimeOfDayIntensity.get())
                                     / 50.0f);
+    m_targetPrecipitationType = m_gamePrecipitationType;
 }
 
 void GLWeather::update()
@@ -350,6 +355,14 @@ T GLWeather::applyTransition(float startTime, T startVal, T targetVal) const
     return (t >= 1.0f) ? targetVal : startVal;
 }
 
+template<typename... Pairs>
+void GLWeather::startTransitions(float &startTime, Pairs... pairs)
+{
+    float oldStartTime = startTime;
+    startTime = m_animationManager.getElapsedTime();
+    (..., (pairs.start = applyTransition(oldStartTime, pairs.start, pairs.target)));
+}
+
 template void GLWeather::startTransitions(float &startTime,
                                           TransitionPair<float> p1,
                                           TransitionPair<float> p2,
@@ -360,14 +373,6 @@ template void GLWeather::startTransitions(float &startTime,
 template void GLWeather::startTransitions(float &startTime,
                                           TransitionPair<float> p1,
                                           TransitionPair<NamedColorEnum> p2);
-
-template<typename... Pairs>
-void GLWeather::startTransitions(float &startTime, Pairs... pairs)
-{
-    float oldStartTime = startTime;
-    startTime = m_animationManager.getElapsedTime();
-    (..., (pairs.start = applyTransition(oldStartTime, pairs.start, pairs.target)));
-}
 
 void GLWeather::initMeshes()
 {
@@ -403,7 +408,9 @@ void GLWeather::render(const GLRenderState &rs)
     const float rainMax = m_currentRainIntensity;
     const float snowMax = m_currentSnowIntensity;
     if (rainMax > 0.0f || snowMax > 0.0f) {
-        const auto particleRs = rs.withBlend(BlendModeEnum::MAX_ALPHA);
+        auto particleRs = rs.withBlend(BlendModeEnum::MAX_ALPHA);
+        particleRs.uniforms.weather.currentPrecipitationIntensity = std::max(rainMax, snowMax);
+
         if (m_simulation) {
             m_simulation->render(particleRs);
         }

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -19,8 +19,6 @@
 #include <glm/glm.hpp>
 
 namespace {
-constexpr float ROOM_Z_SCALE = 7.f;
-
 template<typename T>
 T lerp(T a, T b, float t)
 {
@@ -179,23 +177,15 @@ GLWeather::GLWeather(OpenGL &gl,
     });
 
     m_gl.getUboManager().registerRebuildFunction(
-        Legacy::SharedVboEnum::CameraBlock, [this](Legacy::Functions &glFuncs) {
-            const auto playerPosCoord = m_data.tryGetPosition().value_or(Coordinate{0, 0, 0});
-            auto cameraData = getCameraData(glFuncs.getProjectionMatrix(), playerPosCoord);
-            m_gl.getUboManager().update(glFuncs, Legacy::SharedVboEnum::CameraBlock, cameraData);
-        });
-
-    m_gl.getUboManager().registerRebuildFunction(
-        Legacy::SharedVboEnum::WeatherBlock, [this](Legacy::Functions &glFuncs) {
+        Legacy::SharedVboEnum::WeatherBlock, [this](Legacy::Functions &funcs) {
             GLRenderState::Uniforms::Weather::Params params;
             populateWeatherParams(params);
-            m_gl.getUboManager().update(glFuncs, Legacy::SharedVboEnum::WeatherBlock, params);
+            m_gl.getUboManager().update(funcs, Legacy::SharedVboEnum::WeatherBlock, params);
         });
 }
 
 GLWeather::~GLWeather()
 {
-    m_gl.getUboManager().unregisterRebuildFunction(Legacy::SharedVboEnum::CameraBlock);
     m_gl.getUboManager().unregisterRebuildFunction(Legacy::SharedVboEnum::WeatherBlock);
 }
 
@@ -303,18 +293,6 @@ bool GLWeather::isTransitioning() const
     const bool timeOfDayTransitioning = (animTime - m_timeOfDayTransitionStartTime
                                          < WeatherConstants::TRANSITION_DURATION);
     return weatherTransitioning || timeOfDayTransitioning;
-}
-
-GLRenderState::Uniforms::Weather::Camera GLWeather::getCameraData(
-    const glm::mat4 &viewProj, const Coordinate &playerPosCoord) const
-{
-    GLRenderState::Uniforms::Weather::Camera camera;
-    camera.viewProj = viewProj;
-    camera.playerPos = glm::vec4(static_cast<float>(playerPosCoord.x),
-                                 static_cast<float>(playerPosCoord.y),
-                                 static_cast<float>(playerPosCoord.z),
-                                 ROOM_Z_SCALE);
-    return camera;
 }
 
 NamedColorEnum GLWeather::getCurrentColorIdx() const

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -69,8 +69,8 @@ GLWeather::GLWeather(OpenGL &gl,
 
     weather.timeOfDay.x = static_cast<float>(targetColorIdx); // startIdx
     weather.timeOfDay.y = static_cast<float>(targetColorIdx); // targetIdx
-    weather.timeOfDay.z = m_gameTimeOfDayIntensity;          // todStart
-    weather.timeOfDay.w = m_gameTimeOfDayIntensity;          // todTarget
+    weather.timeOfDay.z = m_gameTimeOfDayIntensity;           // todStart
+    weather.timeOfDay.w = m_gameTimeOfDayIntensity;           // todTarget
 
     weather.intensities = glm::vec4(m_gameRainIntensity,
                                     m_gameSnowIntensity,
@@ -85,33 +85,31 @@ GLWeather::GLWeather(OpenGL &gl,
     weather.config.z = WeatherConstants::TRANSITION_DURATION;
 
     auto startWeatherTransitions = [this]() {
-        auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+        auto &wb = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
 
-        startTransitions(weather.config.x,
-                         TransitionPair<float>{weather.intensities.x, weather.targets.x},
-                         TransitionPair<float>{weather.intensities.y, weather.targets.y},
-                         TransitionPair<float>{weather.intensities.z, weather.targets.z},
-                         TransitionPair<float>{weather.intensities.w, weather.targets.w});
+        startTransitions(wb.config.x,
+                         TransitionPair<float>{wb.intensities.x, wb.targets.x},
+                         TransitionPair<float>{wb.intensities.y, wb.targets.y},
+                         TransitionPair<float>{wb.intensities.z, wb.targets.z},
+                         TransitionPair<float>{wb.intensities.w, wb.targets.w});
     };
 
-    m_observer.sig2_weatherChanged.connect(m_lifetime,
-                                           [this, startWeatherTransitions](PromptWeatherEnum) {
-                                               startWeatherTransitions();
-                                               updateFromGame();
-                                               updateTargets();
+    m_observer.sig2_weatherChanged
+        .connect(m_lifetime, [this, startWeatherTransitions](PromptWeatherEnum) {
+            startWeatherTransitions();
+            updateFromGame();
+            updateTargets();
 
-                                               auto &funcs = deref(
-                                                   m_gl.getSharedFunctions(Badge<GLWeather>{}));
-                                               auto &ubo = m_gl.getUboManager();
-                                               ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(
-                                                   funcs, &Legacy::WeatherBlock::config);
-                                               ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(
-                                                   funcs, &Legacy::WeatherBlock::intensities);
-                                               ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(
-                                                   funcs, &Legacy::WeatherBlock::targets);
+            auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
+            auto &ubo = m_gl.getUboManager();
+            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
+            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
+                                                               &Legacy::WeatherBlock::intensities);
+            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
+                                                               &Legacy::WeatherBlock::targets);
 
-                                               m_animationManager.requestUpdate();
-                                           });
+            m_animationManager.requestUpdate();
+        });
 
     m_observer.sig2_fogChanged.connect(m_lifetime, [this, startWeatherTransitions](PromptFogEnum) {
         startWeatherTransitions();
@@ -122,23 +120,23 @@ GLWeather::GLWeather(OpenGL &gl,
         auto &ubo = m_gl.getUboManager();
         ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
         ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
-                                                          &Legacy::WeatherBlock::intensities);
+                                                           &Legacy::WeatherBlock::intensities);
         ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::targets);
 
         m_animationManager.requestUpdate();
     });
 
     auto startTimeOfDayTransitions = [this]() {
-        auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
-        auto startColor = static_cast<NamedColorEnum>(static_cast<int>(weather.timeOfDay.x));
-        auto targetColor = static_cast<NamedColorEnum>(static_cast<int>(weather.timeOfDay.y));
+        auto &wb = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+        auto startColor = static_cast<NamedColorEnum>(static_cast<int>(wb.timeOfDay.x));
+        auto targetColor = static_cast<NamedColorEnum>(static_cast<int>(wb.timeOfDay.y));
 
-        startTransitions(weather.config.y,
-                         TransitionPair<float>{weather.timeOfDay.z, weather.timeOfDay.w},
+        startTransitions(wb.config.y,
+                         TransitionPair<float>{wb.timeOfDay.z, wb.timeOfDay.w},
                          TransitionPair<NamedColorEnum>{startColor, targetColor});
 
-        weather.timeOfDay.x = static_cast<float>(startColor);
-        weather.timeOfDay.y = static_cast<float>(targetColor);
+        wb.timeOfDay.x = static_cast<float>(startColor);
+        wb.timeOfDay.y = static_cast<float>(targetColor);
     };
 
     m_observer.sig2_timeOfDayChanged
@@ -153,42 +151,37 @@ GLWeather::GLWeather(OpenGL &gl,
             m_gameTimeOfDayIntensity = (timeOfDay == MumeTimeEnum::DAY) ? 0.0f : 1.0f;
             updateTargets();
 
-            auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
-            weather.timeOfDay.y = static_cast<float>(getCurrentColorIdx());
+            auto &wb_tod = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+            wb_tod.timeOfDay.y = static_cast<float>(getCurrentColorIdx());
 
             auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
             auto &ubo = m_gl.getUboManager();
             ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
             ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
-                                                              &Legacy::WeatherBlock::timeOfDay);
+                                                               &Legacy::WeatherBlock::timeOfDay);
 
             m_animationManager.requestUpdate();
         });
 
-    m_observer.sig2_moonVisibilityChanged.connect(m_lifetime,
-                                                  [this, startTimeOfDayTransitions](
-                                                      MumeMoonVisibilityEnum visibility) {
-                                                      if (visibility == m_moonVisibility) {
-                                                          return;
-                                                      }
-                                                      startTimeOfDayTransitions();
+    m_observer.sig2_moonVisibilityChanged
+        .connect(m_lifetime, [this, startTimeOfDayTransitions](MumeMoonVisibilityEnum visibility) {
+            if (visibility == m_moonVisibility) {
+                return;
+            }
+            startTimeOfDayTransitions();
 
-                                                      m_moonVisibility = visibility;
-                                                      auto &weather = m_gl.getUboManager().get<
-                                                          Legacy::SharedVboEnum::WeatherBlock>();
-                                                      weather.timeOfDay.y
-                                                          = static_cast<float>(getCurrentColorIdx());
+            m_moonVisibility = visibility;
+            auto &wb_moon = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+            wb_moon.timeOfDay.y = static_cast<float>(getCurrentColorIdx());
 
-                                                      auto &funcs = deref(
-                                                          m_gl.getSharedFunctions(Badge<GLWeather>{}));
-                                                      auto &ubo = m_gl.getUboManager();
-                                                      ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(
-                                                          funcs, &Legacy::WeatherBlock::config);
-                                                      ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(
-                                                          funcs, &Legacy::WeatherBlock::timeOfDay);
+            auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
+            auto &ubo = m_gl.getUboManager();
+            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
+            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
+                                                               &Legacy::WeatherBlock::timeOfDay);
 
-                                                      m_animationManager.requestUpdate();
-                                                  });
+            m_animationManager.requestUpdate();
+        });
 
     auto onSettingChanged = [this, startWeatherTransitions]() {
         startWeatherTransitions();
@@ -198,7 +191,7 @@ GLWeather::GLWeather(OpenGL &gl,
         auto &ubo = m_gl.getUboManager();
         ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
         ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
-                                                          &Legacy::WeatherBlock::intensities);
+                                                           &Legacy::WeatherBlock::intensities);
         ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::targets);
 
         m_animationManager.requestUpdate();
@@ -229,10 +222,12 @@ GLWeather::GLWeather(OpenGL &gl,
                              : FrameManager::AnimationStatusEnum::Stop;
     });
 
-    m_gl.getUboManager().registerRebuildFunction(
-        Legacy::SharedVboEnum::WeatherBlock, [this](Legacy::Functions &funcs) {
-            m_gl.getUboManager().sync<Legacy::SharedVboEnum::WeatherBlock>(funcs);
-        });
+    m_gl.getUboManager().registerRebuildFunction(Legacy::SharedVboEnum::WeatherBlock,
+                                                 [this](Legacy::Functions &funcs) {
+                                                     m_gl.getUboManager()
+                                                         .sync<Legacy::SharedVboEnum::WeatherBlock>(
+                                                             funcs);
+                                                 });
 }
 
 GLWeather::~GLWeather()
@@ -458,8 +453,9 @@ void GLWeather::render(const GLRenderState &rs)
                                   .withDepthFunction(std::nullopt);
 
     // TimeOfDay
-    const auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
-    if (m_currentTimeOfDay != MumeTimeEnum::DAY || weather.timeOfDay.x != static_cast<float>(NamedColorEnum::TRANSPARENT)
+    const auto &wb = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+    const auto currentStartColor = static_cast<NamedColorEnum>(static_cast<int>(wb.timeOfDay.x));
+    if (m_currentTimeOfDay != MumeTimeEnum::DAY || currentStartColor != NamedColorEnum::TRANSPARENT
         || m_currentTimeOfDayIntensity > 0.0f) {
         if (m_timeOfDay) {
             m_timeOfDay.render(atmosphereRs);

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -89,11 +89,21 @@ GLWeather::GLWeather(OpenGL &gl,
     auto startWeatherTransitions = [this]() {
         auto &wb = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
 
+        const bool startingFromNice = (m_currentRainIntensity <= 0.0f
+                                       && m_currentSnowIntensity <= 0.0f);
+
         startTransitions(wb.config.x,
                          TransitionPair<float>{wb.intensities.x, wb.targets.x},
                          TransitionPair<float>{wb.intensities.y, wb.targets.y},
                          TransitionPair<float>{wb.intensities.z, wb.targets.z},
                          TransitionPair<float>{wb.intensities.w, wb.targets.w});
+
+        if (startingFromNice) {
+            // If we are starting from clear skies, snap the start intensity for rain/snow
+            // immediately so the ratio (pType) is correct during fade-in.
+            wb.intensities.x = wb.targets.x > 0.0f ? 0.001f : 0.0f;
+            wb.intensities.y = wb.targets.y > 0.0f ? 0.001f : 0.0f;
+        }
     };
 
     m_observer.sig2_weatherChanged
@@ -101,15 +111,7 @@ GLWeather::GLWeather(OpenGL &gl,
             startWeatherTransitions();
             updateFromGame();
             updateTargets();
-
-            auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
-            auto &ubo = m_gl.getUboManager();
-            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
-            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
-                                                               &Legacy::WeatherBlock::intensities);
-            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
-                                                               &Legacy::WeatherBlock::targets);
-
+            syncWeatherAtmosphere();
             m_animationManager.requestUpdate();
         });
 
@@ -117,14 +119,7 @@ GLWeather::GLWeather(OpenGL &gl,
         startWeatherTransitions();
         updateFromGame();
         updateTargets();
-
-        auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
-        auto &ubo = m_gl.getUboManager();
-        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
-        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
-                                                           &Legacy::WeatherBlock::intensities);
-        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::targets);
-
+        syncWeatherAtmosphere();
         m_animationManager.requestUpdate();
     });
 
@@ -156,12 +151,7 @@ GLWeather::GLWeather(OpenGL &gl,
             auto &wb_tod = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
             wb_tod.timeOfDay.y = static_cast<float>(getCurrentColorIdx());
 
-            auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
-            auto &ubo = m_gl.getUboManager();
-            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
-            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
-                                                               &Legacy::WeatherBlock::timeOfDay);
-
+            syncWeatherTimeOfDay();
             m_animationManager.requestUpdate();
         });
 
@@ -176,39 +166,21 @@ GLWeather::GLWeather(OpenGL &gl,
             auto &wb_moon = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
             wb_moon.timeOfDay.y = static_cast<float>(getCurrentColorIdx());
 
-            auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
-            auto &ubo = m_gl.getUboManager();
-            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
-            ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
-                                                               &Legacy::WeatherBlock::timeOfDay);
-
+            syncWeatherTimeOfDay();
             m_animationManager.requestUpdate();
         });
 
     auto onSettingChanged = [this, startWeatherTransitions]() {
         startWeatherTransitions();
         updateTargets();
-
-        auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
-        auto &ubo = m_gl.getUboManager();
-        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
-        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs,
-                                                           &Legacy::WeatherBlock::intensities);
-        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::targets);
-
+        syncWeatherAtmosphere();
         m_animationManager.requestUpdate();
     };
 
     auto onTimeOfDaySettingChanged = [this, startTimeOfDayTransitions]() {
         startTimeOfDayTransitions();
-
         updateTargets();
-
-        auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
-        auto &ubo = m_gl.getUboManager();
-        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::config);
-        ubo.syncField<Legacy::SharedVboEnum::WeatherBlock>(funcs, &Legacy::WeatherBlock::timeOfDay);
-
+        syncWeatherTimeOfDay();
         m_animationManager.requestUpdate();
     };
 
@@ -338,13 +310,31 @@ bool GLWeather::isAnimating() const
 bool GLWeather::isTransitioning() const
 {
     const float animTime = m_animationManager.getElapsedTime();
-    const auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+    const auto &wb = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+    const float duration = wb.config.z;
 
-    const bool weatherTransitioning = (animTime - weather.config.x
-                                       < WeatherConstants::TRANSITION_DURATION);
-    const bool timeOfDayTransitioning = (animTime - weather.config.y
-                                         < WeatherConstants::TRANSITION_DURATION);
+    const bool weatherTransitioning = (animTime - wb.config.x < duration);
+    const bool timeOfDayTransitioning = (animTime - wb.config.y < duration);
     return weatherTransitioning || timeOfDayTransitioning;
+}
+
+void GLWeather::syncWeatherAtmosphere()
+{
+    auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
+    auto &ubo = m_gl.getUboManager();
+    ubo.syncFields<Legacy::SharedVboEnum::WeatherBlock>(funcs,
+                                                       &Legacy::WeatherBlock::config,
+                                                       &Legacy::WeatherBlock::intensities,
+                                                       &Legacy::WeatherBlock::targets);
+}
+
+void GLWeather::syncWeatherTimeOfDay()
+{
+    auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
+    auto &ubo = m_gl.getUboManager();
+    ubo.syncFields<Legacy::SharedVboEnum::WeatherBlock>(funcs,
+                                                       &Legacy::WeatherBlock::config,
+                                                       &Legacy::WeatherBlock::timeOfDay);
 }
 
 NamedColorEnum GLWeather::getCurrentColorIdx() const

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -64,25 +64,27 @@ GLWeather::GLWeather(OpenGL &gl,
     m_currentTimeOfDay = m_observer.getTimeOfDay();
     m_gameTimeOfDayIntensity = (m_currentTimeOfDay == MumeTimeEnum::DAY) ? 0.0f : 1.0f;
 
-    auto &weather = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
-    const NamedColorEnum targetColorIdx = getCurrentColorIdx();
+    {
+        auto &wbInit = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();
+        const NamedColorEnum targetColorIdx = getCurrentColorIdx();
 
-    weather.timeOfDay.x = static_cast<float>(targetColorIdx); // startIdx
-    weather.timeOfDay.y = static_cast<float>(targetColorIdx); // targetIdx
-    weather.timeOfDay.z = m_gameTimeOfDayIntensity;           // todStart
-    weather.timeOfDay.w = m_gameTimeOfDayIntensity;           // todTarget
+        wbInit.timeOfDay.x = static_cast<float>(targetColorIdx); // startIdx
+        wbInit.timeOfDay.y = static_cast<float>(targetColorIdx); // targetIdx
+        wbInit.timeOfDay.z = m_gameTimeOfDayIntensity;           // todStart
+        wbInit.timeOfDay.w = m_gameTimeOfDayIntensity;           // todTarget
 
-    weather.intensities = glm::vec4(m_gameRainIntensity,
-                                    m_gameSnowIntensity,
-                                    m_gameCloudsIntensity,
-                                    m_gameFogIntensity);
+        wbInit.intensities = glm::vec4(m_gameRainIntensity,
+                                       m_gameSnowIntensity,
+                                       m_gameCloudsIntensity,
+                                       m_gameFogIntensity);
 
-    updateTargets();
-    weather.intensities = weather.targets;
+        updateTargets();
+        wbInit.intensities = wbInit.targets;
 
-    weather.config.x = -2.0f; // weatherStartTime
-    weather.config.y = -2.0f; // todStartTime
-    weather.config.z = WeatherConstants::TRANSITION_DURATION;
+        wbInit.config.x = -2.0f; // weatherStartTime
+        wbInit.config.y = -2.0f; // todStartTime
+        wbInit.config.z = WeatherConstants::TRANSITION_DURATION;
+    }
 
     auto startWeatherTransitions = [this]() {
         auto &wb = m_gl.getUboManager().get<Legacy::SharedVboEnum::WeatherBlock>();

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -43,9 +43,6 @@ GLWeather::GLWeather(OpenGL &gl,
 {
     updateFromGame();
 
-    m_moonVisibility = m_observer.getMoonVisibility();
-    m_targetMoonIntensity = (m_moonVisibility == MumeMoonVisibilityEnum::BRIGHT) ? 1.0f : 0.0f;
-
     m_currentTimeOfDay = m_observer.getTimeOfDay();
     m_oldTimeOfDay = m_currentTimeOfDay;
     m_gameTimeOfDayIntensity = (m_currentTimeOfDay == MumeTimeEnum::DAY) ? 0.0f : 1.0f;
@@ -58,7 +55,6 @@ GLWeather::GLWeather(OpenGL &gl,
     m_cloudsIntensityStart = m_targetCloudsIntensity;
     m_fogIntensityStart = m_targetFogIntensity;
     m_precipitationTypeStart = m_targetPrecipitationType;
-    m_moonIntensityStart = m_targetMoonIntensity;
 
     auto lerpCurrentIntensities = [this]() {
         m_rainIntensityStart = applyTransition(m_weatherTransitionStartTime,
@@ -105,9 +101,6 @@ GLWeather::GLWeather(OpenGL &gl,
         m_timeOfDayIntensityStart = applyTransition(m_timeOfDayTransitionStartTime,
                                                     m_timeOfDayIntensityStart,
                                                     m_targetTimeOfDayIntensity);
-        m_moonIntensityStart = applyTransition(m_timeOfDayTransitionStartTime,
-                                               m_moonIntensityStart,
-                                               m_targetMoonIntensity);
 
         m_oldTimeOfDay = m_currentTimeOfDay;
         m_currentTimeOfDay = timeOfDay;
@@ -118,24 +111,6 @@ GLWeather::GLWeather(OpenGL &gl,
         m_animationManager.requestUpdate();
     });
 
-    m_observer.sig2_moonVisibilityChanged
-        .connect(m_lifetime, [this](MumeMoonVisibilityEnum visibility) {
-            if (visibility == m_moonVisibility) {
-                return;
-            }
-            m_moonIntensityStart = applyTransition(m_timeOfDayTransitionStartTime,
-                                                   m_moonIntensityStart,
-                                                   m_targetMoonIntensity);
-            m_timeOfDayIntensityStart = applyTransition(m_timeOfDayTransitionStartTime,
-                                                        m_timeOfDayIntensityStart,
-                                                        m_targetTimeOfDayIntensity);
-
-            m_moonVisibility = visibility;
-            m_targetMoonIntensity = (visibility == MumeMoonVisibilityEnum::BRIGHT) ? 1.0f : 0.0f;
-            m_timeOfDayTransitionStartTime = m_animationManager.getElapsedTime();
-            invalidateWeather();
-            m_animationManager.requestUpdate();
-        });
 
     auto onSettingChanged = [this, lerpCurrentIntensities]() {
         lerpCurrentIntensities();

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -106,14 +106,14 @@ GLWeather::GLWeather(OpenGL &gl,
         }
     };
 
-    m_observer.sig2_weatherChanged
-        .connect(m_lifetime, [this, startWeatherTransitions](PromptWeatherEnum) {
-            startWeatherTransitions();
-            updateFromGame();
-            updateTargets();
-            syncWeatherAtmosphere();
-            m_animationManager.requestUpdate();
-        });
+    m_observer.sig2_weatherChanged.connect(m_lifetime,
+                                           [this, startWeatherTransitions](PromptWeatherEnum) {
+                                               startWeatherTransitions();
+                                               updateFromGame();
+                                               updateTargets();
+                                               syncWeatherAtmosphere();
+                                               m_animationManager.requestUpdate();
+                                           });
 
     m_observer.sig2_fogChanged.connect(m_lifetime, [this, startWeatherTransitions](PromptFogEnum) {
         startWeatherTransitions();
@@ -323,9 +323,9 @@ void GLWeather::syncWeatherAtmosphere()
     auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
     auto &ubo = m_gl.getUboManager();
     ubo.syncFields<Legacy::SharedVboEnum::WeatherBlock>(funcs,
-                                                       &Legacy::WeatherBlock::config,
-                                                       &Legacy::WeatherBlock::intensities,
-                                                       &Legacy::WeatherBlock::targets);
+                                                        &Legacy::WeatherBlock::config,
+                                                        &Legacy::WeatherBlock::intensities,
+                                                        &Legacy::WeatherBlock::targets);
 }
 
 void GLWeather::syncWeatherTimeOfDay()
@@ -333,8 +333,8 @@ void GLWeather::syncWeatherTimeOfDay()
     auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
     auto &ubo = m_gl.getUboManager();
     ubo.syncFields<Legacy::SharedVboEnum::WeatherBlock>(funcs,
-                                                       &Legacy::WeatherBlock::config,
-                                                       &Legacy::WeatherBlock::timeOfDay);
+                                                        &Legacy::WeatherBlock::config,
+                                                        &Legacy::WeatherBlock::timeOfDay);
 }
 
 NamedColorEnum GLWeather::getCurrentColorIdx() const

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "Weather.h"
+
+#include "../configuration/configuration.h"
+#include "../display/FrameManager.h"
+#include "../display/Textures.h"
+#include "../global/Badge.h"
+#include "../map/coordinate.h"
+#include "../mapdata/mapdata.h"
+#include "OpenGL.h"
+#include "OpenGLTypes.h"
+#include "legacy/Legacy.h"
+
+#include <algorithm>
+#include <cstdlib>
+
+#include <glm/glm.hpp>
+
+namespace {
+constexpr float TRANSITION_DURATION = 2.0f;
+constexpr float ROOM_Z_SCALE = 7.f;
+
+template<typename T>
+T my_lerp(T a, T b, float t)
+{
+    return a + t * (b - a);
+}
+
+} // namespace
+
+GLWeather::GLWeather(OpenGL &gl,
+                     MapData &mapData,
+                     const MapCanvasTextures &textures,
+                     GameObserver &observer,
+                     FrameManager &animationManager)
+    : m_gl(gl)
+    , m_data(mapData)
+    , m_textures(textures)
+    , m_animationManager(animationManager)
+    , m_observer(observer)
+{
+    updateFromGame();
+
+    m_moonVisibility = m_observer.getMoonVisibility();
+    m_targetMoonIntensity = (m_moonVisibility == MumeMoonVisibilityEnum::BRIGHT) ? 1.0f : 0.0f;
+
+    m_currentTimeOfDay = m_observer.getTimeOfDay();
+    m_oldTimeOfDay = m_currentTimeOfDay;
+    m_gameTimeOfDayIntensity = (m_currentTimeOfDay == MumeTimeEnum::DAY) ? 0.0f : 1.0f;
+
+    updateTargets();
+
+    m_timeOfDayIntensityStart = m_targetTimeOfDayIntensity;
+    m_rainIntensityStart = m_targetRainIntensity;
+    m_snowIntensityStart = m_targetSnowIntensity;
+    m_cloudsIntensityStart = m_targetCloudsIntensity;
+    m_fogIntensityStart = m_targetFogIntensity;
+    m_precipitationTypeStart = m_targetPrecipitationType;
+    m_moonIntensityStart = m_targetMoonIntensity;
+
+    auto lerpCurrentIntensities = [this]() {
+        float t = (m_animationManager.getElapsedTime() - m_weatherTransitionStartTime)
+                  / TRANSITION_DURATION;
+        float factor = std::clamp(t, 0.0f, 1.0f);
+        m_rainIntensityStart = my_lerp(m_rainIntensityStart, m_targetRainIntensity, factor);
+        m_snowIntensityStart = my_lerp(m_snowIntensityStart, m_targetSnowIntensity, factor);
+        m_cloudsIntensityStart = my_lerp(m_cloudsIntensityStart, m_targetCloudsIntensity, factor);
+        m_fogIntensityStart = my_lerp(m_fogIntensityStart, m_targetFogIntensity, factor);
+        m_precipitationTypeStart = my_lerp(m_precipitationTypeStart,
+                                           m_targetPrecipitationType,
+                                           factor);
+    };
+
+    m_observer.sig2_weatherChanged
+        .connect(m_lifetime, [this, lerpCurrentIntensities](PromptWeatherEnum) {
+            lerpCurrentIntensities();
+            updateFromGame();
+            updateTargets();
+            m_weatherTransitionStartTime = m_animationManager.getElapsedTime();
+            invalidateWeather();
+            m_animationManager.requestUpdate();
+        });
+
+    m_observer.sig2_fogChanged.connect(m_lifetime, [this, lerpCurrentIntensities](PromptFogEnum) {
+        lerpCurrentIntensities();
+        updateFromGame();
+        updateTargets();
+        m_weatherTransitionStartTime = m_animationManager.getElapsedTime();
+        invalidateWeather();
+        m_animationManager.requestUpdate();
+    });
+
+    m_observer.sig2_timeOfDayChanged.connect(m_lifetime, [this](MumeTimeEnum timeOfDay) {
+        if (timeOfDay == m_currentTimeOfDay) {
+            return;
+        }
+
+        float t = (m_animationManager.getElapsedTime() - m_timeOfDayTransitionStartTime)
+                  / TRANSITION_DURATION;
+        float factor = std::clamp(t, 0.0f, 1.0f);
+        m_timeOfDayIntensityStart = my_lerp(m_timeOfDayIntensityStart,
+                                            m_targetTimeOfDayIntensity,
+                                            factor);
+        m_moonIntensityStart = my_lerp(m_moonIntensityStart, m_targetMoonIntensity, factor);
+
+        m_oldTimeOfDay = m_currentTimeOfDay;
+        m_currentTimeOfDay = timeOfDay;
+        m_gameTimeOfDayIntensity = (timeOfDay == MumeTimeEnum::DAY) ? 0.0f : 1.0f;
+        updateTargets();
+        m_timeOfDayTransitionStartTime = m_animationManager.getElapsedTime();
+        invalidateWeather();
+        m_animationManager.requestUpdate();
+    });
+
+    m_observer.sig2_moonVisibilityChanged
+        .connect(m_lifetime, [this](MumeMoonVisibilityEnum visibility) {
+            if (visibility == m_moonVisibility) {
+                return;
+            }
+            float t = (m_animationManager.getElapsedTime() - m_timeOfDayTransitionStartTime)
+                      / TRANSITION_DURATION;
+            float factor = std::clamp(t, 0.0f, 1.0f);
+            m_moonIntensityStart = my_lerp(m_moonIntensityStart, m_targetMoonIntensity, factor);
+            m_timeOfDayIntensityStart = my_lerp(m_timeOfDayIntensityStart,
+                                                m_targetTimeOfDayIntensity,
+                                                factor);
+
+            m_moonVisibility = visibility;
+            m_targetMoonIntensity = (visibility == MumeMoonVisibilityEnum::BRIGHT) ? 1.0f : 0.0f;
+            m_timeOfDayTransitionStartTime = m_animationManager.getElapsedTime();
+            invalidateWeather();
+            m_animationManager.requestUpdate();
+        });
+
+    auto onSettingChanged = [this, lerpCurrentIntensities]() {
+        lerpCurrentIntensities();
+        updateTargets();
+        m_weatherTransitionStartTime = m_animationManager.getElapsedTime();
+        invalidateWeather();
+        m_animationManager.requestUpdate();
+    };
+
+    auto onTimeOfDaySettingChanged = [this]() {
+        float t = (m_animationManager.getElapsedTime() - m_timeOfDayTransitionStartTime)
+                  / TRANSITION_DURATION;
+        float factor = std::clamp(t, 0.0f, 1.0f);
+        m_timeOfDayIntensityStart = my_lerp(m_timeOfDayIntensityStart,
+                                            m_targetTimeOfDayIntensity,
+                                            factor);
+
+        updateTargets();
+        m_timeOfDayTransitionStartTime = m_animationManager.getElapsedTime();
+        invalidateWeather();
+        m_animationManager.requestUpdate();
+    };
+
+    setConfig().canvas.weatherPrecipitationIntensity.registerChangeCallback(m_lifetime,
+                                                                            onSettingChanged);
+    setConfig().canvas.weatherAtmosphereIntensity.registerChangeCallback(m_lifetime,
+                                                                         onSettingChanged);
+    setConfig().canvas.weatherTimeOfDayIntensity.registerChangeCallback(m_lifetime,
+                                                                        onTimeOfDaySettingChanged);
+
+    m_animationManager.registerCallback(m_signalLifetime, [this]() {
+        return isAnimating() ? FrameManager::AnimationStatusEnum::Continue
+                             : FrameManager::AnimationStatusEnum::Stop;
+    });
+
+    m_gl.getUboManager().registerRebuildFunction(
+        Legacy::SharedVboEnum::CameraBlock, [this](Legacy::Functions &glFuncs) {
+            const auto playerPosCoord = m_data.tryGetPosition().value_or(Coordinate{0, 0, 0});
+            auto cameraData = getCameraData(m_lastViewProj, playerPosCoord);
+            m_gl.getUboManager().update(glFuncs, Legacy::SharedVboEnum::CameraBlock, cameraData);
+        });
+
+    m_gl.getUboManager().registerRebuildFunction(
+        Legacy::SharedVboEnum::WeatherBlock, [this](Legacy::Functions &glFuncs) {
+            GLRenderState::Uniforms::Weather::Params params;
+            populateWeatherParams(params);
+            m_gl.getUboManager().update(glFuncs, Legacy::SharedVboEnum::WeatherBlock, params);
+        });
+}
+
+GLWeather::~GLWeather() = default;
+
+void GLWeather::updateFromGame()
+{
+    auto w = m_observer.getWeather();
+    auto f = m_observer.getFog();
+
+    m_gameRainIntensity = 0.0f;
+    m_gameSnowIntensity = 0.0f;
+    m_gameCloudsIntensity = 0.0f;
+    m_gameFogIntensity = 0.0f;
+
+    switch (w) {
+    case PromptWeatherEnum::NICE:
+        break;
+    case PromptWeatherEnum::CLOUDS:
+        m_gameCloudsIntensity = 0.5f;
+        break;
+    case PromptWeatherEnum::RAIN:
+        m_gameCloudsIntensity = 0.8f;
+        m_gameRainIntensity = 0.5f;
+        m_targetPrecipitationType = 0.0f;
+        break;
+    case PromptWeatherEnum::HEAVY_RAIN:
+        m_gameCloudsIntensity = 1.0f;
+        m_gameRainIntensity = 1.0f;
+        m_targetPrecipitationType = 0.0f;
+        break;
+    case PromptWeatherEnum::SNOW:
+        m_gameCloudsIntensity = 0.8f;
+        m_gameSnowIntensity = 0.8f;
+        m_targetPrecipitationType = 1.0f;
+        break;
+    }
+
+    switch (f) {
+    case PromptFogEnum::NO_FOG:
+        break;
+    case PromptFogEnum::LIGHT_FOG:
+        m_gameFogIntensity = 0.5f;
+        break;
+    case PromptFogEnum::HEAVY_FOG:
+        m_gameFogIntensity = 1.0f;
+        break;
+    }
+}
+
+void GLWeather::updateTargets()
+{
+    const auto &canvasSettings = getConfig().canvas;
+    m_targetRainIntensity = m_gameRainIntensity
+                            * (static_cast<float>(canvasSettings.weatherPrecipitationIntensity.get())
+                               / 50.0f);
+    m_targetSnowIntensity = m_gameSnowIntensity
+                            * (static_cast<float>(canvasSettings.weatherPrecipitationIntensity.get())
+                               / 50.0f);
+    m_targetCloudsIntensity = m_gameCloudsIntensity
+                              * (static_cast<float>(canvasSettings.weatherAtmosphereIntensity.get())
+                                 / 50.0f);
+    m_targetFogIntensity = m_gameFogIntensity
+                           * (static_cast<float>(canvasSettings.weatherAtmosphereIntensity.get())
+                              / 50.0f);
+    m_targetTimeOfDayIntensity = m_gameTimeOfDayIntensity
+                                 * (static_cast<float>(
+                                        canvasSettings.weatherTimeOfDayIntensity.get())
+                                    / 50.0f);
+}
+
+void GLWeather::update()
+{
+    updateTargets();
+
+    const float animTime = m_animationManager.getElapsedTime();
+
+    float wt = std::clamp((animTime - m_weatherTransitionStartTime) / TRANSITION_DURATION,
+                          0.0f,
+                          1.0f);
+    m_currentRainIntensity = my_lerp(m_rainIntensityStart, m_targetRainIntensity, wt);
+    m_currentSnowIntensity = my_lerp(m_snowIntensityStart, m_targetSnowIntensity, wt);
+    m_currentCloudsIntensity = my_lerp(m_cloudsIntensityStart, m_targetCloudsIntensity, wt);
+    m_currentFogIntensity = my_lerp(m_fogIntensityStart, m_targetFogIntensity, wt);
+
+    float tt = std::clamp((animTime - m_timeOfDayTransitionStartTime) / TRANSITION_DURATION,
+                          0.0f,
+                          1.0f);
+    m_currentTimeOfDayIntensity = my_lerp(m_timeOfDayIntensityStart, m_targetTimeOfDayIntensity, tt);
+}
+
+bool GLWeather::isAnimating() const
+{
+    const bool activePrecipitation = m_currentRainIntensity > 0.0f || m_currentSnowIntensity > 0.0f;
+    const bool activeAtmosphere = m_currentCloudsIntensity > 0.0f || m_currentFogIntensity > 0.0f;
+    return isTransitioning() || activePrecipitation || activeAtmosphere;
+}
+
+bool GLWeather::isTransitioning() const
+{
+    const float animTime = m_animationManager.getElapsedTime();
+    const bool weatherTransitioning = (animTime - m_weatherTransitionStartTime
+                                       < TRANSITION_DURATION);
+    const bool timeOfDayTransitioning = (animTime - m_timeOfDayTransitionStartTime
+                                         < TRANSITION_DURATION);
+    return weatherTransitioning || timeOfDayTransitioning;
+}
+
+GLRenderState::Uniforms::Weather::Camera GLWeather::getCameraData(
+    const glm::mat4 &viewProj, const Coordinate &playerPosCoord) const
+{
+    GLRenderState::Uniforms::Weather::Camera camera;
+    camera.viewProj = viewProj;
+    camera.playerPos = glm::vec4(static_cast<float>(playerPosCoord.x),
+                                 static_cast<float>(playerPosCoord.y),
+                                 static_cast<float>(playerPosCoord.z),
+                                 ROOM_Z_SCALE);
+    return camera;
+}
+
+void GLWeather::populateWeatherParams(GLRenderState::Uniforms::Weather::Params &params) const
+{
+    params.intensities = glm::vec4(std::max(m_rainIntensityStart, m_snowIntensityStart),
+                                   m_cloudsIntensityStart,
+                                   m_fogIntensityStart,
+                                   m_precipitationTypeStart);
+
+    params.targets = glm::vec4(std::max(m_targetRainIntensity, m_targetSnowIntensity),
+                               m_targetCloudsIntensity,
+                               m_targetFogIntensity,
+                               m_targetPrecipitationType);
+
+    auto toNamedColorIdx = [](MumeTimeEnum timeOfDay) -> float {
+        switch (timeOfDay) {
+        case MumeTimeEnum::DAY:
+            return static_cast<float>(NamedColorEnum::TRANSPARENT);
+        case MumeTimeEnum::NIGHT:
+            return static_cast<float>(NamedColorEnum::WEATHER_NIGHT);
+        case MumeTimeEnum::DAWN:
+            return static_cast<float>(NamedColorEnum::WEATHER_DAWN);
+        case MumeTimeEnum::DUSK:
+            return static_cast<float>(NamedColorEnum::WEATHER_DUSK);
+        case MumeTimeEnum::UNKNOWN:
+            return static_cast<float>(NamedColorEnum::TRANSPARENT);
+        }
+        return static_cast<float>(NamedColorEnum::TRANSPARENT);
+    };
+
+    params.timeOfDayIndices.x = toNamedColorIdx(m_oldTimeOfDay);
+    params.timeOfDayIndices.y = toNamedColorIdx(m_currentTimeOfDay);
+    params.timeOfDayIndices.z = m_timeOfDayIntensityStart;
+    params.timeOfDayIndices.w = m_targetTimeOfDayIntensity;
+
+    params.config.x = m_weatherTransitionStartTime;
+    params.config.y = m_timeOfDayTransitionStartTime;
+    params.config.z = TRANSITION_DURATION;
+}
+
+void GLWeather::invalidateCamera()
+{
+    m_gl.getUboManager().invalidate(Legacy::SharedVboEnum::CameraBlock);
+}
+
+void GLWeather::invalidateWeather()
+{
+    m_gl.getUboManager().invalidate(Legacy::SharedVboEnum::WeatherBlock);
+}
+
+void GLWeather::initMeshes()
+{
+    if (!m_simulation) {
+        auto funcs = m_gl.getSharedFunctions(Badge<GLWeather>{});
+        auto &shaderPrograms = funcs->getShaderPrograms();
+
+        m_simulation = std::make_unique<Legacy::ParticleSimulationMesh>(
+            funcs, shaderPrograms.getParticleSimulationShader());
+        m_particles
+            = std::make_unique<Legacy::ParticleRenderMesh>(funcs,
+                                                           shaderPrograms.getParticleRenderShader(),
+                                                           *m_simulation);
+        m_atmosphere = UniqueMesh(
+            std::make_unique<Legacy::AtmosphereMesh>(funcs, shaderPrograms.getAtmosphereShader()));
+        m_timeOfDay = UniqueMesh(
+            std::make_unique<Legacy::TimeOfDayMesh>(funcs, shaderPrograms.getTimeOfDayShader()));
+    }
+}
+
+void GLWeather::prepare(const glm::mat4 &viewProj, const Coordinate &playerPos)
+{
+    initMeshes();
+
+    if (viewProj != m_lastViewProj || playerPos != m_lastPlayerPos) {
+        m_lastViewProj = viewProj;
+        m_lastPlayerPos = playerPos;
+        invalidateCamera();
+    }
+
+    auto &funcs = deref(m_gl.getSharedFunctions(Badge<GLWeather>{}));
+    m_gl.getUboManager().bind(funcs, Legacy::SharedVboEnum::CameraBlock);
+    m_gl.getUboManager().bind(funcs, Legacy::SharedVboEnum::WeatherBlock);
+}
+
+void GLWeather::render(const GLRenderState &rs)
+{
+    // 1. Render Particles (Simulation + Rendering)
+    const float rainMax = m_currentRainIntensity;
+    const float snowMax = m_currentSnowIntensity;
+    if (rainMax > 0.0f || snowMax > 0.0f) {
+        const auto particleRs = rs.withBlend(BlendModeEnum::MAX_ALPHA);
+        if (m_simulation) {
+            m_simulation->render(particleRs);
+        }
+        if (m_particles) {
+            m_particles->render(particleRs);
+        }
+    }
+
+    // 2. Render Atmosphere (TimeOfDay + Atmosphere)
+    const auto atmosphereRs = rs.withBlend(BlendModeEnum::TRANSPARENCY)
+                                  .withDepthFunction(std::nullopt);
+
+    // TimeOfDay
+    if (m_currentTimeOfDay != MumeTimeEnum::DAY || m_oldTimeOfDay != MumeTimeEnum::DAY
+        || m_currentTimeOfDayIntensity > 0.0f) {
+        if (m_timeOfDay) {
+            m_timeOfDay.render(atmosphereRs);
+        }
+    }
+
+    // Atmosphere
+    const float cloudMax = m_currentCloudsIntensity;
+    const float fogMax = m_currentFogIntensity;
+    if ((cloudMax > 0.0f || fogMax > 0.0f) && m_atmosphere) {
+        m_atmosphere.render(atmosphereRs.withTexture0(m_textures.noise->getId()));
+    }
+}

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -227,6 +227,7 @@ void GLWeather::updateFromGame()
 void GLWeather::updateTargets()
 {
     const auto &canvasSettings = getConfig().canvas;
+    // Map 0-100 slider to 0.0-2.0 multiplier, with 50 as neutral.
     m_targetRainIntensity = m_gameRainIntensity
                             * (static_cast<float>(canvasSettings.weatherPrecipitationIntensity.get())
                                / 50.0f);

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -175,6 +175,8 @@ void GLWeather::updateFromGame()
     m_gameSnowIntensity = 0.0f;
     m_gameCloudsIntensity = 0.0f;
     m_gameFogIntensity = 0.0f;
+    // Default to rain (0), will be overridden by SNOW
+    m_targetPrecipitationType = 0.0f;
 
     switch (w) {
     case PromptWeatherEnum::NICE:

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -178,9 +178,9 @@ GLWeather::GLWeather(OpenGL &gl,
 
     m_gl.getUboManager().registerRebuildFunction(
         Legacy::SharedVboEnum::WeatherBlock, [this](Legacy::Functions &funcs) {
-            GLRenderState::Uniforms::Weather::Params params;
+            Legacy::WeatherBlock params;
             populateWeatherParams(params);
-            m_gl.getUboManager().update(funcs, Legacy::SharedVboEnum::WeatherBlock, params);
+            m_gl.getUboManager().update<Legacy::SharedVboEnum::WeatherBlock>(funcs, params);
         });
 }
 
@@ -314,7 +314,7 @@ NamedColorEnum GLWeather::getCurrentColorIdx() const
     return NamedColorEnum::TRANSPARENT;
 }
 
-void GLWeather::populateWeatherParams(GLRenderState::Uniforms::Weather::Params &params) const
+void GLWeather::populateWeatherParams(Legacy::WeatherBlock &params) const
 {
     params.intensities = glm::vec4(std::max(m_rainIntensityStart, m_snowIntensityStart),
                                    m_cloudsIntensityStart,
@@ -416,12 +416,12 @@ void GLWeather::render(const GLRenderState &rs)
     const float snowMax = m_currentSnowIntensity;
     if (rainMax > 0.0f || snowMax > 0.0f) {
         auto particleRs = rs.withBlend(BlendModeEnum::MAX_ALPHA);
-        particleRs.uniforms.weather.currentPrecipitationIntensity = std::max(rainMax, snowMax);
 
         if (m_simulation) {
             m_simulation->render(particleRs);
         }
         if (m_particles) {
+            m_particles->setIntensity(std::max(rainMax, snowMax));
             m_particles->render(particleRs);
         }
     }

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -19,7 +19,6 @@
 #include <glm/glm.hpp>
 
 namespace {
-constexpr float TRANSITION_DURATION = 2.0f;
 constexpr float ROOM_Z_SCALE = 7.f;
 
 template<typename T>
@@ -43,11 +42,13 @@ GLWeather::GLWeather(OpenGL &gl,
 {
     updateFromGame();
 
+    m_moonVisibility = m_observer.getMoonVisibility();
     m_currentTimeOfDay = m_observer.getTimeOfDay();
-    m_oldTimeOfDay = m_currentTimeOfDay;
     m_gameTimeOfDayIntensity = (m_currentTimeOfDay == MumeTimeEnum::DAY) ? 0.0f : 1.0f;
 
     updateTargets();
+
+    m_startColorIdx = m_targetColorIdx = getCurrentColorIdx();
 
     m_timeOfDayIntensityStart = m_targetTimeOfDayIntensity;
     m_rainIntensityStart = m_targetRainIntensity;
@@ -56,77 +57,82 @@ GLWeather::GLWeather(OpenGL &gl,
     m_fogIntensityStart = m_targetFogIntensity;
     m_precipitationTypeStart = m_targetPrecipitationType;
 
-    auto lerpCurrentIntensities = [this]() {
-        m_rainIntensityStart = applyTransition(m_weatherTransitionStartTime,
-                                               m_rainIntensityStart,
-                                               m_targetRainIntensity);
-        m_snowIntensityStart = applyTransition(m_weatherTransitionStartTime,
-                                               m_snowIntensityStart,
-                                               m_targetSnowIntensity);
-        m_cloudsIntensityStart = applyTransition(m_weatherTransitionStartTime,
-                                                 m_cloudsIntensityStart,
-                                                 m_targetCloudsIntensity);
-        m_fogIntensityStart = applyTransition(m_weatherTransitionStartTime,
-                                              m_fogIntensityStart,
-                                              m_targetFogIntensity);
-        m_precipitationTypeStart = applyTransition(m_weatherTransitionStartTime,
-                                                   m_precipitationTypeStart,
-                                                   m_targetPrecipitationType);
+    auto startWeatherTransitions = [this]() {
+        startTransitions(m_weatherTransitionStartTime,
+                         TransitionPair<float>{m_rainIntensityStart, m_targetRainIntensity},
+                         TransitionPair<float>{m_snowIntensityStart, m_targetSnowIntensity},
+                         TransitionPair<float>{m_cloudsIntensityStart, m_targetCloudsIntensity},
+                         TransitionPair<float>{m_fogIntensityStart, m_targetFogIntensity},
+                         TransitionPair<float>{m_precipitationTypeStart, m_targetPrecipitationType});
     };
 
-    m_observer.sig2_weatherChanged
-        .connect(m_lifetime, [this, lerpCurrentIntensities](PromptWeatherEnum) {
-            lerpCurrentIntensities();
-            updateFromGame();
+    m_observer.sig2_weatherChanged.connect(m_lifetime,
+                                           [this, startWeatherTransitions](PromptWeatherEnum) {
+                                               startWeatherTransitions();
+                                               updateFromGame();
+                                               updateTargets();
+                                               invalidateWeather();
+                                               m_animationManager.requestUpdate();
+                                           });
+
+    m_observer.sig2_fogChanged.connect(m_lifetime, [this, startWeatherTransitions](PromptFogEnum) {
+        startWeatherTransitions();
+        updateFromGame();
+        updateTargets();
+        invalidateWeather();
+        m_animationManager.requestUpdate();
+    });
+
+    auto startTimeOfDayTransitions = [this]() {
+        startTransitions(m_timeOfDayTransitionStartTime,
+                         TransitionPair<float>{m_timeOfDayIntensityStart,
+                                               m_targetTimeOfDayIntensity},
+                         TransitionPair<NamedColorEnum>{m_startColorIdx, m_targetColorIdx});
+    };
+
+    m_observer.sig2_timeOfDayChanged
+        .connect(m_lifetime, [this, startTimeOfDayTransitions](MumeTimeEnum timeOfDay) {
+            if (timeOfDay == m_currentTimeOfDay) {
+                return;
+            }
+
+            startTimeOfDayTransitions();
+
+            m_currentTimeOfDay = timeOfDay;
+            m_gameTimeOfDayIntensity = (timeOfDay == MumeTimeEnum::DAY) ? 0.0f : 1.0f;
             updateTargets();
-            m_weatherTransitionStartTime = m_animationManager.getElapsedTime();
+            m_targetColorIdx = getCurrentColorIdx();
+
             invalidateWeather();
             m_animationManager.requestUpdate();
         });
 
-    m_observer.sig2_fogChanged.connect(m_lifetime, [this, lerpCurrentIntensities](PromptFogEnum) {
-        lerpCurrentIntensities();
-        updateFromGame();
+    m_observer.sig2_moonVisibilityChanged.connect(m_lifetime,
+                                                  [this, startTimeOfDayTransitions](
+                                                      MumeMoonVisibilityEnum visibility) {
+                                                      if (visibility == m_moonVisibility) {
+                                                          return;
+                                                      }
+                                                      startTimeOfDayTransitions();
+
+                                                      m_moonVisibility = visibility;
+                                                      m_targetColorIdx = getCurrentColorIdx();
+
+                                                      invalidateWeather();
+                                                      m_animationManager.requestUpdate();
+                                                  });
+
+    auto onSettingChanged = [this, startWeatherTransitions]() {
+        startWeatherTransitions();
         updateTargets();
-        m_weatherTransitionStartTime = m_animationManager.getElapsedTime();
-        invalidateWeather();
-        m_animationManager.requestUpdate();
-    });
-
-    m_observer.sig2_timeOfDayChanged.connect(m_lifetime, [this](MumeTimeEnum timeOfDay) {
-        if (timeOfDay == m_currentTimeOfDay) {
-            return;
-        }
-
-        m_timeOfDayIntensityStart = applyTransition(m_timeOfDayTransitionStartTime,
-                                                    m_timeOfDayIntensityStart,
-                                                    m_targetTimeOfDayIntensity);
-
-        m_oldTimeOfDay = m_currentTimeOfDay;
-        m_currentTimeOfDay = timeOfDay;
-        m_gameTimeOfDayIntensity = (timeOfDay == MumeTimeEnum::DAY) ? 0.0f : 1.0f;
-        updateTargets();
-        m_timeOfDayTransitionStartTime = m_animationManager.getElapsedTime();
-        invalidateWeather();
-        m_animationManager.requestUpdate();
-    });
-
-
-    auto onSettingChanged = [this, lerpCurrentIntensities]() {
-        lerpCurrentIntensities();
-        updateTargets();
-        m_weatherTransitionStartTime = m_animationManager.getElapsedTime();
         invalidateWeather();
         m_animationManager.requestUpdate();
     };
 
-    auto onTimeOfDaySettingChanged = [this]() {
-        m_timeOfDayIntensityStart = applyTransition(m_timeOfDayTransitionStartTime,
-                                                    m_timeOfDayIntensityStart,
-                                                    m_targetTimeOfDayIntensity);
+    auto onTimeOfDaySettingChanged = [this, startTimeOfDayTransitions]() {
+        startTimeOfDayTransitions();
 
         updateTargets();
-        m_timeOfDayTransitionStartTime = m_animationManager.getElapsedTime();
         invalidateWeather();
         m_animationManager.requestUpdate();
     };
@@ -257,9 +263,9 @@ bool GLWeather::isTransitioning() const
 {
     const float animTime = m_animationManager.getElapsedTime();
     const bool weatherTransitioning = (animTime - m_weatherTransitionStartTime
-                                       < TRANSITION_DURATION);
+                                       < WeatherConstants::TRANSITION_DURATION);
     const bool timeOfDayTransitioning = (animTime - m_timeOfDayTransitionStartTime
-                                         < TRANSITION_DURATION);
+                                         < WeatherConstants::TRANSITION_DURATION);
     return weatherTransitioning || timeOfDayTransitioning;
 }
 
@@ -275,6 +281,25 @@ GLRenderState::Uniforms::Weather::Camera GLWeather::getCameraData(
     return camera;
 }
 
+NamedColorEnum GLWeather::getCurrentColorIdx() const
+{
+    switch (m_currentTimeOfDay) {
+    case MumeTimeEnum::DAY:
+        return NamedColorEnum::TRANSPARENT;
+    case MumeTimeEnum::NIGHT:
+        return (m_moonVisibility == MumeMoonVisibilityEnum::BRIGHT)
+                   ? NamedColorEnum::WEATHER_NIGHT_MOON
+                   : NamedColorEnum::WEATHER_NIGHT;
+    case MumeTimeEnum::DAWN:
+        return NamedColorEnum::WEATHER_DAWN;
+    case MumeTimeEnum::DUSK:
+        return NamedColorEnum::WEATHER_DUSK;
+    case MumeTimeEnum::UNKNOWN:
+        return NamedColorEnum::TRANSPARENT;
+    }
+    return NamedColorEnum::TRANSPARENT;
+}
+
 void GLWeather::populateWeatherParams(GLRenderState::Uniforms::Weather::Params &params) const
 {
     params.intensities = glm::vec4(std::max(m_rainIntensityStart, m_snowIntensityStart),
@@ -287,30 +312,14 @@ void GLWeather::populateWeatherParams(GLRenderState::Uniforms::Weather::Params &
                                m_targetFogIntensity,
                                m_targetPrecipitationType);
 
-    auto toNamedColorIdx = [](MumeTimeEnum timeOfDay) -> float {
-        switch (timeOfDay) {
-        case MumeTimeEnum::DAY:
-            return static_cast<float>(NamedColorEnum::TRANSPARENT);
-        case MumeTimeEnum::NIGHT:
-            return static_cast<float>(NamedColorEnum::WEATHER_NIGHT);
-        case MumeTimeEnum::DAWN:
-            return static_cast<float>(NamedColorEnum::WEATHER_DAWN);
-        case MumeTimeEnum::DUSK:
-            return static_cast<float>(NamedColorEnum::WEATHER_DUSK);
-        case MumeTimeEnum::UNKNOWN:
-            return static_cast<float>(NamedColorEnum::TRANSPARENT);
-        }
-        return static_cast<float>(NamedColorEnum::TRANSPARENT);
-    };
-
-    params.timeOfDayIndices.x = toNamedColorIdx(m_oldTimeOfDay);
-    params.timeOfDayIndices.y = toNamedColorIdx(m_currentTimeOfDay);
+    params.timeOfDayIndices.x = static_cast<float>(m_startColorIdx);
+    params.timeOfDayIndices.y = static_cast<float>(m_targetColorIdx);
     params.timeOfDayIndices.z = m_timeOfDayIntensityStart;
     params.timeOfDayIndices.w = m_targetTimeOfDayIntensity;
 
     params.config.x = m_weatherTransitionStartTime;
     params.config.y = m_timeOfDayTransitionStartTime;
-    params.config.z = TRANSITION_DURATION;
+    params.config.z = WeatherConstants::TRANSITION_DURATION;
 }
 
 void GLWeather::invalidateWeather()
@@ -322,9 +331,40 @@ float GLWeather::applyTransition(const float startTime,
                                  const float startVal,
                                  const float targetVal) const
 {
-    const float t = (m_animationManager.getElapsedTime() - startTime) / TRANSITION_DURATION;
+    const float t = (m_animationManager.getElapsedTime() - startTime)
+                    / WeatherConstants::TRANSITION_DURATION;
     const float factor = std::clamp(t, 0.0f, 1.0f);
     return lerp(startVal, targetVal, factor);
+}
+
+template<typename T>
+T GLWeather::applyTransition(float startTime, T startVal, T targetVal) const
+{
+    if (startVal == targetVal) {
+        return startVal;
+    }
+    const float t = (m_animationManager.getElapsedTime() - startTime)
+                    / WeatherConstants::TRANSITION_DURATION;
+    return (t >= 1.0f) ? targetVal : startVal;
+}
+
+template void GLWeather::startTransitions(float &startTime,
+                                          TransitionPair<float> p1,
+                                          TransitionPair<float> p2,
+                                          TransitionPair<float> p3,
+                                          TransitionPair<float> p4,
+                                          TransitionPair<float> p5);
+
+template void GLWeather::startTransitions(float &startTime,
+                                          TransitionPair<float> p1,
+                                          TransitionPair<NamedColorEnum> p2);
+
+template<typename... Pairs>
+void GLWeather::startTransitions(float &startTime, Pairs... pairs)
+{
+    float oldStartTime = startTime;
+    startTime = m_animationManager.getElapsedTime();
+    (..., (pairs.start = applyTransition(oldStartTime, pairs.start, pairs.target)));
 }
 
 void GLWeather::initMeshes()
@@ -375,7 +415,7 @@ void GLWeather::render(const GLRenderState &rs)
                                   .withDepthFunction(std::nullopt);
 
     // TimeOfDay
-    if (m_currentTimeOfDay != MumeTimeEnum::DAY || m_oldTimeOfDay != MumeTimeEnum::DAY
+    if (m_currentTimeOfDay != MumeTimeEnum::DAY || m_startColorIdx != NamedColorEnum::TRANSPARENT
         || m_currentTimeOfDayIntensity > 0.0f) {
         if (m_timeOfDay) {
             m_timeOfDay.render(atmosphereRs);

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -61,16 +61,15 @@ GLWeather::GLWeather(OpenGL &gl,
     m_moonIntensityStart = m_targetMoonIntensity;
 
     auto lerpCurrentIntensities = [this]() {
-        float t = (m_animationManager.getElapsedTime() - m_weatherTransitionStartTime)
-                  / TRANSITION_DURATION;
-        float factor = std::clamp(t, 0.0f, 1.0f);
-        m_rainIntensityStart = my_lerp(m_rainIntensityStart, m_targetRainIntensity, factor);
-        m_snowIntensityStart = my_lerp(m_snowIntensityStart, m_targetSnowIntensity, factor);
-        m_cloudsIntensityStart = my_lerp(m_cloudsIntensityStart, m_targetCloudsIntensity, factor);
-        m_fogIntensityStart = my_lerp(m_fogIntensityStart, m_targetFogIntensity, factor);
-        m_precipitationTypeStart = my_lerp(m_precipitationTypeStart,
-                                           m_targetPrecipitationType,
-                                           factor);
+        applyTransition(m_weatherTransitionStartTime, m_rainIntensityStart, m_targetRainIntensity);
+        applyTransition(m_weatherTransitionStartTime, m_snowIntensityStart, m_targetSnowIntensity);
+        applyTransition(m_weatherTransitionStartTime,
+                        m_cloudsIntensityStart,
+                        m_targetCloudsIntensity);
+        applyTransition(m_weatherTransitionStartTime, m_fogIntensityStart, m_targetFogIntensity);
+        applyTransition(m_weatherTransitionStartTime,
+                        m_precipitationTypeStart,
+                        m_targetPrecipitationType);
     };
 
     m_observer.sig2_weatherChanged
@@ -97,13 +96,12 @@ GLWeather::GLWeather(OpenGL &gl,
             return;
         }
 
-        float t = (m_animationManager.getElapsedTime() - m_timeOfDayTransitionStartTime)
-                  / TRANSITION_DURATION;
-        float factor = std::clamp(t, 0.0f, 1.0f);
-        m_timeOfDayIntensityStart = my_lerp(m_timeOfDayIntensityStart,
-                                            m_targetTimeOfDayIntensity,
-                                            factor);
-        m_moonIntensityStart = my_lerp(m_moonIntensityStart, m_targetMoonIntensity, factor);
+        applyTransition(m_timeOfDayTransitionStartTime,
+                        m_timeOfDayIntensityStart,
+                        m_targetTimeOfDayIntensity);
+        applyTransition(m_timeOfDayTransitionStartTime,
+                        m_moonIntensityStart,
+                        m_targetMoonIntensity);
 
         m_oldTimeOfDay = m_currentTimeOfDay;
         m_currentTimeOfDay = timeOfDay;
@@ -119,13 +117,12 @@ GLWeather::GLWeather(OpenGL &gl,
             if (visibility == m_moonVisibility) {
                 return;
             }
-            float t = (m_animationManager.getElapsedTime() - m_timeOfDayTransitionStartTime)
-                      / TRANSITION_DURATION;
-            float factor = std::clamp(t, 0.0f, 1.0f);
-            m_moonIntensityStart = my_lerp(m_moonIntensityStart, m_targetMoonIntensity, factor);
-            m_timeOfDayIntensityStart = my_lerp(m_timeOfDayIntensityStart,
-                                                m_targetTimeOfDayIntensity,
-                                                factor);
+            applyTransition(m_timeOfDayTransitionStartTime,
+                            m_moonIntensityStart,
+                            m_targetMoonIntensity);
+            applyTransition(m_timeOfDayTransitionStartTime,
+                            m_timeOfDayIntensityStart,
+                            m_targetTimeOfDayIntensity);
 
             m_moonVisibility = visibility;
             m_targetMoonIntensity = (visibility == MumeMoonVisibilityEnum::BRIGHT) ? 1.0f : 0.0f;
@@ -143,12 +140,9 @@ GLWeather::GLWeather(OpenGL &gl,
     };
 
     auto onTimeOfDaySettingChanged = [this]() {
-        float t = (m_animationManager.getElapsedTime() - m_timeOfDayTransitionStartTime)
-                  / TRANSITION_DURATION;
-        float factor = std::clamp(t, 0.0f, 1.0f);
-        m_timeOfDayIntensityStart = my_lerp(m_timeOfDayIntensityStart,
-                                            m_targetTimeOfDayIntensity,
-                                            factor);
+        applyTransition(m_timeOfDayTransitionStartTime,
+                        m_timeOfDayIntensityStart,
+                        m_targetTimeOfDayIntensity);
 
         updateTargets();
         m_timeOfDayTransitionStartTime = m_animationManager.getElapsedTime();
@@ -346,6 +340,13 @@ void GLWeather::invalidateCamera()
 void GLWeather::invalidateWeather()
 {
     m_gl.getUboManager().invalidate(Legacy::SharedVboEnum::WeatherBlock);
+}
+
+void GLWeather::applyTransition(float startTime, float &startVal, float targetVal)
+{
+    float t = (m_animationManager.getElapsedTime() - startTime) / TRANSITION_DURATION;
+    float factor = std::clamp(t, 0.0f, 1.0f);
+    startVal = my_lerp(startVal, targetVal, factor);
 }
 
 void GLWeather::initMeshes()

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -112,4 +112,6 @@ private:
     NODISCARD GLRenderState::Uniforms::Weather::Camera getCameraData(
         const glm::mat4 &viewProj, const Coordinate &playerPos) const;
     void populateWeatherParams(GLRenderState::Uniforms::Weather::Params &params) const;
+
+    void applyTransition(float startTime, float &startVal, float targetVal);
 };

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -95,8 +95,6 @@ private:
     float m_weatherTransitionStartTime = -2.0f;
     float m_timeOfDayTransitionStartTime = -2.0f;
 
-    // Rendering State
-
     // Meshes
     std::unique_ptr<Legacy::ParticleSimulationMesh> m_simulation;
     std::unique_ptr<Legacy::ParticleRenderMesh> m_particles;
@@ -127,8 +125,6 @@ private:
     void initMeshes();
     void invalidateWeather();
 
-    NODISCARD GLRenderState::Uniforms::Weather::Camera getCameraData(
-        const glm::mat4 &viewProj, const Coordinate &playerPos) const;
     void populateWeatherParams(GLRenderState::Uniforms::Weather::Params &params) const;
 
     NODISCARD float applyTransition(float startTime, float startVal, float targetVal) const;

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -93,8 +93,6 @@ private:
     Signal2Lifetime m_signalLifetime;
 
     // Rendering State
-    glm::mat4 m_lastViewProj{0.0f};
-    Coordinate m_lastPlayerPos;
 
     // Meshes
     std::unique_ptr<Legacy::ParticleSimulationMesh> m_simulation;
@@ -114,7 +112,7 @@ public:
 
 public:
     void update();
-    void prepare(const glm::mat4 &viewProj, const Coordinate &playerPos);
+    void prepare();
     void render(const GLRenderState &rs);
 
     NODISCARD bool isAnimating() const;
@@ -124,12 +122,11 @@ private:
     void updateTargets();
     void updateFromGame();
     void initMeshes();
-    void invalidateCamera();
     void invalidateWeather();
 
     NODISCARD GLRenderState::Uniforms::Weather::Camera getCameraData(
         const glm::mat4 &viewProj, const Coordinate &playerPos) const;
     void populateWeatherParams(GLRenderState::Uniforms::Weather::Params &params) const;
 
-    void applyTransition(float startTime, float &startVal, float targetVal);
+    NODISCARD float applyTransition(float startTime, float startVal, float targetVal) const;
 };

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -1,0 +1,115 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "../clock/mumemoment.h"
+#include "../global/ChangeMonitor.h"
+#include "../global/ConfigEnums.h"
+#include "../global/RuleOf5.h"
+#include "../map/PromptFlags.h"
+#include "../map/coordinate.h"
+#include "../observer/gameobserver.h"
+#include "OpenGL.h"
+#include "OpenGLTypes.h"
+#include "legacy/Legacy.h"
+#include "legacy/WeatherMeshes.h"
+
+#include <chrono>
+#include <memory>
+
+class FrameManager;
+class MapData;
+struct MapCanvasTextures;
+
+/**
+ * @brief Manages the logic and rendering of the weather system.
+ * Follows the design and structure of GLFont.
+ */
+class NODISCARD GLWeather final
+{
+private:
+    OpenGL &m_gl;
+    MapData &m_data;
+    const MapCanvasTextures &m_textures;
+    FrameManager &m_animationManager;
+    GameObserver &m_observer;
+    ChangeMonitor::Lifetime m_lifetime;
+
+    // Weather State
+    float m_rainIntensityStart = 0.0f;
+    float m_snowIntensityStart = 0.0f;
+    float m_cloudsIntensityStart = 0.0f;
+    float m_fogIntensityStart = 0.0f;
+    float m_timeOfDayIntensityStart = 0.0f;
+    float m_moonIntensityStart = 0.0f;
+
+    float m_currentRainIntensity = 0.0f;
+    float m_currentSnowIntensity = 0.0f;
+    float m_currentCloudsIntensity = 0.0f;
+    float m_currentFogIntensity = 0.0f;
+    float m_currentTimeOfDayIntensity = 0.0f;
+
+    float m_targetRainIntensity = 0.0f;
+    float m_targetSnowIntensity = 0.0f;
+    float m_targetCloudsIntensity = 0.0f;
+    float m_targetFogIntensity = 0.0f;
+    float m_targetTimeOfDayIntensity = 0.0f;
+    float m_targetMoonIntensity = 0.0f;
+
+    float m_precipitationTypeStart = 0.0f;
+    float m_targetPrecipitationType = 0.0f;
+
+    float m_gameRainIntensity = 0.0f;
+    float m_gameSnowIntensity = 0.0f;
+    float m_gameCloudsIntensity = 0.0f;
+    float m_gameFogIntensity = 0.0f;
+    float m_gameTimeOfDayIntensity = 0.0f;
+
+    MumeTimeEnum m_oldTimeOfDay = MumeTimeEnum::DAY;
+    MumeTimeEnum m_currentTimeOfDay = MumeTimeEnum::DAY;
+    MumeMoonVisibilityEnum m_moonVisibility = MumeMoonVisibilityEnum::UNKNOWN;
+
+    float m_weatherTransitionStartTime = -2.0f;
+    float m_timeOfDayTransitionStartTime = -2.0f;
+
+    Signal2Lifetime m_signalLifetime;
+
+    // Rendering State
+    glm::mat4 m_lastViewProj{0.0f};
+    Coordinate m_lastPlayerPos;
+
+    // Meshes
+    std::unique_ptr<Legacy::ParticleSimulationMesh> m_simulation;
+    std::unique_ptr<Legacy::ParticleRenderMesh> m_particles;
+    UniqueMesh m_atmosphere;
+    UniqueMesh m_timeOfDay;
+
+public:
+    explicit GLWeather(OpenGL &gl,
+                       MapData &mapData,
+                       const MapCanvasTextures &textures,
+                       GameObserver &observer,
+                       FrameManager &frameManager);
+    ~GLWeather();
+
+    DELETE_CTORS_AND_ASSIGN_OPS(GLWeather);
+
+public:
+    void update();
+    void prepare(const glm::mat4 &viewProj, const Coordinate &playerPos);
+    void render(const GLRenderState &rs);
+
+    NODISCARD bool isAnimating() const;
+    NODISCARD bool isTransitioning() const;
+
+private:
+    void updateTargets();
+    void updateFromGame();
+    void initMeshes();
+    void invalidateCamera();
+    void invalidateWeather();
+
+    NODISCARD GLRenderState::Uniforms::Weather::Camera getCameraData(
+        const glm::mat4 &viewProj, const Coordinate &playerPos) const;
+    void populateWeatherParams(GLRenderState::Uniforms::Weather::Params &params) const;
+};

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -125,7 +125,7 @@ private:
     void initMeshes();
     void invalidateWeather();
 
-    void populateWeatherParams(GLRenderState::Uniforms::Weather::Params &params) const;
+    void populateWeatherParams(Legacy::WeatherBlock &params) const;
 
     NODISCARD float applyTransition(float startTime, float startVal, float targetVal) const;
 

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -85,6 +85,7 @@ private:
     float m_gameCloudsIntensity = 0.0f;
     float m_gameFogIntensity = 0.0f;
     float m_gameTimeOfDayIntensity = 0.0f;
+    float m_gamePrecipitationType = 0.0f;
 
     NamedColorEnum m_startColorIdx = NamedColorEnum::TRANSPARENT;
     NamedColorEnum m_targetColorIdx = NamedColorEnum::TRANSPARENT;

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -10,6 +10,8 @@
 #include "../map/coordinate.h"
 #include "../observer/gameobserver.h"
 #include "OpenGL.h"
+
+class FrameManager;
 #include "OpenGLTypes.h"
 #include "legacy/Legacy.h"
 #include "legacy/WeatherMeshes.h"
@@ -17,7 +19,6 @@
 #include <chrono>
 #include <memory>
 
-class FrameManager;
 class MapData;
 struct MapCanvasTextures;
 
@@ -37,6 +38,7 @@ constexpr float WEATHER_RADIUS = 14.0f;
 constexpr float WEATHER_EXTENT = 28.0f;
 constexpr float WEATHER_MASK_RADIUS_OUTER = 12.0f;
 constexpr float WEATHER_MASK_RADIUS_INNER = 8.0f;
+constexpr float TRANSITION_DURATION = 2.0f;
 } // namespace WeatherConstants
 
 /**
@@ -46,6 +48,7 @@ constexpr float WEATHER_MASK_RADIUS_INNER = 8.0f;
 class NODISCARD GLWeather final
 {
 private:
+    struct FrameManagerProxy;
     OpenGL &m_gl;
     MapData &m_data;
     const MapCanvasTextures &m_textures;
@@ -81,8 +84,10 @@ private:
     float m_gameFogIntensity = 0.0f;
     float m_gameTimeOfDayIntensity = 0.0f;
 
-    MumeTimeEnum m_oldTimeOfDay = MumeTimeEnum::DAY;
+    NamedColorEnum m_startColorIdx = NamedColorEnum::TRANSPARENT;
+    NamedColorEnum m_targetColorIdx = NamedColorEnum::TRANSPARENT;
     MumeTimeEnum m_currentTimeOfDay = MumeTimeEnum::DAY;
+    MumeMoonVisibilityEnum m_moonVisibility = MumeMoonVisibilityEnum::UNKNOWN;
 
     float m_weatherTransitionStartTime = -2.0f;
     float m_timeOfDayTransitionStartTime = -2.0f;
@@ -126,4 +131,19 @@ private:
     void populateWeatherParams(GLRenderState::Uniforms::Weather::Params &params) const;
 
     NODISCARD float applyTransition(float startTime, float startVal, float targetVal) const;
+
+    template<typename T>
+    NODISCARD T applyTransition(float startTime, T startVal, T targetVal) const;
+
+    template<typename T>
+    struct TransitionPair
+    {
+        T &start;
+        T target;
+    };
+
+    template<typename... Pairs>
+    void startTransitions(float &startTime, Pairs... pairs);
+
+    NODISCARD NamedColorEnum getCurrentColorIdx() const;
 };

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -103,6 +103,8 @@ private:
     void updateTargets();
     void updateFromGame();
     void initMeshes();
+    void syncWeatherAtmosphere();
+    void syncWeatherTimeOfDay();
 
     NODISCARD float applyTransition(float startTime, float startVal, float targetVal) const;
 

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -21,6 +21,24 @@ class FrameManager;
 class MapData;
 struct MapCanvasTextures;
 
+namespace WeatherConstants {
+/**
+ * @brief Spatial parameters for weather particles and atmosphere.
+ *
+ * WEATHER_RADIUS (14.0) defines the world-space distance from the player
+ * where particles wrap and atmosphere extents are calculated.
+ *
+ * WEATHER_EXTENT (28.0) is the total diameter of the toroidal simulation area.
+ *
+ * Atmosphere and particle masks typically fade out at a 12.0 radius to avoid
+ * sharp edges at the simulation boundaries.
+ */
+constexpr float WEATHER_RADIUS = 14.0f;
+constexpr float WEATHER_EXTENT = 28.0f;
+constexpr float WEATHER_MASK_RADIUS_START = 12.0f;
+constexpr float WEATHER_MASK_RADIUS_END = 8.0f;
+} // namespace WeatherConstants
+
 /**
  * @brief Manages the logic and rendering of the weather system.
  * Follows the design and structure of GLFont.

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -59,26 +59,11 @@ private:
     ChangeMonitor::Lifetime m_lifetime;
 
     // Weather State
-    float m_rainIntensityStart = 0.0f;
-    float m_snowIntensityStart = 0.0f;
-    float m_cloudsIntensityStart = 0.0f;
-    float m_fogIntensityStart = 0.0f;
-    float m_timeOfDayIntensityStart = 0.0f;
-
     float m_currentRainIntensity = 0.0f;
     float m_currentSnowIntensity = 0.0f;
     float m_currentCloudsIntensity = 0.0f;
     float m_currentFogIntensity = 0.0f;
     float m_currentTimeOfDayIntensity = 0.0f;
-
-    float m_targetRainIntensity = 0.0f;
-    float m_targetSnowIntensity = 0.0f;
-    float m_targetCloudsIntensity = 0.0f;
-    float m_targetFogIntensity = 0.0f;
-    float m_targetTimeOfDayIntensity = 0.0f;
-
-    float m_precipitationTypeStart = 0.0f;
-    float m_targetPrecipitationType = 0.0f;
 
     float m_gameRainIntensity = 0.0f;
     float m_gameSnowIntensity = 0.0f;
@@ -87,13 +72,8 @@ private:
     float m_gameTimeOfDayIntensity = 0.0f;
     float m_gamePrecipitationType = 0.0f;
 
-    NamedColorEnum m_startColorIdx = NamedColorEnum::TRANSPARENT;
-    NamedColorEnum m_targetColorIdx = NamedColorEnum::TRANSPARENT;
     MumeTimeEnum m_currentTimeOfDay = MumeTimeEnum::DAY;
     MumeMoonVisibilityEnum m_moonVisibility = MumeMoonVisibilityEnum::UNKNOWN;
-
-    float m_weatherTransitionStartTime = -2.0f;
-    float m_timeOfDayTransitionStartTime = -2.0f;
 
     // Meshes
     std::unique_ptr<Legacy::ParticleSimulationMesh> m_simulation;
@@ -123,9 +103,6 @@ private:
     void updateTargets();
     void updateFromGame();
     void initMeshes();
-    void invalidateWeather();
-
-    void populateWeatherParams(Legacy::WeatherBlock &params) const;
 
     NODISCARD float applyTransition(float startTime, float startVal, float targetVal) const;
 

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -17,6 +17,8 @@ class FrameManager;
 #include "legacy/WeatherMeshes.h"
 
 #include <chrono>
+
+#undef TRANSPARENT // Bad dog, Microsoft; bad dog!!!
 #include <memory>
 
 class MapData;

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -95,8 +95,6 @@ private:
     float m_weatherTransitionStartTime = -2.0f;
     float m_timeOfDayTransitionStartTime = -2.0f;
 
-    Signal2Lifetime m_signalLifetime;
-
     // Rendering State
 
     // Meshes

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -35,8 +35,8 @@ namespace WeatherConstants {
  */
 constexpr float WEATHER_RADIUS = 14.0f;
 constexpr float WEATHER_EXTENT = 28.0f;
-constexpr float WEATHER_MASK_RADIUS_START = 12.0f;
-constexpr float WEATHER_MASK_RADIUS_END = 8.0f;
+constexpr float WEATHER_MASK_RADIUS_OUTER = 12.0f;
+constexpr float WEATHER_MASK_RADIUS_INNER = 8.0f;
 } // namespace WeatherConstants
 
 /**
@@ -59,7 +59,6 @@ private:
     float m_cloudsIntensityStart = 0.0f;
     float m_fogIntensityStart = 0.0f;
     float m_timeOfDayIntensityStart = 0.0f;
-    float m_moonIntensityStart = 0.0f;
 
     float m_currentRainIntensity = 0.0f;
     float m_currentSnowIntensity = 0.0f;
@@ -72,7 +71,6 @@ private:
     float m_targetCloudsIntensity = 0.0f;
     float m_targetFogIntensity = 0.0f;
     float m_targetTimeOfDayIntensity = 0.0f;
-    float m_targetMoonIntensity = 0.0f;
 
     float m_precipitationTypeStart = 0.0f;
     float m_targetPrecipitationType = 0.0f;
@@ -85,7 +83,6 @@ private:
 
     MumeTimeEnum m_oldTimeOfDay = MumeTimeEnum::DAY;
     MumeTimeEnum m_currentTimeOfDay = MumeTimeEnum::DAY;
-    MumeMoonVisibilityEnum m_moonVisibility = MumeMoonVisibilityEnum::UNKNOWN;
 
     float m_weatherTransitionStartTime = -2.0f;
     float m_timeOfDayTransitionStartTime = -2.0f;

--- a/src/opengl/legacy/AbstractShaderProgram.cpp
+++ b/src/opengl/legacy/AbstractShaderProgram.cpp
@@ -5,6 +5,8 @@
 
 #include "../../global/ConfigConsts.h"
 
+#include <cassert>
+
 namespace Legacy {
 
 AbstractShaderProgram::AbstractShaderProgram(std::string dirName,

--- a/src/opengl/legacy/AbstractShaderProgram.h
+++ b/src/opengl/legacy/AbstractShaderProgram.h
@@ -5,6 +5,9 @@
 #include "Legacy.h"
 #include "VBO.h"
 
+#include <string>
+#include <unordered_map>
+
 namespace Legacy {
 
 static constexpr GLuint INVALID_ATTRIB_LOCATION = ~0u;

--- a/src/opengl/legacy/Binders.cpp
+++ b/src/opengl/legacy/Binders.cpp
@@ -25,6 +25,11 @@ BlendBinder::BlendBinder(Functions &functions, const BlendModeEnum blend)
         m_functions.glEnable(GL_BLEND);
         m_functions.glBlendFuncSeparate(GL_ZERO, GL_SRC_COLOR, GL_ZERO, GL_ONE);
         break;
+    case BlendModeEnum::MAX_ALPHA:
+        m_functions.glEnable(GL_BLEND);
+        m_functions.glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
+        m_functions.glBlendEquationSeparate(GL_FUNC_ADD, GL_MAX);
+        break;
     }
 }
 
@@ -36,6 +41,10 @@ BlendBinder::~BlendBinder()
         break;
     case BlendModeEnum::MODULATE:
         m_functions.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        break;
+    case BlendModeEnum::MAX_ALPHA:
+        m_functions.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        m_functions.glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
         break;
     }
     m_functions.glDisable(GL_BLEND);

--- a/src/opengl/legacy/Binders.h
+++ b/src/opengl/legacy/Binders.h
@@ -4,6 +4,9 @@
 
 #include "../../global/utils.h"
 #include "Legacy.h"
+#include "TFO.h"
+#include "VAO.h"
+#include "VBO.h"
 
 #include <optional>
 

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -53,16 +53,6 @@ const char *Functions::getUniformBlockName(const SharedVboEnum block)
     return nullptr;
 }
 
-void Functions::glUniformBlockBinding(const GLuint program, const SharedVboEnum block)
-{
-    virt_glUniformBlockBinding(program, block);
-}
-
-void Functions::glUniformBlockBinding(const Program &program, const SharedVboEnum block)
-{
-    glUniformBlockBinding(program.get(), block);
-}
-
 void Functions::virt_glUniformBlockBinding(const GLuint program, const SharedVboEnum block)
 {
     const char *const block_name = getUniformBlockName(block);

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -14,6 +14,8 @@
 #include "ShaderUtils.h"
 #include "Shaders.h"
 #include "SimpleMesh.h"
+#include "TFO.h"
+#include "VAO.h"
 #include "VBO.h"
 
 #include <cassert>
@@ -49,6 +51,16 @@ const char *Functions::getUniformBlockName(const SharedVboEnum block)
         break;
     }
     return nullptr;
+}
+
+void Functions::glUniformBlockBinding(const GLuint program, const SharedVboEnum block)
+{
+    virt_glUniformBlockBinding(program, block);
+}
+
+void Functions::glUniformBlockBinding(const Program &program, const SharedVboEnum block)
+{
+    glUniformBlockBinding(program.get(), block);
 }
 
 void Functions::virt_glUniformBlockBinding(const GLuint program, const SharedVboEnum block)

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -357,15 +357,16 @@ protected:
     NODISCARD virtual const char *virt_getShaderVersion() const = 0;
     virtual void virt_glUniformBlockBinding(GLuint program, SharedVboEnum block);
 
-protected:
+public:
     NODISCARD static const char *getUniformBlockName(SharedVboEnum block);
 
-public:
     /// platform-specific (ES vs GL)
     NODISCARD bool canRenderQuads() { return virt_canRenderQuads(); }
 
     /// platform-specific (ES vs GL)
     NODISCARD std::optional<GLenum> toGLenum(DrawModeEnum mode) { return virt_toGLenum(mode); }
+
+protected:
 
 private:
     template<typename T>

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -182,6 +182,7 @@ public:
     using Base::glBlendFunc;
     using Base::glBlendFuncSeparate;
     using Base::glBufferData;
+    using Base::glBufferSubData;
     using Base::glClear;
     using Base::glClearColor;
     using Base::glCompileShader;

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -346,7 +346,6 @@ public:
     NODISCARD std::optional<GLenum> toGLenum(DrawModeEnum mode) { return virt_toGLenum(mode); }
 
 protected:
-
 private:
     template<typename T>
     static void enforceTriviallyCopyable()

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -29,7 +29,11 @@ class UboManager;
 class StaticVbos;
 class SharedVbos;
 class SharedVaos;
+class SharedTfos;
+class UboManager;
+class VBO;
 class VAO;
+class Program;
 struct AbstractShaderProgram;
 struct ShaderPrograms;
 struct PointSizeBinder;
@@ -39,7 +43,11 @@ struct PointSizeBinder;
  * Note: SharedVboEnum values are implicitly used as UBO binding indices.
  * They must be 0-based and contiguous.
  */
-#define XFOREACH_SHARED_VBO(X) X(NamedColorsBlock, "NamedColorsBlock")
+#define XFOREACH_SHARED_VBO(X) \
+    X(NamedColorsBlock, "NamedColorsBlock") \
+    X(CameraBlock, "CameraBlock") \
+    X(TimeBlock, "TimeBlock") \
+    X(WeatherBlock, "WeatherBlock")
 
 #define X_COUNT_VBO(element, name) +1
 static constexpr size_t NUM_SHARED_VBOS = 0 XFOREACH_SHARED_VBO(X_COUNT_VBO);
@@ -189,22 +197,10 @@ public:
     using Base::glAttachShader;
     using Base::glBindBuffer;
     using Base::glBindBufferBase;
-
-    /**
-     * @brief Binds a buffer to a uniform block binding point.
-     * @param target Must be GL_UNIFORM_BUFFER.
-     * @param block The uniform block to bind to.
-     * @param buffer The buffer ID.
-     *
-     * Note: This uses the enum value as the fixed binding point.
-     */
-    void glBindBufferBase(const GLenum target, const SharedVboEnum block, const GLuint buffer)
-    {
-        assert(target == GL_UNIFORM_BUFFER);
-        Base::glBindBufferBase(target, getUboBindingIndex(block), buffer);
-    }
+    using Base::glBindBufferRange;
     using Base::glBindTexture;
     using Base::glBindVertexArray;
+    using Base::glBlendEquationSeparate;
     using Base::glBlendFunc;
     using Base::glBlendFuncSeparate;
     using Base::glBufferData;
@@ -217,6 +213,7 @@ public:
     using Base::glDeleteBuffers;
     using Base::glDeleteProgram;
     using Base::glDeleteShader;
+    using Base::glDeleteTransformFeedbacks;
     using Base::glDeleteVertexArrays;
     using Base::glDepthFunc;
     using Base::glDetachShader;
@@ -229,6 +226,7 @@ public:
     using Base::glEnableVertexAttribArray;
     using Base::glGenBuffers;
     using Base::glGenerateMipmap;
+    using Base::glGenTransformFeedbacks;
     using Base::glGenVertexArrays;
     using Base::glGetAttribLocation;
     using Base::glGetIntegerv;
@@ -249,6 +247,12 @@ public:
     using Base::glLinkProgram;
     using Base::glPixelStorei;
     using Base::glShaderSource;
+
+    using Base::glBeginTransformFeedback;
+    using Base::glBindTransformFeedback;
+    using Base::glEndTransformFeedback;
+    using Base::glTransformFeedbackVaryings;
+
     using Base::glTexSubImage3D;
     using Base::glUniform1fv;
     using Base::glUniform1iv;
@@ -263,10 +267,8 @@ public:
      *
      * Note: This uses the enum value as the fixed binding point.
      */
-    void glUniformBlockBinding(const GLuint program, const SharedVboEnum block)
-    {
-        virt_glUniformBlockBinding(program, block);
-    }
+    void glUniformBlockBinding(const GLuint program, const SharedVboEnum block);
+    void glUniformBlockBinding(const Program &program, const SharedVboEnum block);
 
     /**
      * @brief Automatically assigns fixed binding points to all known uniform blocks.

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -7,6 +7,7 @@
 #include "../../global/utils.h"
 #include "../OpenGLConfig.h"
 #include "../OpenGLTypes.h"
+#include "../UboBlocks.h"
 #include "FBO.h"
 
 #include <cmath>
@@ -36,28 +37,6 @@ class Program;
 struct AbstractShaderProgram;
 struct ShaderPrograms;
 struct PointSizeBinder;
-
-// X(EnumName, GL_String_Name)
-/**
- * Note: SharedVboEnum values are implicitly used as UBO binding indices.
- * They must be 0-based and contiguous.
- */
-#define XFOREACH_SHARED_VBO(X) \
-    X(NamedColorsBlock, "NamedColorsBlock") \
-    X(CameraBlock, "CameraBlock") \
-    X(TimeBlock, "TimeBlock") \
-    X(WeatherBlock, "WeatherBlock")
-
-#define X_COUNT_VBO(element, name) +1
-static constexpr size_t NUM_SHARED_VBOS = 0 XFOREACH_SHARED_VBO(X_COUNT_VBO);
-#undef X_COUNT_VBO
-
-enum class SharedVboEnum : uint8_t {
-#define X_ENUM(element, name) element,
-    XFOREACH_SHARED_VBO(X_ENUM)
-#undef X_ENUM
-        NUM_BLOCKS
-};
 
 static_assert(NUM_SHARED_VBOS > 0, "At least one shared VBO must be defined");
 static_assert(static_cast<size_t>(SharedVboEnum::NUM_BLOCKS) == NUM_SHARED_VBOS,

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -25,7 +25,6 @@ class OpenGL;
 
 namespace Legacy {
 
-class UboManager;
 class StaticVbos;
 class SharedVbos;
 class SharedVaos;

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -346,6 +346,7 @@ public:
     NODISCARD std::optional<GLenum> toGLenum(DrawModeEnum mode) { return virt_toGLenum(mode); }
 
 protected:
+
 private:
     template<typename T>
     static void enforceTriviallyCopyable()

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -38,8 +38,8 @@ struct AbstractShaderProgram;
 struct ShaderPrograms;
 struct PointSizeBinder;
 
-static_assert(NUM_SHARED_VBOS > 0, "At least one shared VBO must be defined");
-static_assert(static_cast<size_t>(SharedVboEnum::NUM_BLOCKS) == NUM_SHARED_VBOS,
+static_assert(Legacy::NUM_SHARED_VBOS > 0, "At least one shared VBO must be defined");
+static_assert(static_cast<size_t>(Legacy::SharedVboEnum::NUM_BLOCKS) == Legacy::NUM_SHARED_VBOS,
               "SharedVboEnum must be 0-based and contiguous");
 
 /**

--- a/src/opengl/legacy/ShaderUtils.cpp
+++ b/src/opengl/legacy/ShaderUtils.cpp
@@ -266,4 +266,40 @@ Program loadShaders(Functions &gl, const Source &vert, const Source &frag)
     return result_prog;
 }
 
+Program loadTransformFeedbackShaders(Functions &gl,
+                                     const Source &vert,
+                                     const Source &frag,
+                                     const std::vector<const char *> &varyings)
+{
+    GLuint vshader = compileShader(gl, GL_VERTEX_SHADER, vert);
+    GLuint fshader = compileShader(gl, GL_FRAGMENT_SHADER, frag);
+
+    Program result_prog;
+    result_prog.emplace(gl.shared_from_this());
+    const GLuint prog = result_prog.get();
+
+    gl.glAttachShader(prog, vshader);
+    if (fshader != 0) {
+        gl.glAttachShader(prog, fshader);
+    }
+
+    gl.glTransformFeedbackVaryings(prog,
+                                   static_cast<GLsizei>(varyings.size()),
+                                   varyings.data(),
+                                   GL_INTERLEAVED_ATTRIBS);
+
+    gl.glLinkProgram(prog);
+    checkProgramInfo(gl, prog);
+    gl.applyDefaultUniformBlockBindings(prog);
+
+    gl.glDetachShader(prog, vshader);
+    gl.glDeleteShader(vshader);
+    if (fshader != 0) {
+        gl.glDetachShader(prog, fshader);
+        gl.glDeleteShader(fshader);
+    }
+
+    return result_prog;
+}
+
 } // namespace ShaderUtils

--- a/src/opengl/legacy/ShaderUtils.cpp
+++ b/src/opengl/legacy/ShaderUtils.cpp
@@ -8,6 +8,7 @@
 #include "../../global/NamedColors.h"
 #include "../../global/PrintUtils.h"
 #include "../../global/TextUtils.h"
+#include "../Weather.h"
 
 #include <array>
 #include <cassert>
@@ -214,8 +215,24 @@ NODISCARD static GLuint compileShader(Functions &gl, const GLenum type, const So
     // that's the reason the `ptrs` array below is not `const`.
     std::string defineNamedColors = "#define MAX_NAMED_COLORS " + std::to_string(MAX_NAMED_COLORS)
                                     + "\n";
-    std::array<const char *, 4> ptrs = {gl.getShaderVersion(),
+    std::string defineWeatherRadius = "#define WEATHER_RADIUS "
+                                      + std::to_string(WeatherConstants::WEATHER_RADIUS) + "\n";
+    std::string defineWeatherExtent = "#define WEATHER_EXTENT "
+                                      + std::to_string(WeatherConstants::WEATHER_EXTENT) + "\n";
+    std::string defineWeatherMaskStart = "#define WEATHER_MASK_RADIUS_START "
+                                         + std::to_string(
+                                             WeatherConstants::WEATHER_MASK_RADIUS_START)
+                                         + "\n";
+    std::string defineWeatherMaskEnd = "#define WEATHER_MASK_RADIUS_END "
+                                       + std::to_string(WeatherConstants::WEATHER_MASK_RADIUS_END)
+                                       + "\n";
+
+    std::array<const char *, 8> ptrs = {gl.getShaderVersion(),
                                         defineNamedColors.c_str(),
+                                        defineWeatherRadius.c_str(),
+                                        defineWeatherExtent.c_str(),
+                                        defineWeatherMaskStart.c_str(),
+                                        defineWeatherMaskEnd.c_str(),
                                         "#line 1\n",
                                         source.source.c_str()};
     gl.glShaderSource(shaderId, static_cast<GLsizei>(ptrs.size()), ptrs.data(), nullptr);

--- a/src/opengl/legacy/ShaderUtils.cpp
+++ b/src/opengl/legacy/ShaderUtils.cpp
@@ -219,20 +219,21 @@ NODISCARD static GLuint compileShader(Functions &gl, const GLenum type, const So
                                       + std::to_string(WeatherConstants::WEATHER_RADIUS) + "\n";
     std::string defineWeatherExtent = "#define WEATHER_EXTENT "
                                       + std::to_string(WeatherConstants::WEATHER_EXTENT) + "\n";
-    std::string defineWeatherMaskStart = "#define WEATHER_MASK_RADIUS_START "
+    std::string defineWeatherMaskOuter = "#define WEATHER_MASK_RADIUS_OUTER "
                                          + std::to_string(
-                                             WeatherConstants::WEATHER_MASK_RADIUS_START)
+                                             WeatherConstants::WEATHER_MASK_RADIUS_OUTER)
                                          + "\n";
-    std::string defineWeatherMaskEnd = "#define WEATHER_MASK_RADIUS_END "
-                                       + std::to_string(WeatherConstants::WEATHER_MASK_RADIUS_END)
-                                       + "\n";
+    std::string defineWeatherMaskInner = "#define WEATHER_MASK_RADIUS_INNER "
+                                         + std::to_string(
+                                             WeatherConstants::WEATHER_MASK_RADIUS_INNER)
+                                         + "\n";
 
     std::array<const char *, 8> ptrs = {gl.getShaderVersion(),
                                         defineNamedColors.c_str(),
                                         defineWeatherRadius.c_str(),
                                         defineWeatherExtent.c_str(),
-                                        defineWeatherMaskStart.c_str(),
-                                        defineWeatherMaskEnd.c_str(),
+                                        defineWeatherMaskOuter.c_str(),
+                                        defineWeatherMaskInner.c_str(),
                                         "#line 1\n",
                                         source.source.c_str()};
     gl.glShaderSource(shaderId, static_cast<GLsizei>(ptrs.size()), ptrs.data(), nullptr);

--- a/src/opengl/legacy/ShaderUtils.h
+++ b/src/opengl/legacy/ShaderUtils.h
@@ -29,4 +29,9 @@ struct NODISCARD Source final
 
 NODISCARD Program loadShaders(Functions &gl, const Source &vert, const Source &frag);
 
+NODISCARD Program loadTransformFeedbackShaders(Functions &gl,
+                                               const Source &vert,
+                                               const Source &frag,
+                                               const std::vector<const char *> &varyings);
+
 } // namespace ShaderUtils

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -3,6 +3,7 @@
 
 #include "Shaders.h"
 
+#include "../../global/TextUtils.h"
 #include "ShaderUtils.h"
 
 #include <memory>
@@ -16,7 +17,7 @@ NODISCARD static std::string readWholeResourceFile(const std::string &fullPath)
         throw std::runtime_error("error opening file");
     }
     QTextStream in(&f);
-    return in.readAll().toUtf8().toStdString();
+    return mmqt::toStdStringUtf8(in.readAll());
 }
 
 NODISCARD static ShaderUtils::Source readWholeShader(const std::string &dir, const std::string &name)
@@ -38,6 +39,10 @@ FontShader::~FontShader() = default;
 PointShader::~PointShader() = default;
 BlitShader::~BlitShader() = default;
 FullScreenShader::~FullScreenShader() = default;
+AtmosphereShader::~AtmosphereShader() = default;
+TimeOfDayShader::~TimeOfDayShader() = default;
+ParticleSimulationShader::~ParticleSimulationShader() = default;
+ParticleRenderShader::~ParticleRenderShader() = default;
 
 void ShaderPrograms::early_init()
 {
@@ -52,6 +57,10 @@ void ShaderPrograms::early_init()
     std::ignore = getPointShader();
     std::ignore = getBlitShader();
     std::ignore = getFullScreenShader();
+    std::ignore = getAtmosphereShader();
+    std::ignore = getTimeOfDayShader();
+    std::ignore = getParticleSimulationShader();
+    std::ignore = getParticleRenderShader();
 }
 
 void ShaderPrograms::resetAll()
@@ -67,6 +76,10 @@ void ShaderPrograms::resetAll()
     m_point.reset();
     m_blit.reset();
     m_fullscreen.reset();
+    m_atmosphere.reset();
+    m_timeOfDay.reset();
+    m_particleSimulation.reset();
+    m_particleRender.reset();
 }
 
 // essentially a private member of ShaderPrograms
@@ -141,6 +154,56 @@ const std::shared_ptr<BlitShader> &ShaderPrograms::getBlitShader()
 const std::shared_ptr<FullScreenShader> &ShaderPrograms::getFullScreenShader()
 {
     return getInitialized<FullScreenShader>(m_fullscreen, getFunctions(), "fullscreen");
+}
+
+const std::shared_ptr<AtmosphereShader> &ShaderPrograms::getAtmosphereShader()
+{
+    return getInitialized<AtmosphereShader>(m_atmosphere, getFunctions(), "weather/atmosphere");
+}
+
+const std::shared_ptr<TimeOfDayShader> &ShaderPrograms::getTimeOfDayShader()
+{
+    return getInitialized<TimeOfDayShader>(m_timeOfDay, getFunctions(), "weather/timeofday");
+}
+
+const std::shared_ptr<ParticleSimulationShader> &ShaderPrograms::getParticleSimulationShader()
+{
+    if (!m_particleSimulation) {
+        Functions &funcs = getFunctions();
+        const auto getSource = [&funcs](const std::string &path) -> ShaderUtils::Source {
+            const auto fullPathName = ":/shaders/legacy/weather/simulation/" + path;
+            std::string src;
+            try {
+                src = ::readWholeResourceFile(fullPathName);
+            } catch (...) {
+                // Fallback for frag.glsl if file missing, as some drivers require it
+                if (path == "frag.glsl") {
+                    src = std::string(funcs.getShaderVersion())
+                          + "\nprecision mediump float;\nvoid main() {}\n";
+                } else {
+                    throw;
+                }
+            }
+            return ShaderUtils::Source{fullPathName, src};
+        };
+
+        std::vector<const char *> varyings = {"vPos", "vLife"};
+        auto program = ShaderUtils::loadTransformFeedbackShaders(funcs,
+                                                                 getSource("vert.glsl"),
+                                                                 getSource("frag.glsl"),
+                                                                 varyings);
+        m_particleSimulation = std::make_shared<ParticleSimulationShader>("weather/simulation",
+                                                                          funcs.shared_from_this(),
+                                                                          std::move(program));
+    }
+    return m_particleSimulation;
+}
+
+const std::shared_ptr<ParticleRenderShader> &ShaderPrograms::getParticleRenderShader()
+{
+    return getInitialized<ParticleRenderShader>(m_particleRender,
+                                                getFunctions(),
+                                                "weather/particle");
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/Shaders.h
+++ b/src/opengl/legacy/Shaders.h
@@ -156,6 +156,60 @@ private:
     }
 };
 
+struct NODISCARD AtmosphereShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~AtmosphereShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 & /*mvp*/,
+                          const GLRenderState::Uniforms & /*uniforms*/) final
+    {
+        setTexture("uTexture", 0);
+    }
+};
+
+struct NODISCARD TimeOfDayShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~TimeOfDayShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 & /*mvp*/,
+                          const GLRenderState::Uniforms & /*uniforms*/) final
+    {}
+};
+
+struct NODISCARD ParticleSimulationShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~ParticleSimulationShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 & /*mvp*/,
+                          const GLRenderState::Uniforms & /*uniforms*/) final
+    {}
+};
+
+struct NODISCARD ParticleRenderShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~ParticleRenderShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 & /*mvp*/,
+                          const GLRenderState::Uniforms & /*uniforms*/) final
+    {}
+};
+
 /* owned by Functions */
 struct NODISCARD ShaderPrograms final
 {
@@ -176,6 +230,10 @@ private:
     std::shared_ptr<PointShader> m_point;
     std::shared_ptr<BlitShader> m_blit;
     std::shared_ptr<FullScreenShader> m_fullscreen;
+    std::shared_ptr<AtmosphereShader> m_atmosphere;
+    std::shared_ptr<TimeOfDayShader> m_timeOfDay;
+    std::shared_ptr<ParticleSimulationShader> m_particleSimulation;
+    std::shared_ptr<ParticleRenderShader> m_particleRender;
 
 public:
     explicit ShaderPrograms(Functions &functions)
@@ -208,6 +266,10 @@ public:
     NODISCARD const std::shared_ptr<PointShader> &getPointShader();
     NODISCARD const std::shared_ptr<BlitShader> &getBlitShader();
     NODISCARD const std::shared_ptr<FullScreenShader> &getFullScreenShader();
+    NODISCARD const std::shared_ptr<AtmosphereShader> &getAtmosphereShader();
+    NODISCARD const std::shared_ptr<TimeOfDayShader> &getTimeOfDayShader();
+    NODISCARD const std::shared_ptr<ParticleSimulationShader> &getParticleSimulationShader();
+    NODISCARD const std::shared_ptr<ParticleRenderShader> &getParticleRenderShader();
 
 public:
     void early_init();

--- a/src/opengl/legacy/TFO.cpp
+++ b/src/opengl/legacy/TFO.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "TFO.h"
+
+#include "Legacy.h"
+
+namespace Legacy {
+
+void TFO::emplace(const SharedFunctions &sharedFunctions)
+{
+    reset();
+    m_weakFunctions = sharedFunctions;
+    sharedFunctions->glGenTransformFeedbacks(1, &m_tfo);
+}
+
+void TFO::reset()
+{
+    if (m_tfo != INVALID_TFO) {
+        if (auto shared = m_weakFunctions.lock()) {
+            shared->glDeleteTransformFeedbacks(1, &m_tfo);
+        }
+        m_tfo = INVALID_TFO;
+    }
+}
+
+GLuint TFO::get() const
+{
+    return m_tfo;
+}
+
+} // namespace Legacy

--- a/src/opengl/legacy/TFO.h
+++ b/src/opengl/legacy/TFO.h
@@ -1,0 +1,36 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "Legacy.h"
+
+#include <memory>
+
+namespace Legacy {
+
+class NODISCARD TFO final
+{
+private:
+    static inline constexpr GLuint INVALID_TFO = 0;
+    WeakFunctions m_weakFunctions;
+    GLuint m_tfo = INVALID_TFO;
+
+public:
+    TFO() = default;
+    ~TFO() { reset(); }
+
+    DELETE_CTORS_AND_ASSIGN_OPS(TFO);
+
+public:
+    void emplace(const SharedFunctions &sharedFunctions);
+    void reset();
+    NODISCARD GLuint get() const;
+
+public:
+    NODISCARD explicit operator bool() const { return m_tfo != INVALID_TFO; }
+};
+
+using SharedTfo = std::shared_ptr<TFO>;
+using WeakTfo = std::weak_ptr<TFO>;
+
+} // namespace Legacy

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -82,7 +82,8 @@ void ParticleSimulationMesh::init()
 
 void ParticleSimulationMesh::virt_reset()
 {
-    m_tfo.reset();
+    // Note: TFO is not reset here as it's only created in the constructor
+    // and can be reused.
     for (int i = 0; i < 2; ++i) {
         m_vbos[i].reset();
         m_vaos[i].reset();
@@ -139,7 +140,7 @@ void ParticleRenderMesh::init()
         return;
     }
 
-    for (int i = 0; i < 2; ++i) {
+    for (uint32_t i = 0; i < 2; ++i) {
         m_functions.glBindVertexArray(m_vaos[i].get());
 
         m_functions.glBindBuffer(GL_ARRAY_BUFFER, m_simulation.getParticleVbo(i).get());
@@ -184,11 +185,12 @@ void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
         return;
     }
 
-    // The particle count is determined by the max intensity in the UBO.
-    // However, since we don't have direct access to the UBO data here without re-parsing,
-    // we use a reasonable maximum and let the shader discard if necessary,
-    // or just draw the full 1024 as it's small enough.
-    const GLsizei count = static_cast<GLsizei>(m_simulation.getNumParticles());
+    // Thinning: use precipitation intensity to drive instance count
+    const float intensity = renderState.uniforms.weather.currentPrecipitationIntensity;
+    const GLsizei maxCount = static_cast<GLsizei>(m_simulation.getNumParticles());
+    const GLsizei count = std::max<GLsizei>(
+        1,
+        static_cast<GLsizei>(intensity * static_cast<float>(maxCount)));
 
     auto binder = m_program->bind();
     const glm::mat4 mvp = renderState.mvp.value_or(m_functions.getProjectionMatrix());

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -4,6 +4,7 @@
 #include "WeatherMeshes.h"
 
 #include "../../global/random.h"
+#include "../Weather.h"
 #include "AttributeLessMeshes.h"
 #include "Binders.h"
 
@@ -63,9 +64,12 @@ void ParticleSimulationMesh::init()
     std::vector<WeatherParticleVert> initialData;
     initialData.reserve(m_numParticles);
     for (size_t i = 0; i < m_numParticles; ++i) {
-        initialData.emplace_back(glm::vec2(get_random_float() * 28.0f - 14.0f,
-                                           get_random_float() * 28.0f - 14.0f),
-                                 get_random_float());
+        initialData.emplace_back(
+            glm::vec2(get_random_float() * WeatherConstants::WEATHER_EXTENT
+                          - WeatherConstants::WEATHER_RADIUS,
+                      get_random_float() * WeatherConstants::WEATHER_EXTENT
+                          - WeatherConstants::WEATHER_RADIUS),
+            get_random_float());
     }
 
     for (int i = 0; i < 2; ++i) {
@@ -189,7 +193,7 @@ void ParticleRenderMesh::virt_reset()
 
 bool ParticleRenderMesh::virt_isEmpty() const
 {
-    return m_simulation.virt_isEmpty() || !m_initialized;
+    return m_simulation.virt_isEmpty();
 }
 
 void ParticleRenderMesh::virt_render(const GLRenderState &renderState)

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -155,12 +155,13 @@ ParticleRenderMesh::~ParticleRenderMesh() = default;
 
 void ParticleRenderMesh::init()
 {
-    if (m_initialized) {
+    if (m_initialized || m_simulation.virt_isEmpty()) {
         return;
     }
 
     for (int i = 0; i < 2; ++i) {
         m_functions.glBindVertexArray(m_vaos[i].get());
+
         m_functions.glBindBuffer(GL_ARRAY_BUFFER, m_simulation.getParticleVbo(i).get());
         m_functions.enableAttrib(0,
                                  2,
@@ -177,9 +178,9 @@ void ParticleRenderMesh::init()
                                  reinterpret_cast<void *>(offsetof(WeatherParticleVert, life)));
         m_functions.glVertexAttribDivisor(1, 1);
     }
+
     m_functions.glBindVertexArray(0);
     m_functions.glBindBuffer(GL_ARRAY_BUFFER, 0);
-
     m_initialized = true;
 }
 
@@ -199,6 +200,9 @@ bool ParticleRenderMesh::virt_isEmpty() const
 void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
 {
     init();
+    if (!m_initialized) {
+        return;
+    }
 
     // The particle count is determined by the max intensity in the UBO.
     // However, since we don't have direct access to the UBO data here without re-parsing,
@@ -213,7 +217,6 @@ void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
     RenderStateBinder rsBinder(m_functions, m_functions.getTexLookup(), renderState);
 
     const uint32_t bufferIdx = m_simulation.getCurrentBuffer();
-
     m_functions.glBindVertexArray(m_vaos[bufferIdx].get());
     m_functions.glDrawArraysInstanced(GL_TRIANGLE_STRIP, 0, 4, count);
     m_functions.glBindVertexArray(0);

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -20,7 +20,7 @@ AtmosphereMesh::~AtmosphereMesh() = default;
 void AtmosphereMesh::virt_render(const GLRenderState &renderState)
 {
     auto binder = m_program.bind();
-    const glm::mat4 mvp = m_functions.getProjectionMatrix();
+    const glm::mat4 mvp = renderState.mvp.value_or(m_functions.getProjectionMatrix());
     m_program.setUniforms(mvp, renderState.uniforms);
 
     RenderStateBinder rsBinder(m_functions, m_functions.getTexLookup(), renderState);
@@ -64,12 +64,11 @@ void ParticleSimulationMesh::init()
     std::vector<WeatherParticleVert> initialData;
     initialData.reserve(m_numParticles);
     for (size_t i = 0; i < m_numParticles; ++i) {
-        initialData.emplace_back(
-            glm::vec2(get_random_float() * WeatherConstants::WEATHER_EXTENT
-                          - WeatherConstants::WEATHER_RADIUS,
-                      get_random_float() * WeatherConstants::WEATHER_EXTENT
-                          - WeatherConstants::WEATHER_RADIUS),
-            get_random_float());
+        initialData.emplace_back(glm::vec2(get_random_float() * WeatherConstants::WEATHER_EXTENT
+                                               - WeatherConstants::WEATHER_RADIUS,
+                                           get_random_float() * WeatherConstants::WEATHER_EXTENT
+                                               - WeatherConstants::WEATHER_RADIUS),
+                                 get_random_float());
     }
 
     for (int i = 0; i < 2; ++i) {
@@ -115,7 +114,7 @@ void ParticleSimulationMesh::virt_render(const GLRenderState &renderState)
     init();
 
     auto binder = m_program->bind();
-    const glm::mat4 mvp = m_functions.getProjectionMatrix();
+    const glm::mat4 mvp = renderState.mvp.value_or(m_functions.getProjectionMatrix());
     m_program->setUniforms(mvp, renderState.uniforms);
 
     const uint32_t bufferOut = 1 - m_currentBuffer;
@@ -211,7 +210,7 @@ void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
     const GLsizei count = static_cast<GLsizei>(m_simulation.getNumParticles());
 
     auto binder = m_program->bind();
-    const glm::mat4 mvp = m_functions.getProjectionMatrix();
+    const glm::mat4 mvp = renderState.mvp.value_or(m_functions.getProjectionMatrix());
     m_program->setUniforms(mvp, renderState.uniforms);
 
     RenderStateBinder rsBinder(m_functions, m_functions.getTexLookup(), renderState);

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -149,17 +149,53 @@ ParticleRenderMesh::ParticleRenderMesh(SharedFunctions shared_functions,
 
 ParticleRenderMesh::~ParticleRenderMesh() = default;
 
-void ParticleRenderMesh::init() {}
+void ParticleRenderMesh::init()
+{
+    if (m_initialized) {
+        return;
+    }
+
+    for (int i = 0; i < 2; ++i) {
+        m_functions.glBindVertexArray(m_vaos[i].get());
+        m_functions.glBindBuffer(GL_ARRAY_BUFFER, m_simulation.getParticleVbo(i).get());
+        m_functions.enableAttrib(0,
+                                 2,
+                                 GL_FLOAT,
+                                 GL_FALSE,
+                                 sizeof(WeatherParticleVert),
+                                 reinterpret_cast<void *>(offsetof(WeatherParticleVert, pos)));
+        m_functions.glVertexAttribDivisor(0, 1);
+        m_functions.enableAttrib(1,
+                                 1,
+                                 GL_FLOAT,
+                                 GL_FALSE,
+                                 sizeof(WeatherParticleVert),
+                                 reinterpret_cast<void *>(offsetof(WeatherParticleVert, life)));
+        m_functions.glVertexAttribDivisor(1, 1);
+    }
+    m_functions.glBindVertexArray(0);
+    m_functions.glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    m_initialized = true;
+}
 
 void ParticleRenderMesh::virt_reset()
 {
     for (int i = 0; i < 2; ++i) {
         m_vaos[i].reset();
     }
+    m_initialized = false;
+}
+
+bool ParticleRenderMesh::virt_isEmpty() const
+{
+    return m_simulation.virt_isEmpty() || !m_initialized;
 }
 
 void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
 {
+    init();
+
     // The particle count is determined by the max intensity in the UBO.
     // However, since we don't have direct access to the UBO data here without re-parsing,
     // we use a reasonable maximum and let the shader discard if necessary,
@@ -175,27 +211,8 @@ void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
     const uint32_t bufferIdx = m_simulation.getCurrentBuffer();
 
     m_functions.glBindVertexArray(m_vaos[bufferIdx].get());
-
-    m_functions.glBindBuffer(GL_ARRAY_BUFFER, m_simulation.getParticleVbo(bufferIdx).get());
-    m_functions.enableAttrib(0,
-                             2,
-                             GL_FLOAT,
-                             GL_FALSE,
-                             sizeof(WeatherParticleVert),
-                             reinterpret_cast<void *>(offsetof(WeatherParticleVert, pos)));
-    m_functions.glVertexAttribDivisor(0, 1);
-    m_functions.enableAttrib(1,
-                             1,
-                             GL_FLOAT,
-                             GL_FALSE,
-                             sizeof(WeatherParticleVert),
-                             reinterpret_cast<void *>(offsetof(WeatherParticleVert, life)));
-    m_functions.glVertexAttribDivisor(1, 1);
-
     m_functions.glDrawArraysInstanced(GL_TRIANGLE_STRIP, 0, 4, count);
-
     m_functions.glBindVertexArray(0);
-    m_functions.glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -17,25 +17,6 @@ AtmosphereMesh::AtmosphereMesh(SharedFunctions sharedFunctions,
 
 AtmosphereMesh::~AtmosphereMesh() = default;
 
-void AtmosphereMesh::virt_render(const GLRenderState &renderState)
-{
-    auto binder = m_program.bind();
-    const glm::mat4 mvp = renderState.mvp.value_or(m_functions.getProjectionMatrix());
-    m_program.setUniforms(mvp, renderState.uniforms);
-
-    RenderStateBinder rsBinder(m_functions, m_functions.getTexLookup(), renderState);
-
-    SharedVao shared = m_functions.getSharedVaos().get(SharedVaoEnum::EmptyVao);
-    VAO &vao = deref(shared);
-    if (!vao) {
-        vao.emplace(m_shared_functions);
-    }
-
-    m_functions.glBindVertexArray(vao.get());
-    m_functions.glDrawArrays(m_mode, 0, m_numVerts);
-    m_functions.glBindVertexArray(0);
-}
-
 TimeOfDayMesh::~TimeOfDayMesh() = default;
 
 ParticleSimulationMesh::ParticleSimulationMesh(SharedFunctions shared_functions,

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "WeatherMeshes.h"
+
+#include "../../global/random.h"
+#include "AttributeLessMeshes.h"
+#include "Binders.h"
+
+namespace Legacy {
+
+AtmosphereMesh::AtmosphereMesh(SharedFunctions sharedFunctions,
+                               std::shared_ptr<AtmosphereShader> program)
+    : FullScreenMesh(std::move(sharedFunctions), std::move(program), GL_TRIANGLE_STRIP, 4)
+{}
+
+AtmosphereMesh::~AtmosphereMesh() = default;
+
+void AtmosphereMesh::virt_render(const GLRenderState &renderState)
+{
+    auto binder = m_program.bind();
+    const glm::mat4 mvp = m_functions.getProjectionMatrix();
+    m_program.setUniforms(mvp, renderState.uniforms);
+
+    RenderStateBinder rsBinder(m_functions, m_functions.getTexLookup(), renderState);
+
+    SharedVao shared = m_functions.getSharedVaos().get(SharedVaoEnum::EmptyVao);
+    VAO &vao = deref(shared);
+    if (!vao) {
+        vao.emplace(m_shared_functions);
+    }
+
+    m_functions.glBindVertexArray(vao.get());
+    m_functions.glDrawArrays(m_mode, 0, m_numVerts);
+    m_functions.glBindVertexArray(0);
+}
+
+TimeOfDayMesh::~TimeOfDayMesh() = default;
+
+ParticleSimulationMesh::ParticleSimulationMesh(SharedFunctions shared_functions,
+                                               std::shared_ptr<ParticleSimulationShader> program)
+    : m_shared_functions(std::move(shared_functions))
+    , m_functions(deref(m_shared_functions))
+    , m_program(std::move(program))
+{
+    m_tfo.emplace(m_shared_functions);
+    for (int i = 0; i < 2; ++i) {
+        m_vbos[i].emplace(m_shared_functions);
+        m_vaos[i].emplace(m_shared_functions);
+    }
+}
+
+ParticleSimulationMesh::~ParticleSimulationMesh() = default;
+
+void ParticleSimulationMesh::init()
+{
+    if (m_initialized) {
+        return;
+    }
+
+    auto get_random_float = []() { return static_cast<float>(getRandom(1000000)) / 1000000.0f; };
+
+    std::vector<WeatherParticleVert> initialData;
+    initialData.reserve(m_numParticles);
+    for (size_t i = 0; i < m_numParticles; ++i) {
+        initialData.emplace_back(glm::vec2(get_random_float() * 28.0f - 14.0f,
+                                           get_random_float() * 28.0f - 14.0f),
+                                 get_random_float());
+    }
+
+    for (int i = 0; i < 2; ++i) {
+        m_functions.glBindBuffer(GL_ARRAY_BUFFER, m_vbos[i].get());
+        m_functions.glBufferData(GL_ARRAY_BUFFER,
+                                 static_cast<GLsizeiptr>(initialData.size()
+                                                         * sizeof(WeatherParticleVert)),
+                                 initialData.data(),
+                                 GL_STREAM_DRAW);
+
+        m_functions.glBindVertexArray(m_vaos[i].get());
+        m_functions.enableAttrib(0,
+                                 2,
+                                 GL_FLOAT,
+                                 GL_FALSE,
+                                 sizeof(WeatherParticleVert),
+                                 reinterpret_cast<void *>(offsetof(WeatherParticleVert, pos)));
+        m_functions.enableAttrib(1,
+                                 1,
+                                 GL_FLOAT,
+                                 GL_FALSE,
+                                 sizeof(WeatherParticleVert),
+                                 reinterpret_cast<void *>(offsetof(WeatherParticleVert, life)));
+        m_functions.glBindVertexArray(0);
+        m_functions.glBindBuffer(GL_ARRAY_BUFFER, 0);
+    }
+
+    m_initialized = true;
+}
+
+void ParticleSimulationMesh::virt_reset()
+{
+    m_tfo.reset();
+    for (int i = 0; i < 2; ++i) {
+        m_vbos[i].reset();
+        m_vaos[i].reset();
+    }
+    m_initialized = false;
+}
+
+void ParticleSimulationMesh::virt_render(const GLRenderState &renderState)
+{
+    init();
+
+    auto binder = m_program->bind();
+    const glm::mat4 mvp = m_functions.getProjectionMatrix();
+    m_program->setUniforms(mvp, renderState.uniforms);
+
+    const uint32_t bufferOut = 1 - m_currentBuffer;
+
+    m_functions.glBindVertexArray(m_vaos[m_currentBuffer].get());
+    m_functions.glEnable(GL_RASTERIZER_DISCARD);
+    m_functions.glBindTransformFeedback(GL_TRANSFORM_FEEDBACK, m_tfo.get());
+    m_functions.glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, m_vbos[bufferOut].get());
+
+    {
+        m_functions.glBeginTransformFeedback(GL_POINTS);
+        m_functions.glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(m_numParticles));
+        m_functions.glEndTransformFeedback();
+    }
+    m_functions.glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, 0);
+    m_functions.glBindTransformFeedback(GL_TRANSFORM_FEEDBACK, 0);
+    m_functions.glDisable(GL_RASTERIZER_DISCARD);
+    m_functions.glBindVertexArray(0);
+
+    m_currentBuffer = bufferOut;
+}
+
+ParticleRenderMesh::ParticleRenderMesh(SharedFunctions shared_functions,
+                                       std::shared_ptr<ParticleRenderShader> program,
+                                       const ParticleSimulationMesh &simulation)
+    : m_shared_functions(std::move(shared_functions))
+    , m_functions(deref(m_shared_functions))
+    , m_program(std::move(program))
+    , m_simulation(simulation)
+{
+    for (int i = 0; i < 2; ++i) {
+        m_vaos[i].emplace(m_shared_functions);
+    }
+}
+
+ParticleRenderMesh::~ParticleRenderMesh() = default;
+
+void ParticleRenderMesh::init() {}
+
+void ParticleRenderMesh::virt_reset()
+{
+    for (int i = 0; i < 2; ++i) {
+        m_vaos[i].reset();
+    }
+}
+
+void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
+{
+    // The particle count is determined by the max intensity in the UBO.
+    // However, since we don't have direct access to the UBO data here without re-parsing,
+    // we use a reasonable maximum and let the shader discard if necessary,
+    // or just draw the full 1024 as it's small enough.
+    const GLsizei count = static_cast<GLsizei>(m_simulation.getNumParticles());
+
+    auto binder = m_program->bind();
+    const glm::mat4 mvp = m_functions.getProjectionMatrix();
+    m_program->setUniforms(mvp, renderState.uniforms);
+
+    RenderStateBinder rsBinder(m_functions, m_functions.getTexLookup(), renderState);
+
+    const uint32_t bufferIdx = m_simulation.getCurrentBuffer();
+
+    m_functions.glBindVertexArray(m_vaos[bufferIdx].get());
+
+    m_functions.glBindBuffer(GL_ARRAY_BUFFER, m_simulation.getParticleVbo(bufferIdx).get());
+    m_functions.enableAttrib(0,
+                             2,
+                             GL_FLOAT,
+                             GL_FALSE,
+                             sizeof(WeatherParticleVert),
+                             reinterpret_cast<void *>(offsetof(WeatherParticleVert, pos)));
+    m_functions.glVertexAttribDivisor(0, 1);
+    m_functions.enableAttrib(1,
+                             1,
+                             GL_FLOAT,
+                             GL_FALSE,
+                             sizeof(WeatherParticleVert),
+                             reinterpret_cast<void *>(offsetof(WeatherParticleVert, life)));
+    m_functions.glVertexAttribDivisor(1, 1);
+
+    m_functions.glDrawArraysInstanced(GL_TRIANGLE_STRIP, 0, 4, count);
+
+    m_functions.glBindVertexArray(0);
+    m_functions.glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+} // namespace Legacy

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -53,6 +53,9 @@ void ParticleSimulationMesh::init()
     }
 
     for (int i = 0; i < 2; ++i) {
+        if (!m_vbos[i]) {
+            m_vbos[i].emplace(m_shared_functions);
+        }
         m_functions.glBindBuffer(GL_ARRAY_BUFFER, m_vbos[i].get());
         m_functions.glBufferData(GL_ARRAY_BUFFER,
                                  static_cast<GLsizeiptr>(initialData.size()
@@ -60,6 +63,9 @@ void ParticleSimulationMesh::init()
                                  initialData.data(),
                                  GL_STREAM_DRAW);
 
+        if (!m_vaos[i]) {
+            m_vaos[i].emplace(m_shared_functions);
+        }
         m_functions.glBindVertexArray(m_vaos[i].get());
         m_functions.enableAttrib(0,
                                  2,
@@ -141,6 +147,9 @@ void ParticleRenderMesh::init()
     }
 
     for (uint32_t i = 0; i < 2; ++i) {
+        if (!m_vaos[i]) {
+            m_vaos[i].emplace(m_shared_functions);
+        }
         m_functions.glBindVertexArray(m_vaos[i].get());
 
         m_functions.glBindBuffer(GL_ARRAY_BUFFER, m_simulation.getParticleVbo(i).get());

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -196,6 +196,9 @@ void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
 
     // Thinning: use precipitation intensity to drive instance count
     const float intensity = renderState.uniforms.weather.currentPrecipitationIntensity;
+    if (intensity <= 0.0f) {
+        return;
+    }
     const GLsizei maxCount = static_cast<GLsizei>(m_simulation.getNumParticles());
     const GLsizei count = std::max<GLsizei>(
         1,

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -195,14 +195,13 @@ void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
     }
 
     // Thinning: use precipitation intensity to drive instance count
-    const float intensity = renderState.uniforms.weather.currentPrecipitationIntensity;
-    if (intensity <= 0.0f) {
+    if (m_intensity <= 0.0f) {
         return;
     }
     const GLsizei maxCount = static_cast<GLsizei>(m_simulation.getNumParticles());
     const GLsizei count = std::max<GLsizei>(
         1,
-        static_cast<GLsizei>(intensity * static_cast<float>(maxCount)));
+        static_cast<GLsizei>(m_intensity * static_cast<float>(maxCount)));
 
     auto binder = m_program->bind();
     const glm::mat4 mvp = renderState.mvp.value_or(m_functions.getProjectionMatrix());

--- a/src/opengl/legacy/WeatherMeshes.cpp
+++ b/src/opengl/legacy/WeatherMeshes.cpp
@@ -199,9 +199,9 @@ void ParticleRenderMesh::virt_render(const GLRenderState &renderState)
         return;
     }
     const GLsizei maxCount = static_cast<GLsizei>(m_simulation.getNumParticles());
-    const GLsizei count = std::max<GLsizei>(
-        1,
-        static_cast<GLsizei>(m_intensity * static_cast<float>(maxCount)));
+    const GLsizei count = std::max<GLsizei>(1,
+                                            static_cast<GLsizei>(m_intensity
+                                                                 * static_cast<float>(maxCount)));
 
     auto binder = m_program->bind();
     const glm::mat4 mvp = renderState.mvp.value_or(m_functions.getProjectionMatrix());

--- a/src/opengl/legacy/WeatherMeshes.h
+++ b/src/opengl/legacy/WeatherMeshes.h
@@ -1,0 +1,92 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "../OpenGL.h"
+#include "../OpenGLTypes.h"
+#include "AttributeLessMeshes.h"
+#include "Binders.h"
+#include "Legacy.h"
+#include "Shaders.h"
+#include "TFO.h"
+#include "VAO.h"
+#include "VBO.h"
+
+namespace Legacy {
+
+class NODISCARD AtmosphereMesh final : public FullScreenMesh<AtmosphereShader>
+{
+public:
+    explicit AtmosphereMesh(SharedFunctions sharedFunctions,
+                            std::shared_ptr<AtmosphereShader> program);
+    ~AtmosphereMesh() override;
+
+protected:
+    void virt_render(const GLRenderState &renderState) override;
+};
+
+class NODISCARD TimeOfDayMesh final : public FullScreenMesh<TimeOfDayShader>
+{
+public:
+    using FullScreenMesh::FullScreenMesh;
+    ~TimeOfDayMesh() override;
+};
+
+class NODISCARD ParticleSimulationMesh final : public IRenderable
+{
+private:
+    const SharedFunctions m_shared_functions;
+    Functions &m_functions;
+    const std::shared_ptr<ParticleSimulationShader> m_program;
+
+    TFO m_tfo;
+    VBO m_vbos[2];
+    VAO m_vaos[2];
+
+    uint32_t m_currentBuffer = 0;
+    uint32_t m_numParticles = 1024;
+    bool m_initialized = false;
+
+public:
+    explicit ParticleSimulationMesh(SharedFunctions shared_functions,
+                                    std::shared_ptr<ParticleSimulationShader> program);
+    ~ParticleSimulationMesh() override;
+
+private:
+    void init();
+    void virt_clear() override {}
+    void virt_reset() override;
+    NODISCARD bool virt_isEmpty() const override { return !m_initialized; }
+    void virt_render(const GLRenderState &renderState) override;
+
+public:
+    NODISCARD uint32_t getCurrentBuffer() const { return m_currentBuffer; }
+    NODISCARD uint32_t getNumParticles() const { return m_numParticles; }
+    NODISCARD const VBO &getParticleVbo(uint32_t index) const { return m_vbos[index]; }
+};
+
+class NODISCARD ParticleRenderMesh final : public IRenderable
+{
+private:
+    const SharedFunctions m_shared_functions;
+    Functions &m_functions;
+    const std::shared_ptr<ParticleRenderShader> m_program;
+    const ParticleSimulationMesh &m_simulation;
+
+    VAO m_vaos[2];
+
+public:
+    explicit ParticleRenderMesh(SharedFunctions shared_functions,
+                                std::shared_ptr<ParticleRenderShader> program,
+                                const ParticleSimulationMesh &simulation);
+    ~ParticleRenderMesh() override;
+
+private:
+    void init();
+    void virt_clear() override {}
+    void virt_reset() override;
+    NODISCARD bool virt_isEmpty() const override { return false; }
+    void virt_render(const GLRenderState &renderState) override;
+};
+
+} // namespace Legacy

--- a/src/opengl/legacy/WeatherMeshes.h
+++ b/src/opengl/legacy/WeatherMeshes.h
@@ -59,7 +59,7 @@ public:
     NODISCARD bool virt_isEmpty() const override { return !m_initialized; }
     NODISCARD uint32_t getCurrentBuffer() const { return m_currentBuffer; }
     NODISCARD uint32_t getNumParticles() const { return m_numParticles; }
-    NODISCARD const VBO &getParticleVbo(uint32_t index) const { return m_vbos[index]; }
+    NODISCARD const VBO &getParticleVbo(const uint32_t index) const { return m_vbos[index]; }
 };
 
 class NODISCARD ParticleRenderMesh final : public IRenderable

--- a/src/opengl/legacy/WeatherMeshes.h
+++ b/src/opengl/legacy/WeatherMeshes.h
@@ -20,9 +20,6 @@ public:
     explicit AtmosphereMesh(SharedFunctions sharedFunctions,
                             std::shared_ptr<AtmosphereShader> program);
     ~AtmosphereMesh() override;
-
-protected:
-    void virt_render(const GLRenderState &renderState) override;
 };
 
 class NODISCARD TimeOfDayMesh final : public FullScreenMesh<TimeOfDayShader>

--- a/src/opengl/legacy/WeatherMeshes.h
+++ b/src/opengl/legacy/WeatherMeshes.h
@@ -56,8 +56,10 @@ private:
     void init();
     void virt_clear() override {}
     void virt_reset() override;
-    NODISCARD bool virt_isEmpty() const override { return !m_initialized; }
     void virt_render(const GLRenderState &renderState) override;
+
+public:
+    NODISCARD bool virt_isEmpty() const override { return !m_initialized; }
 
 public:
     NODISCARD uint32_t getCurrentBuffer() const { return m_currentBuffer; }
@@ -74,6 +76,7 @@ private:
     const ParticleSimulationMesh &m_simulation;
 
     VAO m_vaos[2];
+    bool m_initialized = false;
 
 public:
     explicit ParticleRenderMesh(SharedFunctions shared_functions,
@@ -85,7 +88,7 @@ private:
     void init();
     void virt_clear() override {}
     void virt_reset() override;
-    NODISCARD bool virt_isEmpty() const override { return false; }
+    NODISCARD bool virt_isEmpty() const override;
     void virt_render(const GLRenderState &renderState) override;
 };
 

--- a/src/opengl/legacy/WeatherMeshes.h
+++ b/src/opengl/legacy/WeatherMeshes.h
@@ -71,6 +71,7 @@ private:
     const ParticleSimulationMesh &m_simulation;
 
     VAO m_vaos[2];
+    float m_intensity = 0.0f;
     bool m_initialized = false;
 
 public:
@@ -78,6 +79,8 @@ public:
                                 std::shared_ptr<ParticleRenderShader> program,
                                 const ParticleSimulationMesh &simulation);
     ~ParticleRenderMesh() override;
+
+    void setIntensity(const float intensity) { m_intensity = intensity; }
 
 private:
     void init();

--- a/src/opengl/legacy/WeatherMeshes.h
+++ b/src/opengl/legacy/WeatherMeshes.h
@@ -59,7 +59,7 @@ private:
     void virt_render(const GLRenderState &renderState) override;
 
 public:
-    NODISCARD bool virt_isEmpty() const override { return !m_initialized; }
+    NODISCARD bool virt_isEmpty() const override { return false; }
 
 public:
     NODISCARD uint32_t getCurrentBuffer() const { return m_currentBuffer; }

--- a/src/opengl/legacy/WeatherMeshes.h
+++ b/src/opengl/legacy/WeatherMeshes.h
@@ -59,9 +59,7 @@ private:
     void virt_render(const GLRenderState &renderState) override;
 
 public:
-    NODISCARD bool virt_isEmpty() const override { return false; }
-
-public:
+    NODISCARD bool virt_isEmpty() const override { return !m_initialized; }
     NODISCARD uint32_t getCurrentBuffer() const { return m_currentBuffer; }
     NODISCARD uint32_t getNumParticles() const { return m_numParticles; }
     NODISCARD const VBO &getParticleVbo(uint32_t index) const { return m_vbos[index]; }

--- a/src/opengl/legacy/WeatherMeshes.h
+++ b/src/opengl/legacy/WeatherMeshes.h
@@ -41,7 +41,7 @@ private:
     VAO m_vaos[2];
 
     uint32_t m_currentBuffer = 0;
-    uint32_t m_numParticles = 1024;
+    uint32_t m_numParticles = 512;
     bool m_initialized = false;
 
 public:

--- a/src/preferences/AdvancedGraphics.cpp
+++ b/src/preferences/AdvancedGraphics.cpp
@@ -49,32 +49,32 @@ class NODISCARD FpSpinBox final : public QDoubleSpinBox
 private:
     using FP = FixedPoint<D>;
     FP &m_fp;
+    const double m_multiplier;
+    const double m_fraction;
 
 public:
     explicit FpSpinBox(FixedPoint<D> &fp)
         : QDoubleSpinBox()
         , m_fp{fp}
+        , m_multiplier{std::pow(10.0, static_cast<double>(FP::digits))}
+        , m_fraction{1.0 / m_multiplier}
     {
-        const double fraction = std::pow(10.0, -static_cast<double>(FP::digits));
-        setRange(static_cast<double>(m_fp.min) * fraction, static_cast<double>(m_fp.max) * fraction);
+        setRange(static_cast<double>(m_fp.min) * m_fraction,
+                 static_cast<double>(m_fp.max) * m_fraction);
         setValue(m_fp.getDouble());
         setDecimals(FP::digits);
-        setSingleStep(fraction);
+        setSingleStep(m_fraction);
     }
     ~FpSpinBox() final = default;
 
 public:
     NODISCARD int getIntValue() const
     {
-        return static_cast<int>(
-            std::lround(std::clamp(value() * std::pow(10.0, static_cast<double>(FP::digits)),
-                                   static_cast<double>(m_fp.min),
-                                   static_cast<double>(m_fp.max))));
+        return static_cast<int>(std::lround(std::clamp(value() * m_multiplier,
+                                                       static_cast<double>(m_fp.min),
+                                                       static_cast<double>(m_fp.max))));
     }
-    void setIntValue(int value)
-    {
-        setValue(static_cast<double>(value) * std::pow(10.0, -static_cast<double>(FP::digits)));
-    }
+    void setIntValue(int value) { setValue(static_cast<double>(value) * m_fraction); }
 };
 
 template<int D>

--- a/src/preferences/AdvancedGraphics.cpp
+++ b/src/preferences/AdvancedGraphics.cpp
@@ -55,7 +55,7 @@ public:
         : QDoubleSpinBox()
         , m_fp{fp}
     {
-        const double fraction = std::pow(10.0, -FP::digits);
+        const double fraction = std::pow(10.0, -static_cast<double>(FP::digits));
         setRange(static_cast<double>(m_fp.min) * fraction, static_cast<double>(m_fp.max) * fraction);
         setValue(m_fp.getDouble());
         setDecimals(FP::digits);
@@ -66,13 +66,14 @@ public:
 public:
     NODISCARD int getIntValue() const
     {
-        return static_cast<int>(std::lround(std::clamp(value() * std::pow(10.0, FP::digits),
-                                                       static_cast<double>(m_fp.min),
-                                                       static_cast<double>(m_fp.max))));
+        return static_cast<int>(
+            std::lround(std::clamp(value() * std::pow(10.0, static_cast<double>(FP::digits)),
+                                   static_cast<double>(m_fp.min),
+                                   static_cast<double>(m_fp.max))));
     }
     void setIntValue(int value)
     {
-        setValue(static_cast<double>(value) * std::pow(10.0, -FP::digits));
+        setValue(static_cast<double>(value) * std::pow(10.0, -static_cast<double>(FP::digits)));
     }
 };
 

--- a/src/preferences/graphicspage.cpp
+++ b/src/preferences/graphicspage.cpp
@@ -85,6 +85,21 @@ GraphicsPage::GraphicsPage(QWidget *parent)
             this,
             &GraphicsPage::slot_drawUpperLayersTexturedStateChanged);
 
+    connect(ui->weatherAtmosphereSlider, &QSlider::valueChanged, this, [this](int value) {
+        setConfig().canvas.weatherAtmosphereIntensity.set(value);
+        graphicsSettingsChanged();
+    });
+
+    connect(ui->weatherPrecipitationSlider, &QSlider::valueChanged, this, [this](int value) {
+        setConfig().canvas.weatherPrecipitationIntensity.set(value);
+        graphicsSettingsChanged();
+    });
+
+    connect(ui->weatherTimeOfDaySlider, &QSlider::valueChanged, this, [this](int value) {
+        setConfig().canvas.weatherTimeOfDayIntensity.set(value);
+        graphicsSettingsChanged();
+    });
+
     connect(m_advanced.get(),
             &AdvancedGraphicsGroupBox::sig_graphicsSettingsChanged,
             this,
@@ -126,6 +141,10 @@ void GraphicsPage::slot_loadConfig()
     ui->drawNeedsUpdate->setChecked(settings.showMissingMapId.get());
     ui->drawNotMappedExits->setChecked(settings.showUnmappedExits.get());
     ui->drawDoorNames->setChecked(settings.drawDoorNames);
+
+    ui->weatherAtmosphereSlider->setValue(settings.weatherAtmosphereIntensity.get());
+    ui->weatherPrecipitationSlider->setValue(settings.weatherPrecipitationIntensity.get());
+    ui->weatherTimeOfDaySlider->setValue(settings.weatherTimeOfDayIntensity.get());
 }
 
 void GraphicsPage::changeColorClicked(XNamedColor &namedColor, QPushButton *const pushButton)

--- a/src/preferences/graphicspage.ui
+++ b/src/preferences/graphicspage.ui
@@ -298,6 +298,66 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_Weather">
+     <property name="title">
+      <string>Weather and Atmosphere</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_Weather">
+      <item row="0" column="0">
+       <widget class="QLabel" name="weatherAtmosphereLabel">
+        <property name="text">
+         <string>Atmosphere Intensity:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSlider" name="weatherAtmosphereSlider">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="weatherPrecipitationLabel">
+        <property name="text">
+         <string>Precipitation Intensity:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSlider" name="weatherPrecipitationSlider">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="weatherTimeOfDayLabel">
+        <property name="text">
+         <string>Time of Day Intensity:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QSlider" name="weatherTimeOfDaySlider">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox_Advanced">
      <property name="title">
       <string>Advanced Settings</string>

--- a/src/resources/mmapper2.qrc
+++ b/src/resources/mmapper2.qrc
@@ -229,5 +229,13 @@
         <file>shaders/legacy/blit/vert.glsl</file>
         <file>shaders/legacy/fullscreen/frag.glsl</file>
         <file>shaders/legacy/fullscreen/vert.glsl</file>
+        <file>shaders/legacy/weather/atmosphere/frag.glsl</file>
+        <file>shaders/legacy/weather/atmosphere/vert.glsl</file>
+        <file>shaders/legacy/weather/particle/frag.glsl</file>
+        <file>shaders/legacy/weather/particle/vert.glsl</file>
+        <file>shaders/legacy/weather/simulation/frag.glsl</file>
+        <file>shaders/legacy/weather/simulation/vert.glsl</file>
+        <file>shaders/legacy/weather/timeofday/frag.glsl</file>
+        <file>shaders/legacy/weather/timeofday/vert.glsl</file>
     </qresource>
 </RCC>

--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -55,7 +55,7 @@ void main()
     vec3 worldPos = vWorldPos;
 
     float distToPlayer = distance(worldPos.xy, uPlayerPos.xy);
-    float localMask = smoothstep(WEATHER_MASK_RADIUS_START, WEATHER_MASK_RADIUS_END, distToPlayer);
+    float localMask = 1.0 - smoothstep(WEATHER_MASK_RADIUS_INNER, WEATHER_MASK_RADIUS_OUTER, distToPlayer);
 
     float uCurrentTime = uTime.x;
     float uWeatherStartTime = uConfig.x;

--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -5,7 +5,7 @@ precision highp float;
 
 layout(std140) uniform NamedColorsBlock
 {
-    vec4 uNamedColors[32];
+    vec4 uNamedColors[MAX_NAMED_COLORS];
 };
 
 layout(std140) uniform CameraBlock

--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -21,10 +21,10 @@ layout(std140) uniform TimeBlock
 
 layout(std140) uniform WeatherBlock
 {
-    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
-    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
-    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
-    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uIntensities; // rain_start, snow_start, clouds_start, fog_start
+    vec4 uTargets;     // rain_target, snow_target, clouds_target, fog_target
+    vec4 uTimeOfDay;   // x=startIdx, y=targetIdx, z=todStart, w=todTarget
+    vec4 uConfig;      // x=weatherStartTime, y=todStartTime, z=duration, w=unused
 };
 
 uniform sampler2D uTexture;
@@ -64,15 +64,15 @@ void main()
     float uTransitionDuration = uConfig.z;
 
     float weatherLerp = clamp((uCurrentTime - uWeatherStartTime) / uTransitionDuration, 0.0, 1.0);
-    float uCloudsIntensity = mix(uIntensities[1], uTargets[1], weatherLerp);
-    float uFogIntensity = mix(uIntensities[2], uTargets[2], weatherLerp);
+    float uCloudsIntensity = mix(uIntensities[2], uTargets[2], weatherLerp);
+    float uFogIntensity = mix(uIntensities[3], uTargets[3], weatherLerp);
 
     float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
                                 0.0,
                                 1.0);
-    float currentTimeOfDayIntensity = mix(uTimeOfDayIndices.z, uTimeOfDayIndices.w, timeOfDayLerp);
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDayIndices.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDayIndices.y)];
+    float currentTimeOfDayIntensity = mix(uTimeOfDay.z, uTimeOfDay.w, timeOfDayLerp);
+    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDay.x)];
+    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDay.y)];
     vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
     uTimeOfDayColor.a *= currentTimeOfDayIntensity;
 

--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+precision highp float;
+
+layout(std140) uniform NamedColorsBlock
+{
+    vec4 uNamedColors[32];
+};
+
+layout(std140) uniform CameraBlock
+{
+    mat4 uViewProj;
+    vec4 uPlayerPos;        // xyz, w=zScale
+};
+
+layout(std140) uniform TimeBlock
+{
+    vec4 uTime; // x=time, y=delta, zw=unused
+};
+
+layout(std140) uniform WeatherBlock
+{
+    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
+    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
+    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
+    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+};
+
+uniform sampler2D uTexture;
+
+in vec3 vWorldPos;
+out vec4 vFragmentColor;
+
+float get_noise(vec2 p)
+{
+    return texture(uTexture, p / 256.0).r;
+}
+
+float fbm(vec2 p)
+{
+    float v = 0.0;
+    float a = 0.5;
+    vec2 shift = vec2(100.0);
+    for (int i = 0; i < 4; ++i) {
+        v += a * get_noise(p);
+        p = p * 2.0 + shift;
+        a *= 0.5;
+    }
+    return v;
+}
+
+void main()
+{
+    vec3 worldPos = vWorldPos;
+
+    float distToPlayer = distance(worldPos.xy, uPlayerPos.xy);
+    float localMask = smoothstep(12.0, 8.0, distToPlayer);
+
+    float uCurrentTime = uTime.x;
+    float uWeatherStartTime = uConfig.x;
+    float uTimeOfDayStartTime = uConfig.y;
+    float uTransitionDuration = uConfig.z;
+
+    float weatherLerp = clamp((uCurrentTime - uWeatherStartTime) / uTransitionDuration, 0.0, 1.0);
+    float uCloudsIntensity = mix(uIntensities[1], uTargets[1], weatherLerp);
+    float uFogIntensity = mix(uIntensities[2], uTargets[2], weatherLerp);
+
+    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
+                                0.0,
+                                1.0);
+    float currentTimeOfDayIntensity = mix(uTimeOfDayIndices.z, uTimeOfDayIndices.w, timeOfDayLerp);
+    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDayIndices.x)];
+    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDayIndices.y)];
+    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
+    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+
+    // Atmosphere overlay is now transparent by default (TimeOfDay is drawn separately)
+    vec4 result = vec4(0.0);
+
+    // Fog: soft drifting noise
+    if (uFogIntensity > 0.0) {
+        float n = fbm(worldPos.xy * 0.15 + uCurrentTime * 0.1);
+        // Density increases non-linearly with intensity
+        float density = 0.4 + uFogIntensity * 0.4;
+        vec4 fog = vec4(0.8, 0.8, 0.85, uFogIntensity * n * localMask * density);
+        // Emissive boost at night
+        fog.rgb += uTimeOfDayColor.a * 0.15;
+
+        // Blend fog over result
+        float combinedAlpha = 1.0 - (1.0 - result.a) * (1.0 - fog.a);
+        result.rgb = (result.rgb * result.a * (1.0 - fog.a) + fog.rgb * fog.a)
+                     / max(combinedAlpha, 0.001);
+        result.a = combinedAlpha;
+    }
+
+    // Clouds: puffy high-contrast noise
+    if (uCloudsIntensity > 0.0) {
+        float n = fbm(worldPos.xy * 0.06 - uCurrentTime * 0.03);
+        float puffy = smoothstep(0.45, 0.55, n);
+        // Clouds get darker and more "stormy" as intensity increases
+        float storminess = 1.0 - uCloudsIntensity * 0.4;
+        vec4 clouds = vec4(0.9 * storminess,
+                           0.9 * storminess,
+                           1.0 * storminess,
+                           uCloudsIntensity * puffy * localMask * 0.5);
+        // Emissive boost at night
+        clouds.rgb += uTimeOfDayColor.a * 0.1;
+
+        // Blend clouds over result
+        float combinedAlpha = 1.0 - (1.0 - result.a) * (1.0 - clouds.a);
+        result.rgb = (result.rgb * result.a * (1.0 - clouds.a) + clouds.rgb * clouds.a)
+                     / max(combinedAlpha, 0.001);
+        result.a = combinedAlpha;
+    }
+
+    vFragmentColor = result;
+}

--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -34,7 +34,8 @@ out vec4 vFragmentColor;
 
 float get_noise(vec2 p)
 {
-    return texture(uTexture, p / 256.0).r;
+    vec2 size = vec2(textureSize(uTexture, 0));
+    return texture(uTexture, p / size).r;
 }
 
 float fbm(vec2 p)

--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -55,7 +55,7 @@ void main()
     vec3 worldPos = vWorldPos;
 
     float distToPlayer = distance(worldPos.xy, uPlayerPos.xy);
-    float localMask = smoothstep(12.0, 8.0, distToPlayer);
+    float localMask = smoothstep(WEATHER_MASK_RADIUS_START, WEATHER_MASK_RADIUS_END, distToPlayer);
 
     float uCurrentTime = uTime.x;
     float uWeatherStartTime = uConfig.x;

--- a/src/resources/shaders/legacy/weather/atmosphere/vert.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/vert.glsl
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+layout(std140) uniform CameraBlock
+{
+    mat4 uViewProj;
+    vec4 uPlayerPos;        // xyz, w=zScale
+};
+
+out vec3 vWorldPos;
+
+void main()
+{
+    // Quad vertices 0..3 for TRIANGLE_STRIP
+    // 0: (-1, -1), 1: (1, -1), 2: (-1, 1), 3: (1, 1)
+    vec2 offset = vec2(float(gl_VertexID & 1) * 2.0 - 1.0,
+                       float((gl_VertexID >> 1) & 1) * 2.0 - 1.0);
+
+    // Large enough to cover the 12-unit radius mask (30x30 units)
+    vec2 worldXY = uPlayerPos.xy + offset * 15.0;
+    vWorldPos = vec3(worldXY, uPlayerPos.z);
+
+    // Project to screen space
+    gl_Position = uViewProj * vec4(vWorldPos.x, vWorldPos.y, vWorldPos.z * uPlayerPos.w, 1.0);
+}

--- a/src/resources/shaders/legacy/weather/atmosphere/vert.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/vert.glsl
@@ -16,8 +16,8 @@ void main()
     vec2 offset = vec2(float(gl_VertexID & 1) * 2.0 - 1.0,
                        float((gl_VertexID >> 1) & 1) * 2.0 - 1.0);
 
-    // Large enough to cover the 12-unit radius mask (30x30 units)
-    vec2 worldXY = uPlayerPos.xy + offset * 15.0;
+    // Large enough to cover the mask radius (WEATHER_RADIUS is currently 14.0)
+    vec2 worldXY = uPlayerPos.xy + offset * WEATHER_RADIUS;
     vWorldPos = vec3(worldXY, uPlayerPos.z);
 
     // Project to screen space

--- a/src/resources/shaders/legacy/weather/particle/frag.glsl
+++ b/src/resources/shaders/legacy/weather/particle/frag.glsl
@@ -5,7 +5,7 @@ precision highp float;
 
 layout(std140) uniform NamedColorsBlock
 {
-    vec4 uNamedColors[32];
+    vec4 uNamedColors[MAX_NAMED_COLORS];
 };
 
 layout(std140) uniform TimeBlock

--- a/src/resources/shaders/legacy/weather/particle/frag.glsl
+++ b/src/resources/shaders/legacy/weather/particle/frag.glsl
@@ -15,10 +15,10 @@ layout(std140) uniform TimeBlock
 
 layout(std140) uniform WeatherBlock
 {
-    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
-    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
-    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
-    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uIntensities; // rain_start, snow_start, clouds_start, fog_start
+    vec4 uTargets;     // rain_target, snow_target, clouds_target, fog_target
+    vec4 uTimeOfDay;   // x=startIdx, y=targetIdx, z=todStart, w=todTarget
+    vec4 uConfig;      // x=weatherStartTime, y=todStartTime, z=duration, w=unused
 };
 
 in float vLife;
@@ -35,15 +35,17 @@ void main()
     float uTransitionDuration = uConfig.z;
 
     float weatherLerp = clamp((uCurrentTime - uWeatherStartTime) / uTransitionDuration, 0.0, 1.0);
-    float pIntensity = mix(uIntensities.x, uTargets.x, weatherLerp);
-    float pType = mix(uIntensities.w, uTargets.w, weatherLerp);
+    float pRain = mix(uIntensities.x, uTargets.x, weatherLerp);
+    float pSnow = mix(uIntensities.y, uTargets.y, weatherLerp);
+    float pIntensity = max(pRain, pSnow);
+    float pType = pSnow / max(pIntensity, 0.001);
 
     float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
                                 0.0,
                                 1.0);
-    float currentTimeOfDayIntensity = mix(uTimeOfDayIndices.z, uTimeOfDayIndices.w, timeOfDayLerp);
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDayIndices.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDayIndices.y)];
+    float currentTimeOfDayIntensity = mix(uTimeOfDay.z, uTimeOfDay.w, timeOfDayLerp);
+    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDay.x)];
+    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDay.y)];
     vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
     uTimeOfDayColor.a *= currentTimeOfDayIntensity;
 

--- a/src/resources/shaders/legacy/weather/particle/frag.glsl
+++ b/src/resources/shaders/legacy/weather/particle/frag.glsl
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+precision highp float;
+
+layout(std140) uniform NamedColorsBlock
+{
+    vec4 uNamedColors[32];
+};
+
+layout(std140) uniform TimeBlock
+{
+    vec4 uTime; // x=time, y=delta, zw=unused
+};
+
+layout(std140) uniform WeatherBlock
+{
+    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
+    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
+    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
+    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+};
+
+in float vLife;
+in vec2 vLocalCoord;
+in float vLocalMask;
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    float uCurrentTime = uTime.x;
+    float uWeatherStartTime = uConfig.x;
+    float uTimeOfDayStartTime = uConfig.y;
+    float uTransitionDuration = uConfig.z;
+
+    float weatherLerp = clamp((uCurrentTime - uWeatherStartTime) / uTransitionDuration, 0.0, 1.0);
+    float pIntensity = mix(uIntensities.x, uTargets.x, weatherLerp);
+    float pType = mix(uIntensities.w, uTargets.w, weatherLerp);
+
+    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
+                                0.0,
+                                1.0);
+    float currentTimeOfDayIntensity = mix(uTimeOfDayIndices.z, uTimeOfDayIndices.w, timeOfDayLerp);
+    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDayIndices.x)];
+    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDayIndices.y)];
+    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
+    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+
+    float lifeFade = smoothstep(0.0, 0.15, vLife) * smoothstep(1.0, 0.85, vLife);
+
+    // Rain visuals
+    float streak = 1.0 - smoothstep(0.0, 0.15, abs(vLocalCoord.x - 0.5));
+    float rainAlpha = mix(0.4, 0.7, clamp(pIntensity, 0.0, 1.0));
+    vec4 rainColor = vec4(0.6, 0.6, 1.0, pIntensity * streak * vLocalMask * rainAlpha * lifeFade);
+    rainColor.rgb += uTimeOfDayColor.a * 0.2;
+
+    // Snow visuals
+    float dist = distance(vLocalCoord, vec2(0.5));
+    float flake = 1.0 - smoothstep(0.1, 0.2, dist);
+    float snowAlpha = mix(0.6, 0.9, clamp(pIntensity, 0.0, 1.0));
+    vec4 snowColor = vec4(1.0, 1.0, 1.1, pIntensity * flake * vLocalMask * snowAlpha * lifeFade);
+    snowColor.rgb += uTimeOfDayColor.a * 0.3;
+
+    // Interpolate visuals based on pType
+    vec4 pColor = mix(rainColor, snowColor, pType);
+
+    if (pColor.a <= 0.0) {
+        discard;
+    }
+
+    vFragmentColor = pColor;
+}

--- a/src/resources/shaders/legacy/weather/particle/vert.glsl
+++ b/src/resources/shaders/legacy/weather/particle/vert.glsl
@@ -17,10 +17,10 @@ layout(std140) uniform TimeBlock
 
 layout(std140) uniform WeatherBlock
 {
-    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
-    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
-    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
-    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uIntensities; // rain_start, snow_start, clouds_start, fog_start
+    vec4 uTargets;     // rain_target, snow_target, clouds_target, fog_target
+    vec4 uTimeOfDay;   // x=startIdx, y=targetIdx, z=todStart, w=todTarget
+    vec4 uConfig;      // x=weatherStartTime, y=todStartTime, z=duration, w=unused
 };
 
 out float vLife;
@@ -40,8 +40,10 @@ void main()
     float uTransitionDuration = uConfig.z;
 
     float weatherLerp = clamp((uCurrentTime - uWeatherStartTime) / uTransitionDuration, 0.0, 1.0);
-    float pIntensity = mix(uIntensities.x, uTargets.x, weatherLerp);
-    float pType = mix(uIntensities.w, uTargets.w, weatherLerp);
+    float pRain = mix(uIntensities.x, uTargets.x, weatherLerp);
+    float pSnow = mix(uIntensities.y, uTargets.y, weatherLerp);
+    float pIntensity = max(pRain, pSnow);
+    float pType = pSnow / max(pIntensity, 0.001);
 
     float hash = rand(float(gl_InstanceID));
 

--- a/src/resources/shaders/legacy/weather/particle/vert.glsl
+++ b/src/resources/shaders/legacy/weather/particle/vert.glsl
@@ -65,7 +65,7 @@ void main()
     vec3 worldPos = vec3(pos + quadPos * size, uPlayerPos.z);
 
     float distToPlayer = distance(pos, uPlayerPos.xy);
-    vLocalMask = smoothstep(12.0, 8.0, distToPlayer);
+    vLocalMask = smoothstep(WEATHER_MASK_RADIUS_START, WEATHER_MASK_RADIUS_END, distToPlayer);
 
     gl_Position = uViewProj * vec4(worldPos.x, worldPos.y, worldPos.z * uZScale, 1.0);
 }

--- a/src/resources/shaders/legacy/weather/particle/vert.glsl
+++ b/src/resources/shaders/legacy/weather/particle/vert.glsl
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+layout(location = 0) in vec2 aParticlePos;
+layout(location = 1) in float aLife;
+
+layout(std140) uniform CameraBlock
+{
+    mat4 uViewProj;
+    vec4 uPlayerPos;        // xyz, w=zScale
+};
+
+layout(std140) uniform TimeBlock
+{
+    vec4 uTime; // x=time, y=delta, zw=unused
+};
+
+layout(std140) uniform WeatherBlock
+{
+    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
+    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
+    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
+    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+};
+
+out float vLife;
+out vec2 vLocalCoord;
+out float vLocalMask;
+
+float rand(float n)
+{
+    return fract(sin(n) * 43758.5453123);
+}
+
+void main()
+{
+    float uCurrentTime = uTime.x;
+    float uZScale = uPlayerPos.w;
+    float uWeatherStartTime = uConfig.x;
+    float uTransitionDuration = uConfig.z;
+
+    float weatherLerp = clamp((uCurrentTime - uWeatherStartTime) / uTransitionDuration, 0.0, 1.0);
+    float pIntensity = mix(uIntensities.x, uTargets.x, weatherLerp);
+    float pType = mix(uIntensities.w, uTargets.w, weatherLerp);
+
+    float hash = rand(float(gl_InstanceID));
+
+    // Generate quad position from gl_VertexID (0..3)
+    vec2 quadPos = vec2(float(gl_VertexID & 1) - 0.5, float((gl_VertexID >> 1) & 1) - 0.5);
+
+    vLife = aLife;
+    vLocalCoord = quadPos + 0.5;
+
+    // Rain size
+    vec2 rainSize = vec2(1.0 / 12.0, 1.0 / (0.25 - clamp(pIntensity, 0.0, 2.0) * 0.1));
+    // Snow size
+    vec2 snowSize = vec2(1.0 / 4.0, 1.0 / 4.0);
+
+    vec2 size = mix(rainSize, snowSize, pType);
+    vec2 pos = aParticlePos;
+
+    // Extra swaying for snow visuals
+    pos.x += sin(uCurrentTime * 1.2 + hash * 6.28) * 0.4 * pType;
+
+    vec3 worldPos = vec3(pos + quadPos * size, uPlayerPos.z);
+
+    float distToPlayer = distance(pos, uPlayerPos.xy);
+    vLocalMask = smoothstep(12.0, 8.0, distToPlayer);
+
+    gl_Position = uViewProj * vec4(worldPos.x, worldPos.y, worldPos.z * uZScale, 1.0);
+}

--- a/src/resources/shaders/legacy/weather/particle/vert.glsl
+++ b/src/resources/shaders/legacy/weather/particle/vert.glsl
@@ -65,7 +65,7 @@ void main()
     vec3 worldPos = vec3(pos + quadPos * size, uPlayerPos.z);
 
     float distToPlayer = distance(pos, uPlayerPos.xy);
-    vLocalMask = smoothstep(WEATHER_MASK_RADIUS_START, WEATHER_MASK_RADIUS_END, distToPlayer);
+    vLocalMask = 1.0 - smoothstep(WEATHER_MASK_RADIUS_INNER, WEATHER_MASK_RADIUS_OUTER, distToPlayer);
 
     gl_Position = uViewProj * vec4(worldPos.x, worldPos.y, worldPos.z * uZScale, 1.0);
 }

--- a/src/resources/shaders/legacy/weather/simulation/frag.glsl
+++ b/src/resources/shaders/legacy/weather/simulation/frag.glsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+precision highp float;
+
+void main()
+{
+    // Dummy fragment shader for WebGL2 compatibility
+}

--- a/src/resources/shaders/legacy/weather/simulation/vert.glsl
+++ b/src/resources/shaders/legacy/weather/simulation/vert.glsl
@@ -17,10 +17,10 @@ layout(std140) uniform TimeBlock
 
 layout(std140) uniform WeatherBlock
 {
-    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
-    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
-    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
-    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+    vec4 uIntensities; // rain_start, snow_start, clouds_start, fog_start
+    vec4 uTargets;     // rain_target, snow_target, clouds_target, fog_target
+    vec4 uTimeOfDay;   // x=startIdx, y=targetIdx, z=todStart, w=todTarget
+    vec4 uConfig;      // x=weatherStartTime, y=todStartTime, z=duration, w=unused
 };
 
 out vec2 vPos;
@@ -45,8 +45,10 @@ void main()
     float uTransitionDuration = uConfig.z;
 
     float weatherLerp = clamp((uCurrentTime - uWeatherStartTime) / uTransitionDuration, 0.0, 1.0);
-    float pIntensity = mix(uIntensities.x, uTargets.x, weatherLerp);
-    float pType = mix(uIntensities.w, uTargets.w, weatherLerp); // 0=rain, 1=snow
+    float pRain = mix(uIntensities.x, uTargets.x, weatherLerp);
+    float pSnow = mix(uIntensities.y, uTargets.y, weatherLerp);
+    float pIntensity = max(pRain, pSnow);
+    float pType = pSnow / max(pIntensity, 0.001); // 0=rain, 1=snow
 
     vec2 pos = aPos;
     float life = aLife;

--- a/src/resources/shaders/legacy/weather/simulation/vert.glsl
+++ b/src/resources/shaders/legacy/weather/simulation/vert.glsl
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+layout(location = 0) in vec2 aPos;
+layout(location = 1) in float aLife;
+
+layout(std140) uniform CameraBlock
+{
+    mat4 uViewProj;
+    vec4 uPlayerPos;   // xyz, w=zScale
+};
+
+layout(std140) uniform TimeBlock
+{
+    vec4 uTime; // x=time, y=delta, zw=unused
+};
+
+layout(std140) uniform WeatherBlock
+{
+    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
+    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
+    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
+    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+};
+
+out vec2 vPos;
+out float vLife;
+
+float hash21(vec2 p)
+{
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+}
+
+float rand(float n)
+{
+    return fract(sin(n) * 43758.5453123);
+}
+
+void main()
+{
+    float hash = rand(float(gl_VertexID));
+    float uCurrentTime = uTime.x;
+    float uDeltaTime = uTime.y;
+    float uWeatherStartTime = uConfig.x;
+    float uTransitionDuration = uConfig.z;
+
+    float weatherLerp = clamp((uCurrentTime - uWeatherStartTime) / uTransitionDuration, 0.0, 1.0);
+    float pIntensity = mix(uIntensities.x, uTargets.x, weatherLerp);
+    float pType = mix(uIntensities.w, uTargets.w, weatherLerp); // 0=rain, 1=snow
+
+    vec2 pos = aPos;
+    float life = aLife;
+
+    // Rain physics
+    float rainSpeed = (15.0 + pIntensity * 10.0) + hash * 5.0;
+    float rainDecay = 0.35 + hash * 0.15;
+
+    // Snow physics
+    float snowSpeed = (0.75 + pIntensity * 0.75) + hash * 0.5;
+    float snowDecay = 0.015 + hash * 0.01;
+
+    // Interpolate physics based on pType
+    float speed = mix(rainSpeed, snowSpeed, pType);
+    float decay = mix(rainDecay, snowDecay, pType);
+
+    pos.y -= uDeltaTime * speed;
+
+    // Horizontal swaying (only for snow)
+    pos.x += sin(uCurrentTime * 1.2 + hash * 6.28) * (0.1 + pIntensity * 0.2) * pType * uDeltaTime;
+
+    life -= uDeltaTime * decay;
+
+    // Spatial fading
+    float hole = hash21(floor(pos.xy * 4.0));
+    if (hole < 0.02) {
+        life -= uDeltaTime * 2.0; // Expire quickly but not instantly
+    }
+
+    if (life <= 0.0) {
+        life = 1.0;
+        // Respawn at the top
+        float r1 = rand(hash + uCurrentTime);
+        pos.x = uPlayerPos.x + (r1 * 28.0 - 14.0);
+        pos.y = uPlayerPos.y + 14.0;
+    } else {
+        // Toroidal wrap around player (28.0x28.0 area)
+        vec2 rel = pos - uPlayerPos.xy;
+        if (rel.x < -14.0)
+            pos.x += 28.0;
+        else if (rel.x > 14.0)
+            pos.x -= 28.0;
+
+        if (rel.y < -14.0)
+            pos.y += 28.0;
+        else if (rel.y > 14.0)
+            pos.y -= 28.0;
+    }
+
+    vPos = pos;
+    vLife = life;
+    gl_Position = vec4(vPos, 0.0, 1.0);
+}

--- a/src/resources/shaders/legacy/weather/simulation/vert.glsl
+++ b/src/resources/shaders/legacy/weather/simulation/vert.glsl
@@ -80,20 +80,20 @@ void main()
         life = 1.0;
         // Respawn at the top
         float r1 = rand(hash + uCurrentTime);
-        pos.x = uPlayerPos.x + (r1 * 28.0 - 14.0);
-        pos.y = uPlayerPos.y + 14.0;
+        pos.x = uPlayerPos.x + (r1 * WEATHER_EXTENT - WEATHER_RADIUS);
+        pos.y = uPlayerPos.y + WEATHER_RADIUS;
     } else {
-        // Toroidal wrap around player (28.0x28.0 area)
+        // Toroidal wrap around player (WEATHER_EXTENT x WEATHER_EXTENT area)
         vec2 rel = pos - uPlayerPos.xy;
-        if (rel.x < -14.0)
-            pos.x += 28.0;
-        else if (rel.x > 14.0)
-            pos.x -= 28.0;
+        if (rel.x < -WEATHER_RADIUS)
+            pos.x += WEATHER_EXTENT;
+        else if (rel.x > WEATHER_RADIUS)
+            pos.x -= WEATHER_EXTENT;
 
-        if (rel.y < -14.0)
-            pos.y += 28.0;
-        else if (rel.y > 14.0)
-            pos.y -= 28.0;
+        if (rel.y < -WEATHER_RADIUS)
+            pos.y += WEATHER_EXTENT;
+        else if (rel.y > WEATHER_RADIUS)
+            pos.y -= WEATHER_EXTENT;
     }
 
     vPos = pos;

--- a/src/resources/shaders/legacy/weather/timeofday/frag.glsl
+++ b/src/resources/shaders/legacy/weather/timeofday/frag.glsl
@@ -5,7 +5,7 @@ precision highp float;
 
 layout(std140) uniform NamedColorsBlock
 {
-    vec4 uNamedColors[32];
+    vec4 uNamedColors[MAX_NAMED_COLORS];
 };
 
 layout(std140) uniform TimeBlock

--- a/src/resources/shaders/legacy/weather/timeofday/frag.glsl
+++ b/src/resources/shaders/legacy/weather/timeofday/frag.glsl
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+precision highp float;
+
+layout(std140) uniform NamedColorsBlock
+{
+    vec4 uNamedColors[32];
+};
+
+layout(std140) uniform TimeBlock
+{
+    vec4 uTime; // x=time, y=delta, zw=unused
+};
+
+layout(std140) uniform WeatherBlock
+{
+    vec4 uIntensities;      // precip_start, clouds_start, fog_start, type_start
+    vec4 uTargets;          // precip_target, clouds_target, fog_target, type_target
+    vec4 uTimeOfDayIndices; // x=startIdx, y=targetIdx, z=timeOfDayIntensityStart, w=timeOfDayIntensityTarget
+    vec4 uConfig;           // x=weatherStartTime, y=timeOfDayStartTime, z=duration, w=unused
+};
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    float uCurrentTime = uTime.x;
+    float uTimeOfDayStartTime = uConfig.y;
+    float uTransitionDuration = uConfig.z;
+
+    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDayIndices.x)];
+    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDayIndices.y)];
+
+    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
+                                0.0,
+                                1.0);
+    float currentTimeOfDayIntensity = mix(uTimeOfDayIndices.z, uTimeOfDayIndices.w, timeOfDayLerp);
+
+    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
+    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+
+    vFragmentColor = uTimeOfDayColor;
+}

--- a/src/resources/shaders/legacy/weather/timeofday/vert.glsl
+++ b/src/resources/shaders/legacy/weather/timeofday/vert.glsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+void main()
+{
+    // Full screen triangle
+    gl_Position = vec4(vec2((gl_VertexID << 1) & 2, gl_VertexID & 2) * 2.0 - 1.0, 0.0, 1.0);
+}


### PR DESCRIPTION
This PR introduces a shadow-copy mechanism in UboManager to treat UBOs as the central source of truth for global state (Weather, Camera, Time). It eliminates redundant local state members in GLWeather and FrameManager, and implements type-safe partial UBO updates using syncField and glBufferSubData for improved efficiency. WeatherBlock was also refactored to store separate rain and snow intensities.

---
*PR created automatically by Jules for task [8598037282241161576](https://jules.google.com/task/8598037282241161576) started by @nschimme*

## Summary by Sourcery

Introduce CPU-side shadow UBO copies and use them as the single source of truth for weather, time, and camera state, enabling partial, type-safe GPU updates and simplifying dependent components.

Enhancements:
- Refactor GLWeather to drive transitions and rendering directly from WeatherBlock UBO data, eliminating redundant local weather and time-of-day state.
- Extend UboManager with shadow storage for all shared UBO blocks plus helpers for full and partial sync (including syncField/syncFields and sync).
- Update WeatherBlock layout and associated shaders to treat rain and snow intensities separately while preserving existing atmospheric behavior.
- Simplify FrameManager and MapCanvas camera handling to write directly into UBO shadow blocks instead of maintaining parallel structs.