### PR TITLE
Add audio toolbar with Music and Sound volume sliders

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -242,6 +242,8 @@ set(mmapper_SRCS
     group/mmapper2group.h
     logger/autologger.cpp
     logger/autologger.h
+    mainwindow/AudioVolumeSlider.cpp
+    mainwindow/AudioVolumeSlider.h
     mainwindow/MapZoomSlider.cpp
     mainwindow/MapZoomSlider.h
     mainwindow/UpdateDialog.cpp

--- a/src/mainwindow/AudioVolumeSlider.cpp
+++ b/src/mainwindow/AudioVolumeSlider.cpp
@@ -13,13 +13,9 @@ AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
     setRange(0, 100);
     updateFromConfig();
 
-    connect(this, &QSlider::valueChanged, this, [this](int value) {
-        updateToConfig(value);
-    });
+    connect(this, &QSlider::valueChanged, this, [this](int value) { updateToConfig(value); });
 
-    setConfig().audio.registerChangeCallback(m_lifetime, [this]() {
-        updateFromConfig();
-    });
+    setConfig().audio.registerChangeCallback(m_lifetime, [this]() { updateFromConfig(); });
 
     setToolTip(m_type == AudioType::Music ? tr("Music Volume") : tr("Sound Volume"));
 }

--- a/src/mainwindow/AudioVolumeSlider.cpp
+++ b/src/mainwindow/AudioVolumeSlider.cpp
@@ -17,7 +17,6 @@ AudioVolumeSlider::AudioVolumeSlider(QWidget *const parent)
     if constexpr (NO_AUDIO) {
         setEnabled(false);
     }
-    setAudioType(m_type);
 }
 
 AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
@@ -30,6 +29,10 @@ AudioVolumeSlider::~AudioVolumeSlider() = default;
 
 void AudioVolumeSlider::setAudioType(AudioType type)
 {
+    if (m_type == type && toolTip().length() > 0) {
+        return;
+    }
+
     m_type = type;
     updateFromConfig();
 

--- a/src/mainwindow/AudioVolumeSlider.cpp
+++ b/src/mainwindow/AudioVolumeSlider.cpp
@@ -9,6 +9,20 @@
 AudioVolumeSlider::AudioVolumeSlider(QWidget *const parent)
     : QSlider(Qt::Orientation::Horizontal, parent)
 {
+    init();
+}
+
+AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
+    : QSlider(Qt::Orientation::Horizontal, parent)
+    , m_type(type)
+{
+    init();
+}
+
+AudioVolumeSlider::~AudioVolumeSlider() = default;
+
+void AudioVolumeSlider::init()
+{
     setRange(0, 100);
     connect(this, &QSlider::valueChanged, this, [this](int value) { updateToConfig(value); });
 
@@ -17,15 +31,8 @@ AudioVolumeSlider::AudioVolumeSlider(QWidget *const parent)
     if constexpr (NO_AUDIO) {
         setEnabled(false);
     }
+    setAudioType(m_type);
 }
-
-AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
-    : AudioVolumeSlider(parent)
-{
-    setAudioType(type);
-}
-
-AudioVolumeSlider::~AudioVolumeSlider() = default;
 
 void AudioVolumeSlider::setAudioType(AudioType type)
 {

--- a/src/mainwindow/AudioVolumeSlider.cpp
+++ b/src/mainwindow/AudioVolumeSlider.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "AudioVolumeSlider.h"
+
+#include "../configuration/configuration.h"
+#include "../global/SignalBlocker.h"
+
+AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
+    : QSlider(Qt::Orientation::Horizontal, parent)
+    , m_type(type)
+{
+    setRange(0, 100);
+    updateFromConfig();
+
+    connect(this, &QSlider::valueChanged, this, [this](int value) {
+        updateToConfig(value);
+    });
+
+    setConfig().audio.registerChangeCallback(m_lifetime, [this]() {
+        updateFromConfig();
+    });
+
+    setToolTip(m_type == AudioType::Music ? tr("Music Volume") : tr("Sound Volume"));
+}
+
+AudioVolumeSlider::~AudioVolumeSlider() = default;
+
+void AudioVolumeSlider::updateFromConfig()
+{
+    const int actualVolume = (m_type == AudioType::Music) ? getConfig().audio.getMusicVolume()
+                                                          : getConfig().audio.getSoundVolume();
+    if (value() != actualVolume) {
+        const SignalBlocker block{*this};
+        setValue(actualVolume);
+    }
+}
+
+void AudioVolumeSlider::updateToConfig(int value)
+{
+    if (m_type == AudioType::Music) {
+        if (getConfig().audio.getMusicVolume() != value) {
+            setConfig().audio.setMusicVolume(value);
+        }
+    } else {
+        if (getConfig().audio.getSoundVolume() != value) {
+            setConfig().audio.setSoundVolume(value);
+        }
+    }
+}

--- a/src/mainwindow/AudioVolumeSlider.cpp
+++ b/src/mainwindow/AudioVolumeSlider.cpp
@@ -6,16 +6,32 @@
 #include "../configuration/configuration.h"
 #include "../global/SignalBlocker.h"
 
-AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
+AudioVolumeSlider::AudioVolumeSlider(QWidget *const parent)
     : QSlider(Qt::Orientation::Horizontal, parent)
-    , m_type(type)
 {
     setRange(0, 100);
-    updateFromConfig();
-
     connect(this, &QSlider::valueChanged, this, [this](int value) { updateToConfig(value); });
 
     setConfig().audio.registerChangeCallback(m_lifetime, [this]() { updateFromConfig(); });
+
+    if constexpr (NO_AUDIO) {
+        setEnabled(false);
+    }
+    setAudioType(m_type);
+}
+
+AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
+    : AudioVolumeSlider(parent)
+{
+    setAudioType(type);
+}
+
+AudioVolumeSlider::~AudioVolumeSlider() = default;
+
+void AudioVolumeSlider::setAudioType(AudioType type)
+{
+    m_type = type;
+    updateFromConfig();
 
     switch (m_type) {
     case AudioType::Music:
@@ -25,13 +41,7 @@ AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
         setToolTip(tr("Sound Volume"));
         break;
     }
-
-    if constexpr (NO_AUDIO) {
-        setEnabled(false);
-    }
 }
-
-AudioVolumeSlider::~AudioVolumeSlider() = default;
 
 void AudioVolumeSlider::updateFromConfig()
 {

--- a/src/mainwindow/AudioVolumeSlider.cpp
+++ b/src/mainwindow/AudioVolumeSlider.cpp
@@ -25,6 +25,10 @@ AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
         setToolTip(tr("Sound Volume"));
         break;
     }
+
+    if constexpr (NO_AUDIO) {
+        setEnabled(false);
+    }
 }
 
 AudioVolumeSlider::~AudioVolumeSlider() = default;
@@ -49,15 +53,18 @@ void AudioVolumeSlider::updateFromConfig()
 
 void AudioVolumeSlider::updateToConfig(int value)
 {
+    auto &audioSettings = setConfig().audio;
     switch (m_type) {
     case AudioType::Music:
-        if (getConfig().audio.getMusicVolume() != value) {
-            setConfig().audio.setMusicVolume(value);
+        if (audioSettings.getMusicVolume() != value) {
+            audioSettings.setMusicVolume(value);
+            audioSettings.setUnlocked();
         }
         break;
     case AudioType::Sound:
-        if (getConfig().audio.getSoundVolume() != value) {
-            setConfig().audio.setSoundVolume(value);
+        if (audioSettings.getSoundVolume() != value) {
+            audioSettings.setSoundVolume(value);
+            audioSettings.setUnlocked();
         }
         break;
     }

--- a/src/mainwindow/AudioVolumeSlider.cpp
+++ b/src/mainwindow/AudioVolumeSlider.cpp
@@ -17,15 +17,30 @@ AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
 
     setConfig().audio.registerChangeCallback(m_lifetime, [this]() { updateFromConfig(); });
 
-    setToolTip(m_type == AudioType::Music ? tr("Music Volume") : tr("Sound Volume"));
+    switch (m_type) {
+    case AudioType::Music:
+        setToolTip(tr("Music Volume"));
+        break;
+    case AudioType::Sound:
+        setToolTip(tr("Sound Volume"));
+        break;
+    }
 }
 
 AudioVolumeSlider::~AudioVolumeSlider() = default;
 
 void AudioVolumeSlider::updateFromConfig()
 {
-    const int actualVolume = (m_type == AudioType::Music) ? getConfig().audio.getMusicVolume()
-                                                          : getConfig().audio.getSoundVolume();
+    int actualVolume = 0;
+    switch (m_type) {
+    case AudioType::Music:
+        actualVolume = getConfig().audio.getMusicVolume();
+        break;
+    case AudioType::Sound:
+        actualVolume = getConfig().audio.getSoundVolume();
+        break;
+    }
+
     if (value() != actualVolume) {
         const SignalBlocker block{*this};
         setValue(actualVolume);
@@ -34,13 +49,16 @@ void AudioVolumeSlider::updateFromConfig()
 
 void AudioVolumeSlider::updateToConfig(int value)
 {
-    if (m_type == AudioType::Music) {
+    switch (m_type) {
+    case AudioType::Music:
         if (getConfig().audio.getMusicVolume() != value) {
             setConfig().audio.setMusicVolume(value);
         }
-    } else {
+        break;
+    case AudioType::Sound:
         if (getConfig().audio.getSoundVolume() != value) {
             setConfig().audio.setSoundVolume(value);
         }
+        break;
     }
 }

--- a/src/mainwindow/AudioVolumeSlider.h
+++ b/src/mainwindow/AudioVolumeSlider.h
@@ -1,0 +1,28 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "../global/Signal2.h"
+#include "../global/macros.h"
+
+#include <QSlider>
+
+class AudioVolumeSlider final : public QSlider
+{
+    Q_OBJECT
+
+public:
+    enum class AudioType { Music, Sound };
+
+private:
+    AudioType m_type;
+    Signal2Lifetime m_lifetime;
+
+public:
+    explicit AudioVolumeSlider(AudioType type, QWidget *parent = nullptr);
+    ~AudioVolumeSlider() final;
+
+private:
+    void updateFromConfig();
+    void updateToConfig(int value);
+};

--- a/src/mainwindow/AudioVolumeSlider.h
+++ b/src/mainwindow/AudioVolumeSlider.h
@@ -10,17 +10,24 @@
 class AudioVolumeSlider final : public QSlider
 {
     Q_OBJECT
+    Q_PROPERTY(AudioType audioType READ audioType WRITE setAudioType)
 
 public:
-    enum class AudioType { Music, Sound };
+    enum AudioType { Music, Sound };
+    Q_ENUM(AudioType)
 
 private:
-    AudioType m_type;
+    AudioType m_type = AudioType::Music;
     Signal2Lifetime m_lifetime;
 
 public:
+    explicit AudioVolumeSlider(QWidget *parent = nullptr);
     explicit AudioVolumeSlider(AudioType type, QWidget *parent = nullptr);
     ~AudioVolumeSlider() final;
+
+public:
+    NODISCARD AudioType audioType() const { return m_type; }
+    void setAudioType(AudioType type);
 
 private:
     void updateFromConfig();

--- a/src/mainwindow/AudioVolumeSlider.h
+++ b/src/mainwindow/AudioVolumeSlider.h
@@ -29,7 +29,8 @@ public:
     NODISCARD AudioType audioType() const { return m_type; }
     void setAudioType(AudioType type);
 
-private:
     void updateFromConfig();
+
+private:
     void updateToConfig(int value);
 };

--- a/src/mainwindow/AudioVolumeSlider.h
+++ b/src/mainwindow/AudioVolumeSlider.h
@@ -32,5 +32,6 @@ public:
     void updateFromConfig();
 
 private:
+    void init();
     void updateToConfig(int value);
 };

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1434,9 +1434,11 @@ void MainWindow::setupToolBars()
 
     audioToolBar = addToolBar(tr("Audio"));
     audioToolBar->setObjectName("AudioToolBar");
-    audioToolBar->addWidget(new AudioVolumeSlider(AudioVolumeSlider::AudioType::Music, audioToolBar));
+    audioToolBar->addWidget(
+        new AudioVolumeSlider(AudioVolumeSlider::AudioType::Music, audioToolBar));
     audioToolBar->addSeparator();
-    audioToolBar->addWidget(new AudioVolumeSlider(AudioVolumeSlider::AudioType::Sound, audioToolBar));
+    audioToolBar->addWidget(
+        new AudioVolumeSlider(AudioVolumeSlider::AudioType::Sound, audioToolBar));
     audioToolBar->hide();
 }
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1434,9 +1434,9 @@ void MainWindow::setupToolBars()
 
     audioToolBar = addToolBar(tr("Audio"));
     audioToolBar->setObjectName("AudioToolBar");
-    audioToolBar->addWidget(new AudioVolumeSlider(AudioVolumeSlider::AudioType::Music, this));
+    audioToolBar->addWidget(new AudioVolumeSlider(AudioVolumeSlider::AudioType::Music, audioToolBar));
     audioToolBar->addSeparator();
-    audioToolBar->addWidget(new AudioVolumeSlider(AudioVolumeSlider::AudioType::Sound, this));
+    audioToolBar->addWidget(new AudioVolumeSlider(AudioVolumeSlider::AudioType::Sound, audioToolBar));
     audioToolBar->hide();
 }
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -33,6 +33,7 @@
 #include "../roompanel/RoomManager.h"
 #include "../roompanel/RoomWidget.h"
 #include "../viewers/TopLevelWindows.h"
+#include "AudioVolumeSlider.h"
 #include "MapZoomSlider.h"
 #include "UpdateDialog.h"
 #include "aboutdialog.h"
@@ -1186,6 +1187,7 @@ void MainWindow::setupMenuBar()
     toolbars->addAction(roomToolBar->toggleViewAction());
     toolbars->addAction(connectionToolBar->toggleViewAction());
     toolbars->addAction(settingsToolBar->toggleViewAction());
+    toolbars->addAction(audioToolBar->toggleViewAction());
     QMenu *sidepanels = viewMenu->addMenu(tr("&Side Panels"));
     sidepanels->addAction(m_dockDialogLog->toggleViewAction());
     sidepanels->addAction(m_dockDialogClient->toggleViewAction());
@@ -1429,6 +1431,13 @@ void MainWindow::setupToolBars()
     settingsToolBar->setObjectName("PreferencesToolBar");
     settingsToolBar->addAction(preferencesAct);
     settingsToolBar->hide();
+
+    audioToolBar = addToolBar(tr("Audio"));
+    audioToolBar->setObjectName("AudioToolBar");
+    audioToolBar->addWidget(new AudioVolumeSlider(AudioVolumeSlider::AudioType::Music, this));
+    audioToolBar->addSeparator();
+    audioToolBar->addWidget(new AudioVolumeSlider(AudioVolumeSlider::AudioType::Sound, this));
+    audioToolBar->hide();
 }
 
 void MainWindow::setupStatusBar()

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -135,6 +135,7 @@ private:
     QToolBar *roomToolBar = nullptr;
     QToolBar *connectionToolBar = nullptr;
     QToolBar *settingsToolBar = nullptr;
+    QToolBar *audioToolBar = nullptr;
 
     QMenu *fileMenu = nullptr;
     QMenu *editMenu = nullptr;

--- a/src/preferences/audiopage.cpp
+++ b/src/preferences/audiopage.cpp
@@ -20,21 +20,6 @@ AudioPage::AudioPage(QWidget *const parent)
     ui->setupUi(this);
 
     slot_updateDevices();
-
-    auto *const musicVolumeSlider = new AudioVolumeSlider(AudioVolumeSlider::AudioType::Music, this);
-    auto *const soundsVolumeSlider
-        = new AudioVolumeSlider(AudioVolumeSlider::AudioType::Sound, this);
-
-    ui->gridLayoutMusic->replaceWidget(ui->musicVolumeSlider, musicVolumeSlider);
-    ui->gridLayoutSounds->replaceWidget(ui->soundsVolumeSlider, soundsVolumeSlider);
-
-    delete ui->musicVolumeSlider;
-    delete ui->soundsVolumeSlider;
-
-    // Use these names to avoid breaking layout or other code if it expects them
-    musicVolumeSlider->setObjectName("musicVolumeSlider");
-    soundsVolumeSlider->setObjectName("soundsVolumeSlider");
-
     slot_loadConfig();
 
     connect(ui->outputDeviceComboBox,

--- a/src/preferences/audiopage.cpp
+++ b/src/preferences/audiopage.cpp
@@ -5,6 +5,7 @@
 
 #include "../configuration/configuration.h"
 #include "../global/SignalBlocker.h"
+#include "../mainwindow/AudioVolumeSlider.h"
 #include "ui_audiopage.h"
 
 #ifndef MMAPPER_NO_AUDIO
@@ -19,16 +20,23 @@ AudioPage::AudioPage(QWidget *const parent)
     ui->setupUi(this);
 
     slot_updateDevices();
+
+    auto *const musicVolumeSlider = new AudioVolumeSlider(AudioVolumeSlider::AudioType::Music, this);
+    auto *const soundsVolumeSlider
+        = new AudioVolumeSlider(AudioVolumeSlider::AudioType::Sound, this);
+
+    ui->gridLayoutMusic->replaceWidget(ui->musicVolumeSlider, musicVolumeSlider);
+    ui->gridLayoutSounds->replaceWidget(ui->soundsVolumeSlider, soundsVolumeSlider);
+
+    delete ui->musicVolumeSlider;
+    delete ui->soundsVolumeSlider;
+
+    // Use these names to avoid breaking layout or other code if it expects them
+    musicVolumeSlider->setObjectName("musicVolumeSlider");
+    soundsVolumeSlider->setObjectName("soundsVolumeSlider");
+
     slot_loadConfig();
 
-    connect(ui->musicVolumeSlider,
-            &QSlider::valueChanged,
-            this,
-            &AudioPage::slot_musicVolumeChanged);
-    connect(ui->soundsVolumeSlider,
-            &QSlider::valueChanged,
-            this,
-            &AudioPage::slot_soundsVolumeChanged);
     connect(ui->outputDeviceComboBox,
             &QComboBox::currentIndexChanged,
             this,
@@ -41,8 +49,6 @@ AudioPage::AudioPage(QWidget *const parent)
 
     if constexpr (NO_AUDIO) {
         ui->outputDeviceComboBox->setEnabled(false);
-        ui->musicVolumeSlider->setEnabled(false);
-        ui->soundsVolumeSlider->setEnabled(false);
     }
 }
 
@@ -53,13 +59,9 @@ AudioPage::~AudioPage()
 
 void AudioPage::slot_loadConfig()
 {
-    SignalBlocker musicBlocker(*ui->musicVolumeSlider);
-    SignalBlocker soundsBlocker(*ui->soundsVolumeSlider);
     SignalBlocker outputBlocker(*ui->outputDeviceComboBox);
 
     const auto &settings = getConfig().audio;
-    ui->musicVolumeSlider->setValue(settings.getMusicVolume());
-    ui->soundsVolumeSlider->setValue(settings.getSoundVolume());
 
     int index = ui->outputDeviceComboBox->findData(settings.getOutputDeviceId());
     if (index != -1) {
@@ -67,20 +69,6 @@ void AudioPage::slot_loadConfig()
     } else {
         ui->outputDeviceComboBox->setCurrentIndex(0);
     }
-}
-
-void AudioPage::slot_musicVolumeChanged(int value)
-{
-    auto &settings = setConfig().audio;
-    settings.setMusicVolume(value);
-    settings.setUnlocked();
-}
-
-void AudioPage::slot_soundsVolumeChanged(int value)
-{
-    auto &settings = setConfig().audio;
-    settings.setSoundVolume(value);
-    settings.setUnlocked();
 }
 
 void AudioPage::slot_outputDeviceChanged(int index)

--- a/src/preferences/audiopage.cpp
+++ b/src/preferences/audiopage.cpp
@@ -44,9 +44,13 @@ AudioPage::~AudioPage()
 
 void AudioPage::slot_loadConfig()
 {
+    SignalBlocker musicBlocker(*ui->musicVolumeSlider);
+    SignalBlocker soundsBlocker(*ui->soundsVolumeSlider);
     SignalBlocker outputBlocker(*ui->outputDeviceComboBox);
 
     const auto &settings = getConfig().audio;
+    ui->musicVolumeSlider->updateFromConfig();
+    ui->soundsVolumeSlider->updateFromConfig();
 
     int index = ui->outputDeviceComboBox->findData(settings.getOutputDeviceId());
     if (index != -1) {

--- a/src/preferences/audiopage.h
+++ b/src/preferences/audiopage.h
@@ -23,8 +23,6 @@ public:
 
 public slots:
     void slot_loadConfig();
-    void slot_musicVolumeChanged(int);
-    void slot_soundsVolumeChanged(int);
     void slot_outputDeviceChanged(int);
     void slot_updateDevices();
 };

--- a/src/preferences/audiopage.ui
+++ b/src/preferences/audiopage.ui
@@ -44,12 +44,9 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSlider" name="musicVolumeSlider">
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="AudioVolumeSlider" name="musicVolumeSlider">
+        <property name="audioType">
+         <enum>AudioVolumeSlider::Music</enum>
         </property>
        </widget>
       </item>
@@ -70,12 +67,9 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSlider" name="soundsVolumeSlider">
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="AudioVolumeSlider" name="soundsVolumeSlider">
+        <property name="audioType">
+         <enum>AudioVolumeSlider::Sound</enum>
         </property>
        </widget>
       </item>
@@ -97,6 +91,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AudioVolumeSlider</class>
+   <extends>QSlider</extends>
+   <header>mainwindow/AudioVolumeSlider.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,6 +146,8 @@ add_test(NAME TestProxy COMMAND TestProxy)
 # MainWindow
 set(mainwindow_SRCS
     ../src/global/Version.h
+    ../src/mainwindow/AudioVolumeSlider.cpp
+    ../src/mainwindow/AudioVolumeSlider.h
     ../src/mainwindow/UpdateDialog.cpp
     ../src/mainwindow/UpdateDialog.h
     )

--- a/tests/TestMainWindow.cpp
+++ b/tests/TestMainWindow.cpp
@@ -3,7 +3,9 @@
 
 #include "TestMainWindow.h"
 
+#include "../src/configuration/configuration.h"
 #include "../src/global/Version.h"
+#include "../src/mainwindow/AudioVolumeSlider.h"
 #include "../src/mainwindow/UpdateDialog.h"
 
 #include <QDebug>
@@ -47,6 +49,32 @@ void TestMainWindow::updaterTest()
     CompareVersion newerPatch{"2.9.0"};
     QVERIFY2(newerPatch > current, "Newer major version is greater than older version");
     QVERIFY2((current > newerPatch) == false, "Older version is not newer than newer patch version");
+}
+
+void TestMainWindow::audioToolbarTest()
+{
+    setEnteredMain();
+
+    AudioVolumeSlider musicSlider(AudioVolumeSlider::AudioType::Music);
+    AudioVolumeSlider soundSlider(AudioVolumeSlider::AudioType::Sound);
+
+    // Initial value from default config (50)
+    QCOMPARE(musicSlider.value(), 50);
+    QCOMPARE(soundSlider.value(), 50);
+
+    // Update config -> slider updates
+    setConfig().audio.setMusicVolume(75);
+    QCOMPARE(musicSlider.value(), 75);
+
+    setConfig().audio.setSoundVolume(25);
+    QCOMPARE(soundSlider.value(), 25);
+
+    // Update slider -> config updates
+    musicSlider.setValue(90);
+    QCOMPARE(getConfig().audio.getMusicVolume(), 90);
+
+    soundSlider.setValue(10);
+    QCOMPARE(getConfig().audio.getSoundVolume(), 10);
 }
 
 QTEST_MAIN(TestMainWindow)

--- a/tests/TestMainWindow.cpp
+++ b/tests/TestMainWindow.cpp
@@ -9,6 +9,7 @@
 #include "../src/mainwindow/UpdateDialog.h"
 
 #include <QDebug>
+#include <QScopeGuard>
 #include <QtTest/QtTest>
 
 const char *getMMapperVersion()
@@ -55,10 +56,19 @@ void TestMainWindow::audioToolbarTest()
 {
     setEnteredMain();
 
+    const int originalMusic = getConfig().audio.getMusicVolume();
+    const int originalSound = getConfig().audio.getSoundVolume();
+
+    // Ensure we restore configuration
+    auto cleanup = qScopeGuard([=]() {
+        setConfig().audio.setMusicVolume(originalMusic);
+        setConfig().audio.setSoundVolume(originalSound);
+    });
+
     AudioVolumeSlider musicSlider(AudioVolumeSlider::AudioType::Music);
     AudioVolumeSlider soundSlider(AudioVolumeSlider::AudioType::Sound);
 
-    // Initial value from current config
+    // Initial value should match current config defaults
     QCOMPARE(musicSlider.value(), getConfig().audio.getMusicVolume());
     QCOMPARE(soundSlider.value(), getConfig().audio.getSoundVolume());
 

--- a/tests/TestMainWindow.cpp
+++ b/tests/TestMainWindow.cpp
@@ -58,9 +58,9 @@ void TestMainWindow::audioToolbarTest()
     AudioVolumeSlider musicSlider(AudioVolumeSlider::AudioType::Music);
     AudioVolumeSlider soundSlider(AudioVolumeSlider::AudioType::Sound);
 
-    // Initial value from default config (50)
-    QCOMPARE(musicSlider.value(), 50);
-    QCOMPARE(soundSlider.value(), 50);
+    // Initial value from current config
+    QCOMPARE(musicSlider.value(), getConfig().audio.getMusicVolume());
+    QCOMPARE(soundSlider.value(), getConfig().audio.getSoundVolume());
 
     // Update config -> slider updates
     setConfig().audio.setMusicVolume(75);

--- a/tests/TestMainWindow.h
+++ b/tests/TestMainWindow.h
@@ -17,4 +17,5 @@ public:
 private:
 private Q_SLOTS:
     void updaterTest();
+    void audioToolbarTest();
 };


### PR DESCRIPTION
This change adds a new "Audio" toolbar to the main window. The toolbar contains two horizontal sliders for controlling Music and Sound volumes. These sliders are synchronized with the application's configuration, so changes in the UI update the config and vice versa. The new toolbar is integrated into the "View -> Toolbars" menu and is hidden by default, following the application's existing patterns.

---
*PR created automatically by Jules for task [10882304437039952006](https://jules.google.com/task/10882304437039952006) started by @nschimme*

## Summary by Sourcery

Add a new audio toolbar with sliders for music and sound volume that are synchronized with application configuration and available via the View → Toolbars menu.

New Features:
- Introduce reusable AudioVolumeSlider widget that binds music and sound volume sliders to the global audio configuration.
- Add an Audio toolbar to the main window containing music and sound volume sliders, hidden by default and togglable from the View → Toolbars menu.

Enhancements:
- Refactor audio preferences page to delegate volume handling to AudioVolumeSlider instead of managing slider state and config updates manually.

Build:
- Register AudioVolumeSlider sources in the main application and test CMake build configurations.

Tests:
- Add MainWindow test coverage to verify AudioVolumeSlider stays in sync with configuration changes in both directions.