### PR TITLE
media: fix memory leak and handle errors in WASM music playback

### DIFF
--- a/src/media/MusicManager.cpp
+++ b/src/media/MusicManager.cpp
@@ -19,6 +19,8 @@
 #include <QTemporaryFile>
 #include <QTimer>
 
+#include <memory>
+
 MusicManager::MusicManager(MediaLibrary &library, QObject *const parent)
     : QObject(parent)
     , m_library(library)
@@ -135,25 +137,26 @@ void MusicManager::playMusic(const QString &musicFile)
         }
         m_library.fetchAsync(musicFile, [this, musicFile, playMusic2](const QByteArray &data) {
             if (data.isEmpty()) {
+                qWarning() << "MusicManager: received empty data for" << musicFile
+                           << "- skipping playback";
                 return;
             }
-            QTemporaryFile *tempFile = new QTemporaryFile(QDir::tempPath() + "/mmapper_XXXXXX."
-                                                          + QFileInfo(musicFile).suffix());
+            auto tempFile = std::make_unique<QTemporaryFile>(QDir::tempPath() + "/mmapper_XXXXXX."
+                                                             + QFileInfo(musicFile).suffix());
             if (!tempFile->open()) {
                 qWarning() << "MusicManager: failed to create temp file for" << musicFile;
-                delete tempFile;
                 return;
             }
             const qint64 bytesWritten = tempFile->write(data);
             if (bytesWritten != static_cast<qint64>(data.size())) {
                 qWarning() << "MusicManager: failed to write temp file for" << musicFile
                            << "- expected" << data.size() << "bytes, wrote" << bytesWritten;
-                delete tempFile;
                 return;
             }
             tempFile->close();
-            m_wasmFiles.insert(musicFile, tempFile);
-            playMusic2(QUrl::fromLocalFile(tempFile->fileName()));
+            const QString fileName = tempFile->fileName();
+            m_wasmFiles.insert(musicFile, tempFile.release());
+            playMusic2(QUrl::fromLocalFile(fileName));
         });
         return;
     }

--- a/src/media/MusicManager.cpp
+++ b/src/media/MusicManager.cpp
@@ -14,12 +14,12 @@
 #include <QUrl>
 #endif
 
+#include <memory>
+
 #include <QDir>
 #include <QFileInfo>
 #include <QTemporaryFile>
 #include <QTimer>
-
-#include <memory>
 
 MusicManager::MusicManager(MediaLibrary &library, QObject *const parent)
     : QObject(parent)

--- a/src/media/MusicManager.cpp
+++ b/src/media/MusicManager.cpp
@@ -134,16 +134,22 @@ void MusicManager::playMusic(const QString &musicFile)
             return;
         }
         m_library.fetchAsync(musicFile, [this, musicFile, playMusic2](const QByteArray &data) {
+            if (data.isEmpty()) {
+                return;
+            }
             QTemporaryFile *tempFile = new QTemporaryFile(QDir::tempPath() + "/mmapper_XXXXXX."
                                                           + QFileInfo(musicFile).suffix());
             if (!tempFile->open()) {
                 qWarning() << "MusicManager: failed to create temp file for" << musicFile;
+                delete tempFile;
                 return;
             }
             const qint64 bytesWritten = tempFile->write(data);
             if (bytesWritten != static_cast<qint64>(data.size())) {
                 qWarning() << "MusicManager: failed to write temp file for" << musicFile
                            << "- expected" << data.size() << "bytes, wrote" << bytesWritten;
+                delete tempFile;
+                return;
             }
             tempFile->close();
             m_wasmFiles.insert(musicFile, tempFile);


### PR DESCRIPTION
Address code review comments for WASM music fetching in MusicManager. This change adds an early return for empty data, ensures QTemporaryFile is deleted on open() failure to prevent memory leaks, and handles partial or failed writes by deleting the temp file and returning early to avoid playing truncated audio.

---
*PR created automatically by Jules for task [13816465392684563086](https://jules.google.com/task/13816465392684563086) started by @nschimme*

## Summary by Sourcery

Improve robustness of WASM music playback by validating fetched data and managing temporary files more safely.

Bug Fixes:
- Prevent memory leaks by using RAII for temporary music files and ensuring they are cleaned up on failures.
- Avoid attempting to play music when the fetched WASM data is empty or when writing to the temporary file fails or is incomplete.