### PR TITLE
Persist audio unlock state for non-Wasm platforms

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,8 +10,8 @@ set(mmapper_SRCS
     adventure/lineparsers.h
     adventure/xpstatuswidget.cpp
     adventure/xpstatuswidget.h
-    client/AudioHintWidget.cpp
-    client/AudioHintWidget.h
+    display/AudioHintWidget.cpp
+    display/AudioHintWidget.h
     media/AudioManager.cpp
     media/AudioManager.h
     media/DescriptionWidget.cpp

--- a/src/client/ClientWidget.cpp
+++ b/src/client/ClientWidget.cpp
@@ -51,11 +51,6 @@ ClientWidget::ClientWidget(ConnectionListener &listener,
     if constexpr (CURRENT_PLATFORM == PlatformEnum::Wasm) {
         ui.playButton->click();
     }
-
-    auto &cfg = getConfig().audio;
-    if (NO_AUDIO || cfg.isUnlocked() || (cfg.getMusicVolume() == 0 && cfg.getSoundVolume() == 0)) {
-        ui.audioHint->setVisible(false);
-    }
 }
 
 ClientWidget::~ClientWidget() = default;

--- a/src/client/ClientWidget.cpp
+++ b/src/client/ClientWidget.cpp
@@ -53,8 +53,7 @@ ClientWidget::ClientWidget(ConnectionListener &listener,
     }
 
     auto &cfg = getConfig().audio;
-    if (NO_AUDIO || CURRENT_PLATFORM != PlatformEnum::Wasm
-        || (cfg.getMusicVolume() == 0 && cfg.getSoundVolume() == 0)) {
+    if (NO_AUDIO || cfg.isUnlocked() || (cfg.getMusicVolume() == 0 && cfg.getSoundVolume() == 0)) {
         ui.audioHint->setVisible(false);
     }
 }

--- a/src/client/ClientWidget.ui
+++ b/src/client/ClientWidget.ui
@@ -343,8 +343,6 @@
         <bool>true</bool>
        </property>
       </widget>
-      <widget class="AudioHintWidget" name="audioHint">
-      </widget>
       <widget class="StackedInputWidget" name="input" native="true"/>
      </widget>
     </widget>
@@ -368,12 +366,6 @@
    <class>PreviewWidget</class>
    <extends>QTextEdit</extends>
    <header>client/PreviewWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>AudioHintWidget</class>
-   <extends>QWidget</extends>
-   <header>client/AudioHintWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -270,6 +270,7 @@ ConstString KEY_MAP_MODE = "Map Mode";
 ConstString KEY_MUSIC_VOLUME = "Music volume";
 ConstString KEY_SOUND_VOLUME = "Sound volume";
 ConstString KEY_AUDIO_OUTPUT_DEVICE = "Audio output device";
+ConstString KEY_AUDIO_UNLOCKED = "Audio unlocked";
 ConstString KEY_MAXIMUM_NUMBER_OF_PATHS = "maximum number of paths";
 ConstString KEY_MULTIPLE_CONNECTIONS_PENALTY = "multiple connections penalty";
 ConstString KEY_MUME_START_EPOCH = "Mume start epoch";
@@ -772,7 +773,11 @@ void Configuration::AdventurePanelSettings::read(const QSettings &conf)
 
 void Configuration::AudioSettings::read(const QSettings &conf)
 {
-    m_unlocked = (CURRENT_PLATFORM != PlatformEnum::Wasm);
+    if constexpr (CURRENT_PLATFORM == PlatformEnum::Wasm) {
+        m_unlocked = false;
+    } else {
+        m_unlocked = conf.value(KEY_AUDIO_UNLOCKED, false).toBool();
+    }
     m_musicVolume = std::clamp(conf.value(KEY_MUSIC_VOLUME, 50).toInt(), 0, 100);
     m_soundVolume = std::clamp(conf.value(KEY_SOUND_VOLUME, 50).toInt(), 0, 100);
     m_outputDeviceId = conf.value(KEY_AUDIO_OUTPUT_DEVICE).toByteArray();
@@ -957,6 +962,9 @@ void Configuration::AdventurePanelSettings::write(QSettings &conf) const
 
 void Configuration::AudioSettings::write(QSettings &conf) const
 {
+    if constexpr (CURRENT_PLATFORM != PlatformEnum::Wasm) {
+        conf.setValue(KEY_AUDIO_UNLOCKED, m_unlocked);
+    }
     conf.setValue(KEY_MUSIC_VOLUME, m_musicVolume);
     conf.setValue(KEY_SOUND_VOLUME, m_soundVolume);
     conf.setValue(KEY_AUDIO_OUTPUT_DEVICE, m_outputDeviceId);

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -773,11 +773,9 @@ void Configuration::AdventurePanelSettings::read(const QSettings &conf)
 
 void Configuration::AudioSettings::read(const QSettings &conf)
 {
-    if constexpr (CURRENT_PLATFORM == PlatformEnum::Wasm) {
-        m_unlocked = false;
-    } else {
-        m_unlocked = conf.value(KEY_AUDIO_UNLOCKED, false).toBool();
-    }
+    m_unlocked = (CURRENT_PLATFORM == PlatformEnum::Wasm)
+                     ? false
+                     : conf.value(KEY_AUDIO_UNLOCKED, false).toBool();
     m_musicVolume = std::clamp(conf.value(KEY_MUSIC_VOLUME, 50).toInt(), 0, 100);
     m_soundVolume = std::clamp(conf.value(KEY_SOUND_VOLUME, 50).toInt(), 0, 100);
     m_outputDeviceId = conf.value(KEY_AUDIO_OUTPUT_DEVICE).toByteArray();

--- a/src/display/AudioHintWidget.cpp
+++ b/src/display/AudioHintWidget.cpp
@@ -48,6 +48,15 @@ AudioHintWidget::AudioHintWidget(QWidget *const parent)
         settings.setSoundVolume(0);
         hide();
     });
+
+    auto updateAudioHint = [this]() {
+        auto &cfg = getConfig().audio;
+        setVisible(!NO_AUDIO && !cfg.isUnlocked()
+                   && (cfg.getMusicVolume() > 0 || cfg.getSoundVolume() > 0));
+    };
+
+    updateAudioHint();
+    setConfig().audio.registerChangeCallback(m_lifetime, updateAudioHint);
 }
 
 AudioHintWidget::~AudioHintWidget() = default;

--- a/src/display/AudioHintWidget.cpp
+++ b/src/display/AudioHintWidget.cpp
@@ -15,8 +15,10 @@
 AudioHintWidget::AudioHintWidget(QWidget *const parent)
     : QWidget(parent)
 {
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
     QHBoxLayout *layout = new QHBoxLayout(this);
-    layout->setContentsMargins(10, 0, 10, 0);
+    layout->setContentsMargins(10, 4, 10, 4);
     layout->setSpacing(8);
 
     m_iconLabel = new QLabel(this);

--- a/src/display/AudioHintWidget.h
+++ b/src/display/AudioHintWidget.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
+#include "../global/Signal2.h"
 #include "../global/macros.h"
 
 #include <QObject>
@@ -23,4 +24,5 @@ private:
     QLabel *m_textLabel;
     QPushButton *m_yesButton;
     QPushButton *m_noButton;
+    Signal2Lifetime m_lifetime;
 };

--- a/src/display/Filenames.cpp
+++ b/src/display/Filenames.cpp
@@ -6,7 +6,6 @@
 
 #include "../configuration/configuration.h"
 #include "../global/ConfigConsts-Computed.h"
-#include "../global/ConfigConsts.h"
 #include "../global/Consts.h"
 #include "../global/EnumIndexedArray.h"
 #include "../global/NullPointerException.h"
@@ -91,10 +90,7 @@ NODISCARD static const char *getFilenameSuffix(const E x)
 QString getAssetsPath()
 {
     static const QString assetsDirName = QStringLiteral("assets");
-    ;
 
-    // Note: CURRENT_PLATFORM is derived from Qt's Q_OS_* macros in ConfigConsts-Computed.h.
-    // We use if constexpr with CURRENT_PLATFORM here for cleaner cross-platform logic.
     if constexpr (CURRENT_PLATFORM == PlatformEnum::Wasm) {
         return assetsDirName + "/";
     }

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -6,6 +6,8 @@
 
 #include "mapwindow.h"
 
+#include "AudioHintWidget.h"
+#include "../configuration/configuration.h"
 #include "../display/Filenames.h"
 #include "../global/MakeQPointer.h"
 #include "../global/SignalBlocker.h"
@@ -59,6 +61,10 @@ MapWindow::MapWindow(MapData &mapData,
     assert(m_canvasContainer->parent() == this);
 
     m_gridLayout->addWidget(m_canvasContainer, 0, 0, 1, 1);
+
+    m_audioHint = new AudioHintWidget(this);
+    m_gridLayout->addWidget(m_audioHint, 2, 0, 1, 2);
+
     setMinimumSize(m_canvas->minimumSize());
 
     // Splash setup

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -15,8 +15,6 @@
 #include "AudioHintWidget.h"
 #include "mapcanvas.h"
 
-#include <memory>
-
 #include <QGridLayout>
 #include <QLabel>
 #include <QPixmap>

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -35,6 +35,8 @@ MapWindow::MapWindow(MapData &mapData,
     m_gridLayout = mmqt::makeQPointer<QGridLayout>(this);
     m_gridLayout->setSpacing(0);
     m_gridLayout->setContentsMargins(0, 0, 0, 0);
+    m_gridLayout->setRowStretch(0, 1);
+    m_gridLayout->setColumnStretch(0, 1);
 
     m_verticalScrollBar = mmqt::makeQPointer<QScrollBar>(this);
     m_verticalScrollBar->setOrientation(Qt::Vertical);

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -6,13 +6,13 @@
 
 #include "mapwindow.h"
 
-#include "AudioHintWidget.h"
 #include "../configuration/configuration.h"
 #include "../display/Filenames.h"
 #include "../global/MakeQPointer.h"
 #include "../global/SignalBlocker.h"
 #include "../global/Version.h"
 #include "../global/utils.h"
+#include "AudioHintWidget.h"
 #include "mapcanvas.h"
 
 #include <memory>

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -5,7 +5,6 @@
 // Author: Marek Krejza <krejza@gmail.com> (Caligor)
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
-#include "../global/Signal2.h"
 #include "../map/coordinate.h"
 #include "mapcanvas.h"
 

--- a/src/display/mapwindow.h
+++ b/src/display/mapwindow.h
@@ -5,6 +5,7 @@
 // Author: Marek Krejza <krejza@gmail.com> (Caligor)
 // Author: Nils Schimmelmann <nschimme@gmail.com> (Jahara)
 
+#include "../global/Signal2.h"
 #include "../map/coordinate.h"
 #include "mapcanvas.h"
 
@@ -18,6 +19,7 @@
 #include <QtCore>
 #include <QtGlobal>
 
+class AudioHintWidget;
 class GameObserver;
 class MapCanvas;
 class MapData;
@@ -42,6 +44,7 @@ protected:
     QPointer<MapCanvas> m_canvas;
     QPointer<QWidget> m_canvasContainer;
     QPointer<QLabel> m_splashLabel;
+    QPointer<AudioHintWidget> m_audioHint;
     QPointer<QTimer> m_scrollTimer;
     int m_verticalScrollStep = 0;
     int m_horizontalScrollStep = 0;


### PR DESCRIPTION
The audio unlock state is now persisted for desktop platforms, allowing users to choose if they want audio once and have that choice remembered. On WebAssembly, the state remains non-persistent and defaults to locked to satisfy browser requirements for user interaction before audio playback. The audio hint widget is now shown on all platforms if the state is not unlocked, enabling its use for first-time setup or upgrades on desktop.

---
*PR created automatically by Jules for task [2631466955741994346](https://jules.google.com/task/2631466955741994346) started by @nschimme*

## Summary by Sourcery

Persist audio unlock state on non-Wasm platforms and surface the audio hint widget from the map window instead of the client widget.

New Features:
- Remember the audio unlocked state across sessions on non-Wasm platforms via a new configuration key.

Enhancements:
- Show the audio hint widget in the map window when audio is enabled but still locked, and keep it updated via configuration change callbacks.
- Relocate the AudioHintWidget implementation from the client layer to the display layer and adjust its layout and sizing for better appearance.