### PR TITLE
Fix KDE Neon GPG key retrieval in AppImage build workflow

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Add KDE Neon repository
       run: |
-        wget -qO - https://archive.neon.kde.org/public.key | sudo gpg --dearmor -o /usr/share/keyrings/kde-neon.gpg
+        curl -sSfL --retry 5 --retry-delay 5 https://archive.neon.kde.org/public.key | sudo gpg --dearmor --yes -o /usr/share/keyrings/kde-neon.gpg
         echo "deb [signed-by=/usr/share/keyrings/kde-neon.gpg] http://archive.neon.kde.org/user jammy main" | sudo tee /etc/apt/sources.list.d/kde-neon.list
         sudo apt update -qq
 


### PR DESCRIPTION
This change fixes a build failure in the `.github/workflows/build-appimage.yml` workflow where the step to add the KDE Neon repository was failing due to an empty or invalid GPG key download. By switching to `curl -sSfL` with retries and specific `gpg` flags, the process becomes more resilient to network flakiness and server-side errors.

---
*PR created automatically by Jules for task [12019726563005072585](https://jules.google.com/task/12019726563005072585) started by @nschimme*

## Summary by Sourcery

CI:
- Harden KDE Neon GPG key download in the AppImage build workflow by switching to curl with retries and safer gpg invocation.