### PR TITLE
Implement GPU-based door state rendering

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -413,6 +413,8 @@ set(mmapper_SRCS
     opengl/FontFormatFlags.h
     opengl/LineRendering.cpp
     opengl/LineRendering.h
+    opengl/GLDoors.cpp
+    opengl/GLDoors.h
     opengl/OpenGL.cpp
     opengl/OpenGL.h
     opengl/UboManager.h

--- a/src/display/Connections.cpp
+++ b/src/display/Connections.cpp
@@ -6,6 +6,7 @@
 #include "../configuration/configuration.h"
 #include "../global/Flags.h"
 #include "../map/DoorFlags.h"
+#include "../map/DoorStateEnum.h"
 #include "../map/ExitFieldVariant.h"
 #include "../mapdata/mapdata.h"
 #include "../opengl/Font.h"
@@ -293,6 +294,10 @@ void ConnectionDrawer::drawRoomConnectionsAndDoors(const RoomHandle &room)
                 if (sourceExit.exitIsDoor() && sourceExit.hasDoorName()
                     && sourceExit.doorIsHidden()) {
                     drawRoomDoorName(room, sourceDir, targetRoom, targetDir);
+                }
+
+                if (sourceExit.exitIsDoor()) {
+                    drawDoorMarker(room, sourceDir);
                 }
             }
         }
@@ -624,6 +629,8 @@ ConnectionMeshes ConnectionDrawerBuffers::getMeshes(OpenGL &gl) const
     result.redTris = gl.createColoredTriBatch(red.triVerts);
     result.normalQuads = gl.createColoredQuadBatch(normal.quadVerts);
     result.redQuads = gl.createColoredQuadBatch(red.quadVerts);
+    result.normalDoors = gl.createDoorBatch(normal.doorVerts);
+    result.redDoors = gl.createDoorBatch(red.doorVerts);
     return result;
 }
 
@@ -645,6 +652,8 @@ void ConnectionMeshes::render(const int thisLayer, const int focusedLayer) const
     redTris.render(common_style);
     normalQuads.render(common_style);
     redQuads.render(common_style);
+    normalDoors.render(common_style);
+    redDoors.render(common_style);
 }
 
 void MapCanvas::paintNearbyConnectionPoints()
@@ -791,6 +800,92 @@ void ConnectionDrawer::ConnectionFakeGL::drawTriangle(const glm::vec3 &a,
     verts.emplace_back(color, a + m_offset);
     verts.emplace_back(color, b + m_offset);
     verts.emplace_back(color, c + m_offset);
+}
+
+void ConnectionDrawer::ConnectionFakeGL::drawDoorQuad(const glm::vec3 &a,
+                                                      const glm::vec3 &b,
+                                                      const glm::vec3 &c,
+                                                      const glm::vec3 &d,
+                                                      ServerRoomId roomId,
+                                                      ExitDirEnum dir)
+{
+    auto &verts = deref(m_currentBuffer).doorVerts;
+    const uint32_t rid = roomId.asUint32();
+    const uint32_t d_idx = static_cast<uint32_t>(dir);
+    verts.emplace_back(a + m_offset, rid, d_idx);
+    verts.emplace_back(b + m_offset, rid, d_idx);
+    verts.emplace_back(c + m_offset, rid, d_idx);
+    verts.emplace_back(d + m_offset, rid, d_idx);
+}
+
+void ConnectionDrawer::drawDoorMarker(const RoomHandle &room, const ExitDirEnum dir)
+{
+    const Coordinate &pos = room.getPosition();
+    if (pos.z != m_currentLayer) {
+        return;
+    }
+
+    const float srcZ = static_cast<float>(pos.z);
+    const float roomX = static_cast<float>(pos.x);
+    const float roomY = static_cast<float>(pos.y);
+
+    m_fake.setOffset(roomX, roomY, 0.0f);
+    m_fake.setNormal(); // Doors are always "normal" for now, or match connection?
+    // Actually let's check if the exit is in red
+    if (!room.getExit(dir).exitIsExit()) {
+        m_fake.setRed();
+    }
+
+    const float doorWidth = 0.4f;
+    const float doorThickness = 0.05f;
+    const float offsetFromRoom = 0.4f;
+
+    glm::vec3 p1, p2, p3, p4;
+
+    switch (dir) {
+    case ExitDirEnum::NORTH:
+        p1 = {0.5f - doorWidth / 2, 0.5f + offsetFromRoom, srcZ};
+        p2 = {0.5f + doorWidth / 2, 0.5f + offsetFromRoom, srcZ};
+        p3 = {0.5f + doorWidth / 2, 0.5f + offsetFromRoom + doorThickness, srcZ};
+        p4 = {0.5f - doorWidth / 2, 0.5f + offsetFromRoom + doorThickness, srcZ};
+        break;
+    case ExitDirEnum::SOUTH:
+        p1 = {0.5f - doorWidth / 2, 0.5f - offsetFromRoom - doorThickness, srcZ};
+        p2 = {0.5f + doorWidth / 2, 0.5f - offsetFromRoom - doorThickness, srcZ};
+        p3 = {0.5f + doorWidth / 2, 0.5f - offsetFromRoom, srcZ};
+        p4 = {0.5f - doorWidth / 2, 0.5f - offsetFromRoom, srcZ};
+        break;
+    case ExitDirEnum::EAST:
+        p1 = {0.5f + offsetFromRoom, 0.5f - doorWidth / 2, srcZ};
+        p2 = {0.5f + offsetFromRoom + doorThickness, 0.5f - doorWidth / 2, srcZ};
+        p3 = {0.5f + offsetFromRoom + doorThickness, 0.5f + doorWidth / 2, srcZ};
+        p4 = {0.5f + offsetFromRoom, 0.5f + doorWidth / 2, srcZ};
+        break;
+    case ExitDirEnum::WEST:
+        p1 = {0.5f - offsetFromRoom - doorThickness, 0.5f - doorWidth / 2, srcZ};
+        p2 = {0.5f - offsetFromRoom, 0.5f - doorWidth / 2, srcZ};
+        p3 = {0.5f - offsetFromRoom, 0.5f + doorWidth / 2, srcZ};
+        p4 = {0.5f - offsetFromRoom - doorThickness, 0.5f + doorWidth / 2, srcZ};
+        break;
+    case ExitDirEnum::UP:
+        p1 = {0.7f, 0.7f, srcZ};
+        p2 = {0.8f, 0.7f, srcZ};
+        p3 = {0.8f, 0.8f, srcZ};
+        p4 = {0.7f, 0.8f, srcZ};
+        break;
+    case ExitDirEnum::DOWN:
+        p1 = {0.2f, 0.2f, srcZ};
+        p2 = {0.3f, 0.2f, srcZ};
+        p3 = {0.3f, 0.3f, srcZ};
+        p4 = {0.2f, 0.3f, srcZ};
+        break;
+    default:
+        m_fake.setOffset(0, 0, 0);
+        return;
+    }
+
+    m_fake.drawDoorQuad(p1, p2, p3, p4, room.getServerId(), dir);
+    m_fake.setOffset(0, 0, 0);
 }
 
 void ConnectionDrawer::ConnectionFakeGL::drawLineStrip(const std::vector<glm::vec3> &points)

--- a/src/display/Connections.cpp
+++ b/src/display/Connections.cpp
@@ -843,6 +843,9 @@ void ConnectionDrawer::drawDoorMarker(const RoomHandle &room, const ExitDirEnum 
     glm::vec3 p1, p2, p3, p4;
 
     switch (dir) {
+    case ExitDirEnum::UNKNOWN:
+    case ExitDirEnum::NONE:
+        return;
     case ExitDirEnum::NORTH:
         p1 = {0.5f - doorWidth / 2, 0.5f + offsetFromRoom, srcZ};
         p2 = {0.5f + doorWidth / 2, 0.5f + offsetFromRoom, srcZ};

--- a/src/display/Connections.h
+++ b/src/display/Connections.h
@@ -71,6 +71,7 @@ struct NODISCARD ConnectionDrawerColorBuffer final
 {
     std::vector<ColorVert> triVerts;
     std::vector<ColorVert> quadVerts;
+    std::vector<DoorVert> doorVerts;
 
     ConnectionDrawerColorBuffer() = default;
     DEFAULT_MOVES_DELETE_COPIES(ConnectionDrawerColorBuffer);
@@ -80,8 +81,12 @@ struct NODISCARD ConnectionDrawerColorBuffer final
     {
         triVerts.clear();
         quadVerts.clear();
+        doorVerts.clear();
     }
-    NODISCARD bool empty() const { return triVerts.empty() && quadVerts.empty(); }
+    NODISCARD bool empty() const
+    {
+        return triVerts.empty() && quadVerts.empty() && doorVerts.empty();
+    }
 };
 
 struct NODISCARD ConnectionMeshes final
@@ -90,6 +95,8 @@ struct NODISCARD ConnectionMeshes final
     UniqueMesh redTris;
     UniqueMesh normalQuads;
     UniqueMesh redQuads;
+    UniqueMesh normalDoors;
+    UniqueMesh redDoors;
 
     ConnectionMeshes() = default;
     DEFAULT_MOVES_DELETE_COPIES(ConnectionMeshes);
@@ -145,6 +152,12 @@ private:
     public:
         void drawTriangle(const glm::vec3 &a, const glm::vec3 &b, const glm::vec3 &c);
         void drawLineStrip(const std::vector<glm::vec3> &points);
+        void drawDoorQuad(const glm::vec3 &a,
+                          const glm::vec3 &b,
+                          const glm::vec3 &c,
+                          const glm::vec3 &d,
+                          ServerRoomId roomId,
+                          ExitDirEnum dir);
     };
 
 private:
@@ -215,6 +228,8 @@ public:
                                  float dY,
                                  float srcZ,
                                  float dstZ);
+
+    void drawDoorMarker(const RoomHandle &room, ExitDirEnum dir);
 };
 
 using BatchedConnections = std::unordered_map<int, ConnectionDrawerBuffers>;

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -73,6 +73,7 @@ MapCanvas::MapCanvas(MapData &mapData,
     , m_groupManager{groupManager}
     , m_frameManager{static_cast<QOpenGLWindow &>(*this), m_opengl.getUboManager()}
     , m_weather{m_opengl, m_data, m_textures, observer, m_frameManager}
+    , m_doors{observer, m_opengl.getUboManager()}
 {
     syncViewportConfig();
 

--- a/src/display/mapcanvas.h
+++ b/src/display/mapcanvas.h
@@ -12,6 +12,7 @@
 #include "../mapdata/roomselection.h"
 #include "../opengl/Font.h"
 #include "../opengl/FontFormatFlags.h"
+#include "../opengl/GLDoors.h"
 #include "../opengl/OpenGL.h"
 #include "../opengl/Weather.h"
 #include "FrameManager.h"
@@ -147,6 +148,7 @@ private:
     std::unique_ptr<QOpenGLDebugLogger> m_logger;
     Signal2Lifetime m_lifetime;
     GLWeather m_weather;
+    GLDoors m_doors;
 
 public:
     explicit MapCanvas(MapData &mapData,

--- a/src/map/DoorStateEnum.h
+++ b/src/map/DoorStateEnum.h
@@ -1,0 +1,11 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include <cstdint>
+
+enum class DoorStateEnum : uint8_t {
+    CLOSED = 0,
+    OPEN = 1,
+    BROKEN = 2
+};

--- a/src/map/DoorStateEnum.h
+++ b/src/map/DoorStateEnum.h
@@ -4,8 +4,4 @@
 
 #include <cstdint>
 
-enum class DoorStateEnum : uint8_t {
-    CLOSED = 0,
-    OPEN = 1,
-    BROKEN = 2
-};
+enum class DoorStateEnum : uint8_t { CLOSED = 0, OPEN = 1, BROKEN = 2 };

--- a/src/observer/gameobserver.h
+++ b/src/observer/gameobserver.h
@@ -5,7 +5,10 @@
 
 #include "../clock/mumemoment.h"
 #include "../global/Signal2.h"
+#include "../map/DoorStateEnum.h"
+#include "../map/ExitDirection.h"
 #include "../map/PromptFlags.h"
+#include "../map/roomid.h"
 #include "../proxy/GmcpMessage.h"
 
 class NODISCARD GameObserver final
@@ -26,6 +29,8 @@ public:
     Signal2<PromptWeatherEnum> sig2_weatherChanged;
     Signal2<PromptFogEnum> sig2_fogChanged;
     Signal2<MumeMoment> sig2_tick;
+
+    Signal2<ServerRoomId, ExitDirEnum, DoorStateEnum> sig2_doorStateChanged;
 
     Signal2<> sig2_gainedLevel;
 
@@ -51,6 +56,11 @@ public:
     void observeWeather(PromptWeatherEnum weather);
     void observeFog(PromptFogEnum fog);
     void observeTick(const MumeMoment &moment) { sig2_tick.invoke(moment); }
+
+    void observeDoorState(ServerRoomId id, ExitDirEnum dir, DoorStateEnum state)
+    {
+        sig2_doorStateChanged.invoke(id, dir, state);
+    }
 
     void observeGainedLevel() { sig2_gainedLevel.invoke(); }
 

--- a/src/opengl/GLDoors.cpp
+++ b/src/opengl/GLDoors.cpp
@@ -11,8 +11,8 @@ GLDoors::GLDoors(GameObserver &observer, Legacy::UboManager &uboManager)
     : m_observer{observer}
     , m_uboManager{uboManager}
 {
-    m_lifetime = m_observer.sig2_doorStateChanged.connect(
-        [this](ServerRoomId id, ExitDirEnum dir, DoorStateEnum state) {
+    m_observer.sig2_doorStateChanged
+        .connect(m_lifetime, [this](ServerRoomId id, ExitDirEnum dir, DoorStateEnum state) {
             onDoorStateChanged(id, dir, state);
         });
 

--- a/src/opengl/GLDoors.cpp
+++ b/src/opengl/GLDoors.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 The MMapper Authors
 
 #include "GLDoors.h"
+
 #include "legacy/Legacy.h"
 
 #include <algorithm>
@@ -29,8 +30,9 @@ void GLDoors::onDoorStateChanged(ServerRoomId id, ExitDirEnum dir, DoorStateEnum
     const DoorKey key{id, dir};
 
     // Find if already in deque
-    auto it = std::find_if(m_doors.begin(), m_doors.end(),
-                           [&key](const DoorEntry &e) { return e.key == key; });
+    auto it = std::find_if(m_doors.begin(), m_doors.end(), [&key](const DoorEntry &e) {
+        return e.key == key;
+    });
 
     if (state == DoorStateEnum::CLOSED) {
         if (it != m_doors.end()) {

--- a/src/opengl/GLDoors.cpp
+++ b/src/opengl/GLDoors.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "GLDoors.h"
+#include "legacy/Legacy.h"
+
+#include <algorithm>
+
+GLDoors::GLDoors(GameObserver &observer, Legacy::UboManager &uboManager)
+    : m_observer{observer}
+    , m_uboManager{uboManager}
+{
+    m_lifetime = m_observer.sig2_doorStateChanged.connect(
+        [this](ServerRoomId id, ExitDirEnum dir, DoorStateEnum state) {
+            onDoorStateChanged(id, dir, state);
+        });
+
+    m_uboManager.registerRebuildFunction(Legacy::SharedVboEnum::DoorBlock,
+                                         [this](Legacy::Functions &gl) { rebuildUbo(gl); });
+}
+
+GLDoors::~GLDoors()
+{
+    m_uboManager.unregisterRebuildFunction(Legacy::SharedVboEnum::DoorBlock);
+}
+
+void GLDoors::onDoorStateChanged(ServerRoomId id, ExitDirEnum dir, DoorStateEnum state)
+{
+    const DoorKey key{id, dir};
+
+    // Find if already in deque
+    auto it = std::find_if(m_doors.begin(), m_doors.end(),
+                           [&key](const DoorEntry &e) { return e.key == key; });
+
+    if (state == DoorStateEnum::CLOSED) {
+        if (it != m_doors.end()) {
+            m_doors.erase(it);
+            m_uboManager.invalidate(Legacy::SharedVboEnum::DoorBlock);
+        }
+    } else {
+        if (it != m_doors.end()) {
+            if (it->state != state) {
+                it->state = state;
+                m_uboManager.invalidate(Legacy::SharedVboEnum::DoorBlock);
+            }
+            // Move to newest? User agreed cascaded updates are bad, but UBO rebuild is cheap for 100 entries.
+            // Let's stick to simple FIFO/update-in-place for now as agreed.
+        } else {
+            if (m_doors.size() >= 100) {
+                m_doors.pop_front();
+            }
+            m_doors.push_back({key, state});
+            m_uboManager.invalidate(Legacy::SharedVboEnum::DoorBlock);
+        }
+    }
+}
+
+void GLDoors::rebuildUbo(Legacy::Functions &gl)
+{
+    Legacy::DoorBlock block{};
+    for (size_t i = 0; i < m_doors.size(); ++i) {
+        const auto &entry = m_doors[i];
+        block.doors[i] = glm::uvec4(entry.key.roomId.asUint32(),
+                                    static_cast<uint32_t>(entry.key.dir),
+                                    static_cast<uint32_t>(entry.state),
+                                    0);
+    }
+    // Rest of block.doors is zero-initialized (roomId=0 is invalid).
+    m_uboManager.update<Legacy::SharedVboEnum::DoorBlock>(gl, block);
+}

--- a/src/opengl/GLDoors.h
+++ b/src/opengl/GLDoors.h
@@ -1,0 +1,52 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "../global/ChangeMonitor.h"
+#include "../global/RuleOf5.h"
+#include "../map/DoorStateEnum.h"
+#include "../map/ExitDirection.h"
+#include "../map/roomid.h"
+#include "../observer/gameobserver.h"
+#include "UboBlocks.h"
+#include "UboManager.h"
+
+#include <deque>
+
+namespace Legacy {
+class Functions;
+}
+
+class NODISCARD GLDoors final
+{
+private:
+    GameObserver &m_observer;
+    Legacy::UboManager &m_uboManager;
+    ChangeMonitor::Lifetime m_lifetime;
+
+    struct DoorKey {
+        ServerRoomId roomId;
+        ExitDirEnum dir;
+
+        bool operator==(const DoorKey& other) const {
+            return roomId == other.roomId && dir == other.dir;
+        }
+    };
+
+    struct DoorEntry {
+        DoorKey key;
+        DoorStateEnum state;
+    };
+
+    std::deque<DoorEntry> m_doors; // FIFO of non-closed doors
+
+public:
+    explicit GLDoors(GameObserver &observer, Legacy::UboManager &uboManager);
+    ~GLDoors();
+
+    DELETE_CTORS_AND_ASSIGN_OPS(GLDoors);
+
+private:
+    void onDoorStateChanged(ServerRoomId id, ExitDirEnum dir, DoorStateEnum state);
+    void rebuildUbo(Legacy::Functions &gl);
+};

--- a/src/opengl/GLDoors.h
+++ b/src/opengl/GLDoors.h
@@ -24,16 +24,19 @@ private:
     Legacy::UboManager &m_uboManager;
     ChangeMonitor::Lifetime m_lifetime;
 
-    struct DoorKey {
+    struct DoorKey
+    {
         ServerRoomId roomId;
         ExitDirEnum dir;
 
-        bool operator==(const DoorKey& other) const {
+        bool operator==(const DoorKey &other) const
+        {
             return roomId == other.roomId && dir == other.dir;
         }
     };
 
-    struct DoorEntry {
+    struct DoorEntry
+    {
         DoorKey key;
         DoorStateEnum state;
     };

--- a/src/opengl/GLDoors.h
+++ b/src/opengl/GLDoors.h
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
-#include "../global/ChangeMonitor.h"
 #include "../global/RuleOf5.h"
+#include "../global/Signal2.h"
 #include "../map/DoorStateEnum.h"
 #include "../map/ExitDirection.h"
 #include "../map/roomid.h"
@@ -22,7 +22,7 @@ class NODISCARD GLDoors final
 private:
     GameObserver &m_observer;
     Legacy::UboManager &m_uboManager;
-    ChangeMonitor::Lifetime m_lifetime;
+    Signal2Lifetime m_lifetime;
 
     struct DoorKey
     {

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -175,6 +175,11 @@ void OpenGL::renderColored(const DrawModeEnum type,
     getFunctions().renderColored(type, verts, state);
 }
 
+UniqueMesh OpenGL::createDoorBatch(const std::vector<DoorVert> &batch)
+{
+    return getFunctions().createDoorBatch(batch);
+}
+
 void OpenGL::renderPoints(const std::vector<ColorVert> &verts, const GLRenderState &state)
 {
     getFunctions().renderPoints(verts, state);

--- a/src/opengl/OpenGL.h
+++ b/src/opengl/OpenGL.h
@@ -97,6 +97,8 @@ public:
     NODISCARD UniqueMesh createRoomQuadTexBatch(const std::vector<RoomQuadTexVert> &verts,
                                                 MMTextureId texture);
 
+    NODISCARD UniqueMesh createDoorBatch(const std::vector<DoorVert> &batch);
+
 public:
     NODISCARD UniqueMesh createFontMesh(const SharedMMTexture &texture,
                                         DrawModeEnum mode,

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -42,6 +42,19 @@ struct NODISCARD TexVert final
     {}
 };
 
+struct NODISCARD DoorVert final
+{
+    glm::vec3 vert{};
+    uint32_t roomId = 0;
+    uint32_t direction = 0;
+
+    explicit DoorVert(const glm::vec3 &vert_, uint32_t roomId_, uint32_t direction_)
+        : vert{vert_}
+        , roomId{roomId_}
+        , direction{direction_}
+    {}
+};
+
 using TexVertVector = std::vector<TexVert>;
 
 struct NODISCARD ColoredTexVert final

--- a/src/opengl/UboBlocks.h
+++ b/src/opengl/UboBlocks.h
@@ -24,7 +24,8 @@ namespace Legacy {
     X(NamedColorsBlock, "NamedColorsBlock") \
     X(CameraBlock, "CameraBlock") \
     X(TimeBlock, "TimeBlock") \
-    X(WeatherBlock, "WeatherBlock")
+    X(WeatherBlock, "WeatherBlock") \
+    X(DoorBlock, "DoorBlock")
 
 #define X_ENUM(element, name) element,
 enum class NODISCARD SharedVboEnum : uint8_t { XFOREACH_SHARED_VBO(X_ENUM) NUM_BLOCKS };
@@ -76,6 +77,16 @@ struct NODISCARD WeatherBlock final
 struct NODISCARD NamedColorsBlock final
 {
     std::array<glm::vec4, MAX_NAMED_COLORS> colors{};
+};
+
+/**
+ * @brief Memory layout for the Door uniform block.
+ * Must match DoorBlock in shaders (std140 layout).
+ */
+struct NODISCARD DoorBlock final
+{
+    // x = roomId, y = direction, z = state, w = unused
+    std::array<glm::uvec4, 100> doors{};
 };
 
 template<SharedVboEnum Block>

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -156,7 +156,7 @@ UniqueMesh Functions::createDoorBatch(const std::vector<DoorVert> &batch)
 {
     const auto mode = DrawModeEnum::QUADS;
     const auto &prog = getShaderPrograms().getDoorShader();
-    return createMesh<DoorMesh>(shared_from_this(), mode, batch, prog);
+    return createUniqueMesh<DoorMesh>(shared_from_this(), mode, batch, prog);
 }
 
 template<typename VertexType_, template<typename> typename Mesh_, typename ShaderType_>

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -152,6 +152,13 @@ UniqueMesh Functions::createRoomQuadTexBatch(const std::vector<RoomQuadTexVert> 
     return createTexturedMesh<RoomQuadTexMesh>(shared_from_this(), mode, batch, prog, texture);
 }
 
+UniqueMesh Functions::createDoorBatch(const std::vector<DoorVert> &batch)
+{
+    const auto mode = DrawModeEnum::QUADS;
+    const auto &prog = getShaderPrograms().getDoorShader();
+    return createMesh<DoorMesh>(shared_from_this(), mode, batch, prog);
+}
+
 template<typename VertexType_, template<typename> typename Mesh_, typename ShaderType_>
 static void renderImmediate(const SharedFunctions &sharedFunctions,
                             const DrawModeEnum mode,

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -443,6 +443,8 @@ public:
     NODISCARD UniqueMesh createRoomQuadTexBatch(const std::vector<RoomQuadTexVert> &batch,
                                                 MMTextureId texture);
 
+    NODISCARD UniqueMesh createDoorBatch(const std::vector<DoorVert> &batch);
+
 public:
     NODISCARD UniqueMesh createFontMesh(const SharedMMTexture &texture,
                                         DrawModeEnum mode,

--- a/src/opengl/legacy/Meshes.h
+++ b/src/opengl/legacy/Meshes.h
@@ -63,6 +63,66 @@ private:
     }
 };
 
+// Door markers
+template<typename VertexType_>
+class NODISCARD DoorMesh final : public SimpleMesh<VertexType_, DoorShader>
+{
+public:
+    using Base = SimpleMesh<VertexType_, DoorShader>;
+    using Base::Base;
+
+private:
+    struct NODISCARD Attribs final
+    {
+        GLuint vertPos = INVALID_ATTRIB_LOCATION;
+        GLuint roomIdPos = INVALID_ATTRIB_LOCATION;
+        GLuint directionPos = INVALID_ATTRIB_LOCATION;
+
+        NODISCARD static Attribs getLocations(DoorShader &shader)
+        {
+            Attribs result;
+            result.vertPos = shader.getAttribLocation("aVert");
+            result.roomIdPos = shader.getAttribLocation("aRoomId");
+            result.directionPos = shader.getAttribLocation("aDirection");
+            return result;
+        }
+    };
+
+    std::optional<Attribs> m_boundAttribs;
+
+    void virt_bind() override
+    {
+        const auto vertSize = static_cast<GLsizei>(sizeof(VertexType_));
+        static_assert(sizeof(std::declval<VertexType_>().vert) == 3 * sizeof(GLfloat));
+        static_assert(sizeof(std::declval<VertexType_>().roomId) == sizeof(uint32_t));
+        static_assert(sizeof(std::declval<VertexType_>().direction) == sizeof(uint32_t));
+
+        Functions &gl = Base::m_functions;
+        const auto attribs = Attribs::getLocations(Base::m_program);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, Base::m_vbo.get());
+        gl.enableAttrib(attribs.vertPos, 3, GL_FLOAT, GL_FALSE, vertSize, VPO(vert));
+        gl.enableAttribI(attribs.roomIdPos, 1, GL_UNSIGNED_INT, vertSize, VPO(roomId));
+        gl.enableAttribI(attribs.directionPos, 1, GL_UNSIGNED_INT, vertSize, VPO(direction));
+        m_boundAttribs = attribs;
+    }
+
+    void virt_unbind() override
+    {
+        if (!m_boundAttribs) {
+            assert(false);
+            return;
+        }
+
+        auto &attribs = m_boundAttribs.value();
+        Functions &gl = Base::m_functions;
+        gl.glDisableVertexAttribArray(attribs.vertPos);
+        gl.glDisableVertexAttribArray(attribs.roomIdPos);
+        gl.glDisableVertexAttribArray(attribs.directionPos);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, 0);
+        m_boundAttribs.reset();
+    }
+};
+
 // Per-vertex color
 // flat-shaded in MMapper, due to glShadeModel(GL_FLAT)
 template<typename VertexType_>

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -43,6 +43,7 @@ AtmosphereShader::~AtmosphereShader() = default;
 TimeOfDayShader::~TimeOfDayShader() = default;
 ParticleSimulationShader::~ParticleSimulationShader() = default;
 ParticleRenderShader::~ParticleRenderShader() = default;
+DoorShader::~DoorShader() = default;
 
 void ShaderPrograms::early_init()
 {
@@ -61,6 +62,7 @@ void ShaderPrograms::early_init()
     std::ignore = getTimeOfDayShader();
     std::ignore = getParticleSimulationShader();
     std::ignore = getParticleRenderShader();
+    std::ignore = getDoorShader();
 }
 
 void ShaderPrograms::resetAll()
@@ -80,6 +82,7 @@ void ShaderPrograms::resetAll()
     m_timeOfDay.reset();
     m_particleSimulation.reset();
     m_particleRender.reset();
+    m_door.reset();
 }
 
 // essentially a private member of ShaderPrograms
@@ -204,6 +207,11 @@ const std::shared_ptr<ParticleRenderShader> &ShaderPrograms::getParticleRenderSh
     return getInitialized<ParticleRenderShader>(m_particleRender,
                                                 getFunctions(),
                                                 "weather/particle");
+}
+
+const std::shared_ptr<DoorShader> &ShaderPrograms::getDoorShader()
+{
+    return getInitialized<DoorShader>(m_door, getFunctions(), "door");
 }
 
 } // namespace Legacy

--- a/src/opengl/legacy/Shaders.h
+++ b/src/opengl/legacy/Shaders.h
@@ -210,6 +210,21 @@ private:
     {}
 };
 
+struct NODISCARD DoorShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~DoorShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms) final
+    {
+        setColor("uColor", uniforms.color);
+        setMatrix("uMVP", mvp);
+    }
+};
+
 /* owned by Functions */
 struct NODISCARD ShaderPrograms final
 {
@@ -234,6 +249,7 @@ private:
     std::shared_ptr<TimeOfDayShader> m_timeOfDay;
     std::shared_ptr<ParticleSimulationShader> m_particleSimulation;
     std::shared_ptr<ParticleRenderShader> m_particleRender;
+    std::shared_ptr<DoorShader> m_door;
 
 public:
     explicit ShaderPrograms(Functions &functions)
@@ -270,6 +286,7 @@ public:
     NODISCARD const std::shared_ptr<TimeOfDayShader> &getTimeOfDayShader();
     NODISCARD const std::shared_ptr<ParticleSimulationShader> &getParticleSimulationShader();
     NODISCARD const std::shared_ptr<ParticleRenderShader> &getParticleRenderShader();
+    NODISCARD const std::shared_ptr<DoorShader> &getDoorShader();
 
 public:
     void early_init();

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -3,6 +3,7 @@
 
 #include "../global/CaseUtils.h"
 #include "../group/mmapper2group.h"
+#include "../map/DoorStateEnum.h"
 #include "../map/ExitsFlags.h"
 #include "../map/ParseTree.h"
 #include "../map/PromptFlags.h"
@@ -43,6 +44,8 @@ void MumeXmlParser::slot_parseGmcpInput(const GmcpMessage &msg)
         parseGmcpEventMoved(obj);
     } else if (msg.isRoomInfo()) {
         parseGmcpRoomInfo(obj);
+    } else if (msg.isRoomUpdateExits()) {
+        parseGmcpUpdateExits(obj);
     }
 }
 
@@ -177,7 +180,6 @@ NODISCARD static RoomDesc getRoomDesc(const JsonObj &obj)
 
 struct NODISCARD Misc final
 {
-    enum class DoorStateEnum { CLOSED, OPEN, BROKEN };
     using DoorStates = EnumIndexedArray<DoorStateEnum, ExitDirEnum, NUM_EXITS>;
     DoorStates doors{};
     RawExits exits{};
@@ -189,14 +191,14 @@ static void processOneFlag(const QString &flag,
                            const ExitDirEnum d,
                            RawExit &exit,
                            ConnectedRoomFlagsType &connectedRoomFlags,
-                           Misc::DoorStateEnum &door)
+                           DoorStateEnum &door)
 {
     if (flag == "hidden") {
         exit.addDoorFlags(DoorFlagEnum::HIDDEN);
     } else if (flag == "broken") {
-        door = Misc::DoorStateEnum::BROKEN;
+        door = DoorStateEnum::BROKEN;
     } else if (flag == "closed") {
-        door = Misc::DoorStateEnum::CLOSED;
+        door = DoorStateEnum::CLOSED;
     } else if (flag == "climb-down" || flag == "climb-up") {
         exit.addExitFlags(ExitFlagEnum::CLIMB);
     } else if (flag == "road" || flag == "trail") {
@@ -251,7 +253,7 @@ NODISCARD static Misc getMisc(const JsonObj &obj, const ServerRoomId room, bool 
             currentExit.addExitFlags(ExitFlagEnum::DOOR);
             currentExit.setDoorName(mmqt::makeDoorName(doorName));
             auto &currentDoor = result.doors.at(d);
-            currentDoor = Misc::DoorStateEnum::OPEN;
+            currentDoor = DoorStateEnum::OPEN;
         }
 
         const auto optFlags = exit.getArray("flags");
@@ -273,7 +275,7 @@ NODISCARD static Misc getMisc(const JsonObj &obj, const ServerRoomId room, bool 
         for (const ExitDirEnum alt_dir : ALL_EXITS_NESWUD) {
             const auto &eThisExit = result.exits[alt_dir];
             const auto eThisClosed = eThisExit.exitIsDoor()
-                                     && result.doors.at(alt_dir) == Misc::DoorStateEnum::CLOSED;
+                                 && result.doors.at(alt_dir) == DoorStateEnum::CLOSED;
 
             // Do not flag indirect sunlight if there was a closed door, no exit, or we saw direct sunlight
             if (!eThisExit.exitIsExit() || eThisClosed
@@ -389,5 +391,54 @@ void MumeXmlParser::parseGmcpRoomInfo(const JsonObj &obj)
     m_commonData.roomExits = misc.exits;
     m_commonData.exitIds = misc.exitIds;
 
+    for (const ExitDirEnum d : ALL_EXITS_NESWUD) {
+        if (m_commonData.roomExits[d].exitIsDoor()) {
+            m_observer.observeDoorState(m_serverId, d, misc.doors.at(d));
+        }
+    }
+
     m_eventReady = true;
+}
+
+void MumeXmlParser::parseGmcpUpdateExits(const JsonObj &obj)
+{
+    using namespace mume_xml_parser_gmcp_detail;
+    if (m_serverId == INVALID_SERVER_ROOMID) {
+        return;
+    }
+
+    // Room.Update.Exits payload: {"exits": {"n": {"flags": ["closed"]}}}
+    auto exits = obj.getObject("exits");
+    if (!exits) {
+        return;
+    }
+
+    for (const ExitDirEnum d : ALL_EXITS_NESWUD) {
+        const char dir[2] = {lowercaseDirection(d)[0], char_consts::C_NUL};
+        const auto optExit = exits->getObject(dir);
+        if (!optExit) {
+            continue;
+        }
+
+        const JsonObj &exit = *optExit;
+        const auto optFlags = exit.getArray("flags");
+        if (!optFlags) {
+            continue;
+        }
+
+        DoorStateEnum door = DoorStateEnum::OPEN; // Default to open if name exists but no flags?
+        // Actually MUME only sends flags if they changed, but we need to know if it's a door.
+        // If we get an update for it, it should be a door.
+        for (const JsonValue &pflag : *optFlags) {
+            if (auto optString = pflag.getString()) {
+                const QString flag = optString.value();
+                if (flag == "broken") {
+                    door = DoorStateEnum::BROKEN;
+                } else if (flag == "closed") {
+                    door = DoorStateEnum::CLOSED;
+                }
+            }
+        }
+        m_observer.observeDoorState(m_serverId, d, door);
+    }
 }

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -275,7 +275,7 @@ NODISCARD static Misc getMisc(const JsonObj &obj, const ServerRoomId room, bool 
         for (const ExitDirEnum alt_dir : ALL_EXITS_NESWUD) {
             const auto &eThisExit = result.exits[alt_dir];
             const auto eThisClosed = eThisExit.exitIsDoor()
-                                 && result.doors.at(alt_dir) == DoorStateEnum::CLOSED;
+                                     && result.doors.at(alt_dir) == DoorStateEnum::CLOSED;
 
             // Do not flag indirect sunlight if there was a closed door, no exit, or we saw direct sunlight
             if (!eThisExit.exitIsExit() || eThisClosed

--- a/src/parser/mumexmlparser.h
+++ b/src/parser/mumexmlparser.h
@@ -106,4 +106,5 @@ private:
     void parseGmcpCharVitals(const JsonObj &obj);
     void parseGmcpEventMoved(const JsonObj &obj);
     void parseGmcpRoomInfo(const JsonObj &obj);
+    void parseGmcpUpdateExits(const JsonObj &obj);
 };

--- a/src/resources/mmapper2.qrc
+++ b/src/resources/mmapper2.qrc
@@ -237,5 +237,7 @@
         <file>shaders/legacy/weather/simulation/vert.glsl</file>
         <file>shaders/legacy/weather/timeofday/frag.glsl</file>
         <file>shaders/legacy/weather/timeofday/vert.glsl</file>
+        <file>shaders/legacy/door/frag.glsl</file>
+        <file>shaders/legacy/door/vert.glsl</file>
     </qresource>
 </RCC>

--- a/src/resources/shaders/legacy/door/frag.glsl
+++ b/src/resources/shaders/legacy/door/frag.glsl
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+uniform vec4 uColor;
+
+in float vAlpha;
+
+out vec4 fColor;
+
+void main()
+{
+    fColor = vec4(uColor.rgb, uColor.a * vAlpha);
+}

--- a/src/resources/shaders/legacy/door/vert.glsl
+++ b/src/resources/shaders/legacy/door/vert.glsl
@@ -9,22 +9,26 @@ layout(location = 2) in uint aDirection;
 
 out float vAlpha;
 
-struct DoorEntry {
+struct DoorEntry
+{
     uint roomId;
     uint direction;
     uint state;
     uint unused;
 };
 
-layout(std140) uniform DoorBlock {
+layout(std140) uniform DoorBlock
+{
     DoorEntry doors[100];
-} uDoors;
+}
+uDoors;
 
 void main()
 {
     vAlpha = 1.0;
     for (int i = 0; i < 100; ++i) {
-        if (uDoors.doors[i].roomId == 0u) break;
+        if (uDoors.doors[i].roomId == 0u)
+            break;
         if (uDoors.doors[i].roomId == aRoomId && uDoors.doors[i].direction == aDirection) {
             // State: 0=CLOSED, 1=OPEN, 2=BROKEN
             // Open or broken doors are mostly transparent

--- a/src/resources/shaders/legacy/door/vert.glsl
+++ b/src/resources/shaders/legacy/door/vert.glsl
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+uniform mat4 uMVP;
+
+layout(location = 0) in vec3 aVert;
+layout(location = 1) in uint aRoomId;
+layout(location = 2) in uint aDirection;
+
+out float vAlpha;
+
+struct DoorEntry {
+    uint roomId;
+    uint direction;
+    uint state;
+    uint unused;
+};
+
+layout(std140) uniform DoorBlock {
+    DoorEntry doors[100];
+} uDoors;
+
+void main()
+{
+    vAlpha = 1.0;
+    for (int i = 0; i < 100; ++i) {
+        if (uDoors.doors[i].roomId == 0u) break;
+        if (uDoors.doors[i].roomId == aRoomId && uDoors.doors[i].direction == aDirection) {
+            // State: 0=CLOSED, 1=OPEN, 2=BROKEN
+            // Open or broken doors are mostly transparent
+            if (uDoors.doors[i].state != 0u) {
+                vAlpha = 0.2;
+            }
+            break;
+        }
+    }
+    gl_Position = uMVP * vec4(aVert, 1.0);
+}


### PR DESCRIPTION
This task involved designing and implementing a system to render door states (open/closed/broken) on the map, with the state stored and processed on the GPU using a Uniform Buffer Object (UBO).

Major components:
1.  **State Management**: `GLDoors` class manages a 100-entry FIFO of doors that are not in the default 'CLOSED' state. It communicates with the GPU via the `DoorBlock` UBO.
2.  **GMCP Integration**: The parser was enhanced to extract door state information from MUME's GMCP messages and propagate it via signals.
3.  **GPU Rendering**: A new shader-based rendering path was added for door markers. The vertex shader performs a lookup in the `DoorBlock` UBO using room ID and exit direction to determine the door's current state and adjust its visual representation (alpha transparency).
4.  **Architectural Alignment**: The implementation follows the project's existing patterns for UBO management, batch rendering, and observer-based updates.

---
*PR created automatically by Jules for task [6408329742008029072](https://jules.google.com/task/6408329742008029072) started by @nschimme*

## Summary by Sourcery

Render door markers on the map using GPU-side door state stored in a uniform buffer and kept in sync with live GMCP exit updates.

New Features:
- Draw per-exit door markers for rooms using a dedicated door mesh and shader pipeline.
- Track and propagate door state changes (open/closed/broken) from GMCP messages through GameObserver to the renderer via a DoorBlock UBO.

Enhancements:
- Introduce a shared DoorStateEnum and door-state signal to centralize door status handling across parser, observer, and rendering layers.
- Extend the OpenGL legacy infrastructure with a DoorShader, DoorVert vertex format, and DoorMesh support for batched door rendering.