### PR TITLE
opengl: introduce UboManager with lazy UBO management and fix startup…

### DIFF
--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -241,9 +241,8 @@ void MapCanvas::initializeGL()
         .registerRebuildFunction(Legacy::SharedVboEnum::NamedColorsBlock,
                                  [](Legacy::Functions &funcs) {
                                      auto &uboManager = funcs.getUboManager();
-                                     uboManager.update(funcs,
-                                                       Legacy::SharedVboEnum::NamedColorsBlock,
-                                                       XNamedColor::getAllColorsAsVec4());
+                                     uboManager.update<Legacy::SharedVboEnum::NamedColorsBlock>(
+                                         funcs, XNamedColor::getAllColorsAsBlock());
                                  });
 
     updateMultisampling();

--- a/src/global/NamedColors.cpp
+++ b/src/global/NamedColors.cpp
@@ -3,6 +3,7 @@
 
 #include "NamedColors.h"
 
+#include "../opengl/UboBlocks.h"
 #include "EnumIndexedArray.h"
 
 #include <cassert>
@@ -17,13 +18,12 @@ struct NODISCARD GlobalData final
     using InitArray = EnumIndexedArray<bool, NamedColorEnum, NUM_NAMED_COLORS>;
     using Map = std::map<std::string, NamedColorEnum>;
     using NamesVector = std::vector<std::string>;
-    using Vec4Vector = std::vector<glm::vec4>;
 
 private:
     Map m_map;
     NamesVector m_names;
     ColorVector m_colors;
-    Vec4Vector m_vec4s;
+    Legacy::NamedColorsBlock m_colorsBlock;
     InitArray m_initialized;
 
 private:
@@ -33,7 +33,6 @@ public:
     GlobalData()
     {
         m_colors.resize(NUM_NAMED_COLORS);
-        m_vec4s.resize(MAX_NAMED_COLORS);
         m_names.resize(NUM_NAMED_COLORS);
 
         static const auto white = Colors::white;
@@ -46,7 +45,7 @@ public:
             const auto color = (id == NamedColorEnum::TRANSPARENT) ? transparent_black : white;
 
             m_colors[idx] = color;
-            m_vec4s[idx] = color.getVec4();
+            m_colorsBlock.colors[idx] = color.getVec4();
             m_names[idx] = name;
             m_map.emplace(name, id);
         };
@@ -73,7 +72,7 @@ public:
 
         const auto idx = getIndex(id);
         m_colors.at(idx) = c;
-        m_vec4s.at(idx) = c.getVec4();
+        m_colorsBlock.colors.at(idx) = c.getVec4();
         m_initialized.at(id) = true;
         return true;
     }
@@ -86,7 +85,7 @@ public:
 
     NODISCARD const std::vector<std::string> &getAllNames() const { return m_names; }
     NODISCARD const std::vector<Color> &getAllColors() const { return m_colors; }
-    NODISCARD const std::vector<glm::vec4> &getAllVec4s() const { return m_vec4s; }
+    NODISCARD const Legacy::NamedColorsBlock &getAllColorsAsBlock() const { return m_colorsBlock; }
 
 public:
     NODISCARD std::optional<NamedColorEnum> lookup(std::string_view name) const
@@ -146,7 +145,7 @@ const std::vector<Color> &XNamedColor::getAllColors()
     return getGlobalData().getAllColors();
 }
 
-const std::vector<glm::vec4> &XNamedColor::getAllColorsAsVec4()
+const Legacy::NamedColorsBlock &XNamedColor::getAllColorsAsBlock()
 {
-    return getGlobalData().getAllVec4s();
+    return getGlobalData().getAllColorsAsBlock();
 }

--- a/src/global/NamedColors.h
+++ b/src/global/NamedColors.h
@@ -9,6 +9,10 @@
 #include <string_view>
 #include <vector>
 
+namespace Legacy {
+struct NamedColorsBlock;
+}
+
 #undef TRANSPARENT // Bad dog, Microsoft; bad dog!!!
 
 // X(_id, _name)
@@ -101,6 +105,6 @@ public:
 
 public:
     NODISCARD static const std::vector<Color> &getAllColors();
-    NODISCARD static const std::vector<glm::vec4> &getAllColorsAsVec4();
+    NODISCARD static const Legacy::NamedColorsBlock &getAllColorsAsBlock();
     NODISCARD static const std::vector<std::string> &getAllNames();
 };

--- a/src/opengl/UboBlocks.h
+++ b/src/opengl/UboBlocks.h
@@ -1,0 +1,73 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "../global/NamedColors.h"
+#include "../global/utils.h"
+
+#include <array>
+#include <cstdint>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include <glm/glm.hpp>
+
+namespace Legacy {
+
+// X(EnumName, GL_String_Name)
+/**
+ * Note: SharedVboEnum values are implicitly used as UBO binding indices.
+ * They must be 0-based and contiguous.
+ */
+#define XFOREACH_SHARED_VBO(X) X(NamedColorsBlock, "NamedColorsBlock")
+
+#define X_ENUM(element, name) element,
+enum class NODISCARD SharedVboEnum : uint8_t { XFOREACH_SHARED_VBO(X_ENUM) NUM_BLOCKS };
+#undef X_ENUM
+
+static constexpr size_t NUM_SHARED_VBOS = static_cast<size_t>(SharedVboEnum::NUM_BLOCKS);
+
+inline constexpr const char *const SharedVboNames[] = {
+#define X_NAME(EnumName, StringName) StringName,
+    XFOREACH_SHARED_VBO(X_NAME)
+#undef X_NAME
+};
+
+/**
+ * @brief Memory layout for the NamedColors uniform block.
+ * Must match NamedColorsBlock in shaders (std140 layout).
+ */
+struct NODISCARD NamedColorsBlock final
+{
+    std::array<glm::vec4, MAX_NAMED_COLORS> colors{};
+};
+
+template<SharedVboEnum Block>
+struct BlockType;
+
+#define X_TYPE(EnumName, StringName) \
+    template<> \
+    struct BlockType<SharedVboEnum::EnumName> \
+    { \
+        using type = EnumName; \
+    };
+XFOREACH_SHARED_VBO(X_TYPE)
+#undef X_TYPE
+
+#define X_ASSERT(EnumName, StringName) \
+    static_assert(std::is_standard_layout_v<EnumName>, \
+                  "UBO block " #EnumName " must have standard layout for offset calculations"); \
+    static_assert(std::is_trivially_copyable_v<EnumName>, \
+                  "UBO block " #EnumName " must be trivially copyable for buffer uploads");
+XFOREACH_SHARED_VBO(X_ASSERT)
+#undef X_ASSERT
+
+template<std::size_t... Is>
+auto MakeSharedVboBlocksHelper(std::index_sequence<Is...>)
+    -> std::tuple<typename BlockType<static_cast<SharedVboEnum>(Is)>::type...>;
+
+using SharedVboBlocks = decltype(MakeSharedVboBlocksHelper(
+    std::make_index_sequence<NUM_SHARED_VBOS>{}));
+
+} // namespace Legacy

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -6,6 +6,7 @@
 #include "../global/RuleOf5.h"
 #include "../global/logging.h"
 #include "../global/utils.h"
+#include "UboBlocks.h"
 #include "legacy/Legacy.h"
 #include "legacy/VBO.h"
 
@@ -13,6 +14,7 @@
 #include <cstddef>
 #include <functional>
 #include <optional>
+#include <tuple>
 #include <type_traits>
 #include <vector>
 
@@ -37,6 +39,24 @@ public:
 
 public:
     /**
+     * @brief Accesses the CPU-side shadow copy of a UBO block by its enum.
+     */
+    template<Legacy::SharedVboEnum Block>
+    typename Legacy::BlockType<Block>::type &get()
+    {
+        return std::get<typename Legacy::BlockType<Block>::type>(m_shadowBlocks);
+    }
+
+    /**
+     * @brief Accesses the CPU-side shadow copy of a UBO block by its enum (const).
+     */
+    template<Legacy::SharedVboEnum Block>
+    const typename Legacy::BlockType<Block>::type &get() const
+    {
+        return std::get<typename Legacy::BlockType<Block>::type>(m_shadowBlocks);
+    }
+
+    /**
      * @brief Marks a UBO block as dirty by resetting its bound state.
      */
     void invalidate(Legacy::SharedVboEnum block) { m_boundBuffers[block] = std::nullopt; }
@@ -51,15 +71,31 @@ public:
 
     /**
      * @brief Registers a function that can rebuild the UBO data.
+     *
+     * @param block           UBO block identifier.
+     * @param func            Function used to rebuild the UBO data.
+     * @param allowOverwrite  If false (default), overwriting an existing rebuild function
+     *                        will trigger a debug assertion. Set to true only when an
+     *                        overwrite is intentional.
      */
-    void registerRebuildFunction(Legacy::SharedVboEnum block, RebuildFunction func)
+    void registerRebuildFunction(Legacy::SharedVboEnum block,
+                                 RebuildFunction func,
+                                 bool allowOverwrite = false)
     {
         if (m_rebuildFunctions[block]) {
-            MMLOG_WARNING() << "UboManager::registerRebuildFunction: overwriting existing "
-                               "rebuild function for UBO block "
-                            << static_cast<int>(block);
+            assert(allowOverwrite
+                   && "UboManager::registerRebuildFunction: overwriting existing "
+                      "rebuild function for UBO block");
         }
         m_rebuildFunctions[block] = std::move(func);
+    }
+
+    /**
+     * @brief Unregisters a rebuild function for a UBO block.
+     */
+    void unregisterRebuildFunction(Legacy::SharedVboEnum block)
+    {
+        m_rebuildFunctions[block] = nullptr;
     }
 
     /**
@@ -78,20 +114,26 @@ public:
         }
 
         const auto &func = m_rebuildFunctions[block];
-        assert(func && "UBO block is invalid and no rebuild function is registered");
-        if (func) {
-            func(gl);
-
-            if (const auto bound = m_boundBuffers[block]) {
-                return *bound;
-            }
-
-            MMLOG_ERROR() << "UboManager::updateIfInvalid: rebuild function failed to call "
-                             "update() for block "
-                          << static_cast<int>(block);
-            assert(false && "Rebuild function must call update()");
+        if (!func) {
+            const char *name = Legacy::Functions::getUniformBlockName(block);
+            MMLOG_ERROR() << "UboManager::updateIfInvalid: UBO block '" << name
+                          << "' is invalid and no rebuild function is registered";
+            throw std::runtime_error("UBO block '" + std::string(name)
+                                     + "' is invalid and no rebuild function is registered");
         }
-        return 0;
+
+        func(gl);
+
+        if (const auto bound = m_boundBuffers[block]) {
+            return *bound;
+        }
+
+        const char *name = Legacy::Functions::getUniformBlockName(block);
+        MMLOG_ERROR() << "UboManager::updateIfInvalid: rebuild function failed to call "
+                         "update() for block '"
+                      << name << "'";
+        throw std::runtime_error("Rebuild function for block '" + std::string(name)
+                                 + "' failed to call update()");
     }
 
     /**
@@ -123,6 +165,76 @@ public:
         Legacy::VBO &vbo = getOrCreateVbo(gl, block);
         gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW);
         return bind_internal(gl, block, vbo.get());
+    }
+
+    /**
+     * @brief Type-safe upload to a UBO.
+     * Enforces the correct data structure for the given block identifier.
+     * Also updates the shadow copy.
+     */
+    template<Legacy::SharedVboEnum Block>
+    GLuint update(Legacy::Functions &gl, const typename Legacy::BlockType<Block>::type &data)
+    {
+        get<Block>() = data;
+        return update(gl, Block, data);
+    }
+
+    /**
+     * @brief Syncs the entire shadow copy of a block to the GPU.
+     */
+    template<Legacy::SharedVboEnum Block>
+    GLuint sync(Legacy::Functions &gl)
+    {
+        return update(gl, Block, get<Block>());
+    }
+
+    /**
+     * @brief Syncs multiple specific fields of a block to the GPU in a single bind.
+     * @param gl       Legacy functions.
+     * @param members  Pointers to the members in the block struct.
+     */
+    template<Legacy::SharedVboEnum Block, typename T, typename... Us>
+    void syncFields(Legacy::Functions &gl, Us T::*...members)
+    {
+        using BlockType = typename Legacy::BlockType<Block>::type;
+        static_assert(std::is_same_v<T, BlockType>, "Members must belong to the correct block type");
+        static_assert(std::is_standard_layout_v<BlockType>,
+                      "Block type must have standard layout for offset calculation");
+
+        // If the block has never been fully uploaded, fall back to a full sync.
+        // glBufferSubData requires pre-allocated GPU storage from a prior glBufferData call.
+        if (isInvalid(Block)) {
+            sync<Block>(gl);
+            return;
+        }
+
+        const auto &blockData = get<Block>();
+        Legacy::VBO &vbo = getOrCreateVbo(gl, Block);
+        gl.glBindBuffer(GL_UNIFORM_BUFFER, vbo.get());
+
+        (gl.glBufferSubData(GL_UNIFORM_BUFFER,
+                            static_cast<GLintptr>(
+                                reinterpret_cast<std::uintptr_t>(&(blockData.*members))
+                                - reinterpret_cast<std::uintptr_t>(&blockData)),
+                            static_cast<GLsizeiptr>(sizeof(Us)),
+                            &(blockData.*members)),
+         ...);
+
+        gl.glBindBuffer(GL_UNIFORM_BUFFER, 0);
+
+        // Ensure it's bound to the correct point.
+        bind_internal(gl, Block, vbo.get());
+    }
+
+    /**
+     * @brief Syncs a specific field of a block to the GPU.
+     * @param gl      Legacy functions.
+     * @param member  Pointer to the member in the block struct.
+     */
+    template<Legacy::SharedVboEnum Block, typename T, typename U>
+    void syncField(Legacy::Functions &gl, U T::*member)
+    {
+        syncFields<Block>(gl, member);
     }
 
     /**
@@ -183,6 +295,9 @@ private:
 private:
     EnumIndexedArray<RebuildFunction, Legacy::SharedVboEnum> m_rebuildFunctions;
     EnumIndexedArray<std::optional<GLuint>, Legacy::SharedVboEnum> m_boundBuffers;
+
+    // Tuple of all block types for shadow storage.
+    Legacy::SharedVboBlocks m_shadowBlocks;
 };
 
 } // namespace Legacy

--- a/src/opengl/legacy/AbstractShaderProgram.cpp
+++ b/src/opengl/legacy/AbstractShaderProgram.cpp
@@ -5,6 +5,8 @@
 
 #include "../../global/ConfigConsts.h"
 
+#include <cassert>
+
 namespace Legacy {
 
 AbstractShaderProgram::AbstractShaderProgram(std::string dirName,

--- a/src/opengl/legacy/AbstractShaderProgram.h
+++ b/src/opengl/legacy/AbstractShaderProgram.h
@@ -5,6 +5,9 @@
 #include "Legacy.h"
 #include "VBO.h"
 
+#include <string>
+#include <unordered_map>
+
 namespace Legacy {
 
 static constexpr GLuint INVALID_ATTRIB_LOCATION = ~0u;

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -7,6 +7,7 @@
 #include "../../global/utils.h"
 #include "../OpenGLConfig.h"
 #include "../OpenGLTypes.h"
+#include "../UboBlocks.h"
 #include "FBO.h"
 
 #include <cmath>
@@ -25,35 +26,18 @@ class OpenGL;
 
 namespace Legacy {
 
-class UboManager;
 class StaticVbos;
 class SharedVbos;
 class SharedVaos;
+class UboManager;
+class VBO;
 class VAO;
 struct AbstractShaderProgram;
 struct ShaderPrograms;
 struct PointSizeBinder;
 
-// X(EnumName, GL_String_Name)
-/**
- * Note: SharedVboEnum values are implicitly used as UBO binding indices.
- * They must be 0-based and contiguous.
- */
-#define XFOREACH_SHARED_VBO(X) X(NamedColorsBlock, "NamedColorsBlock")
-
-#define X_COUNT_VBO(element, name) +1
-static constexpr size_t NUM_SHARED_VBOS = 0 XFOREACH_SHARED_VBO(X_COUNT_VBO);
-#undef X_COUNT_VBO
-
-enum class SharedVboEnum : uint8_t {
-#define X_ENUM(element, name) element,
-    XFOREACH_SHARED_VBO(X_ENUM)
-#undef X_ENUM
-        NUM_BLOCKS
-};
-
-static_assert(NUM_SHARED_VBOS > 0, "At least one shared VBO must be defined");
-static_assert(static_cast<size_t>(SharedVboEnum::NUM_BLOCKS) == NUM_SHARED_VBOS,
+static_assert(Legacy::NUM_SHARED_VBOS > 0, "At least one shared VBO must be defined");
+static_assert(static_cast<size_t>(Legacy::SharedVboEnum::NUM_BLOCKS) == Legacy::NUM_SHARED_VBOS,
               "SharedVboEnum must be 0-based and contiguous");
 
 /**
@@ -189,25 +173,12 @@ public:
     using Base::glAttachShader;
     using Base::glBindBuffer;
     using Base::glBindBufferBase;
-
-    /**
-     * @brief Binds a buffer to a uniform block binding point.
-     * @param target Must be GL_UNIFORM_BUFFER.
-     * @param block The uniform block to bind to.
-     * @param buffer The buffer ID.
-     *
-     * Note: This uses the enum value as the fixed binding point.
-     */
-    void glBindBufferBase(const GLenum target, const SharedVboEnum block, const GLuint buffer)
-    {
-        assert(target == GL_UNIFORM_BUFFER);
-        Base::glBindBufferBase(target, getUboBindingIndex(block), buffer);
-    }
     using Base::glBindTexture;
     using Base::glBindVertexArray;
     using Base::glBlendFunc;
     using Base::glBlendFuncSeparate;
     using Base::glBufferData;
+    using Base::glBufferSubData;
     using Base::glClear;
     using Base::glClearColor;
     using Base::glCompileShader;
@@ -263,10 +234,7 @@ public:
      *
      * Note: This uses the enum value as the fixed binding point.
      */
-    void glUniformBlockBinding(const GLuint program, const SharedVboEnum block)
-    {
-        virt_glUniformBlockBinding(program, block);
-    }
+    void glUniformBlockBinding(const GLuint program, const SharedVboEnum block);
 
     /**
      * @brief Automatically assigns fixed binding points to all known uniform blocks.
@@ -356,16 +324,16 @@ protected:
     NODISCARD virtual const char *virt_getShaderVersion() const = 0;
     virtual void virt_glUniformBlockBinding(GLuint program, SharedVboEnum block);
 
-protected:
+public:
     NODISCARD static const char *getUniformBlockName(SharedVboEnum block);
 
-public:
     /// platform-specific (ES vs GL)
     NODISCARD bool canRenderQuads() { return virt_canRenderQuads(); }
 
     /// platform-specific (ES vs GL)
     NODISCARD std::optional<GLenum> toGLenum(DrawModeEnum mode) { return virt_toGLenum(mode); }
 
+protected:
 private:
     template<typename T>
     static void enforceTriviallyCopyable()


### PR DESCRIPTION
… crash

Adds UboBlocks.h with NamedColorsBlock definition and UboManager with lazy UBO rebuild pattern. Fixes a crash where syncFields() called glBufferSubData on a buffer with no prior glBufferData allocation by falling back to a full sync when the block is invalid.

## Summary by Sourcery

Introduce a centralized UBO block definition and lazy UBO management with CPU-side shadow storage, and hook named colors into this system while hardening error handling.

New Features:
- Add UboBlocks definitions for shared uniform blocks, including a NamedColorsBlock layout, and derive type-safe mappings from block enums to block structures.
- Extend UboManager with CPU-side shadow copies, type-safe update/sync helpers, and fine-grained field syncing for UBOs.

Bug Fixes:
- Prevent a startup crash by falling back to a full UBO sync when attempting partial updates on blocks that have not yet been fully uploaded, and by throwing clear errors when rebuild functions are missing or misbehaving.

Enhancements:
- Move shared UBO enum definitions and metadata out of Legacy.h into a dedicated UboBlocks header and add compile-time layout checks.
- Tighten UboManager rebuild function registration with optional overwrite assertions and runtime error reporting, replacing silent failures and log-only warnings.
- Expose uniform block names and enums through Legacy::Functions for better diagnostics and binding management.
- Refactor NamedColors to maintain a NamedColorsBlock structure compatible with the new UBO system and update users to consume it.