### PR TITLE
Update Flatpak KDE runtime version to 6.10

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -17,7 +17,7 @@ jobs:
   build-flatpak:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.9
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.10
       options: --privileged
 
     steps:

--- a/org.mume.MMapper.json
+++ b/org.mume.MMapper.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.mume.MMapper",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.9",
+    "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "finish-args": [
         "--share=network",

--- a/src/global/Diff.cpp
+++ b/src/global/Diff.cpp
@@ -7,6 +7,7 @@
 #include "logging.h"
 #include "tests.h"
 
+#include <cstdint>
 #include <ostream>
 #include <sstream>
 #include <vector>

--- a/src/global/Diff.h
+++ b/src/global/Diff.h
@@ -6,6 +6,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <map>


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump the Flatpak KDE runtime version in org.mume.MMapper.json.