### PR TITLE
Improve time of day shader transitions with Oklab and smoothstep

### DIFF
--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -67,14 +67,12 @@ void main()
     float uCloudsIntensity = mix(uIntensities[2], uTargets[2], weatherLerp);
     float uFogIntensity = mix(uIntensities[3], uTargets[3], weatherLerp);
 
-    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
-                                0.0,
-                                1.0);
+    float tTod = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration, 0.0, 1.0);
+    float timeOfDayLerp = smoothstep(0.0, 1.0, tTod);
     float currentTimeOfDayIntensity = mix(uTimeOfDay.z, uTimeOfDay.w, timeOfDayLerp);
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDay.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDay.y)];
-    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
-    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+    float alphaStart = uNamedColors[int(uTimeOfDay.x)].a;
+    float alphaTarget = uNamedColors[int(uTimeOfDay.y)].a;
+    float uTimeOfDayAlpha = mix(alphaStart, alphaTarget, timeOfDayLerp) * currentTimeOfDayIntensity;
 
     // Atmosphere overlay is now transparent by default (TimeOfDay is drawn separately)
     vec4 result = vec4(0.0);
@@ -86,7 +84,7 @@ void main()
         float density = 0.4 + uFogIntensity * 0.4;
         vec4 fog = vec4(0.8, 0.8, 0.85, uFogIntensity * n * localMask * density);
         // Emissive boost at night
-        fog.rgb += uTimeOfDayColor.a * 0.15;
+        fog.rgb += uTimeOfDayAlpha * 0.15;
 
         // Blend fog over result
         float combinedAlpha = 1.0 - (1.0 - result.a) * (1.0 - fog.a);
@@ -106,7 +104,7 @@ void main()
                            1.0 * storminess,
                            uCloudsIntensity * puffy * localMask * 0.5);
         // Emissive boost at night
-        clouds.rgb += uTimeOfDayColor.a * 0.1;
+        clouds.rgb += uTimeOfDayAlpha * 0.1;
 
         // Blend clouds over result
         float combinedAlpha = 1.0 - (1.0 - result.a) * (1.0 - clouds.a);

--- a/src/resources/shaders/legacy/weather/particle/frag.glsl
+++ b/src/resources/shaders/legacy/weather/particle/frag.glsl
@@ -40,14 +40,12 @@ void main()
     float pIntensity = max(pRain, pSnow);
     float pType = pSnow / max(pIntensity, 0.001);
 
-    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
-                                0.0,
-                                1.0);
+    float tTod = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration, 0.0, 1.0);
+    float timeOfDayLerp = smoothstep(0.0, 1.0, tTod);
     float currentTimeOfDayIntensity = mix(uTimeOfDay.z, uTimeOfDay.w, timeOfDayLerp);
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDay.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDay.y)];
-    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
-    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+    float alphaStart = uNamedColors[int(uTimeOfDay.x)].a;
+    float alphaTarget = uNamedColors[int(uTimeOfDay.y)].a;
+    float uTimeOfDayAlpha = mix(alphaStart, alphaTarget, timeOfDayLerp) * currentTimeOfDayIntensity;
 
     float lifeFade = smoothstep(0.0, 0.15, vLife) * smoothstep(1.0, 0.85, vLife);
 
@@ -55,14 +53,14 @@ void main()
     float streak = 1.0 - smoothstep(0.0, 0.15, abs(vLocalCoord.x - 0.5));
     float rainAlpha = mix(0.4, 0.7, clamp(pIntensity, 0.0, 1.0));
     vec4 rainColor = vec4(0.6, 0.6, 1.0, pIntensity * streak * vLocalMask * rainAlpha * lifeFade);
-    rainColor.rgb += uTimeOfDayColor.a * 0.2;
+    rainColor.rgb += uTimeOfDayAlpha * 0.2;
 
     // Snow visuals
     float dist = distance(vLocalCoord, vec2(0.5));
     float flake = 1.0 - smoothstep(0.1, 0.2, dist);
     float snowAlpha = mix(0.6, 0.9, clamp(pIntensity, 0.0, 1.0));
     vec4 snowColor = vec4(1.0, 1.0, 1.1, pIntensity * flake * vLocalMask * snowAlpha * lifeFade);
-    snowColor.rgb += uTimeOfDayColor.a * 0.3;
+    snowColor.rgb += uTimeOfDayAlpha * 0.3;
 
     // Interpolate visuals based on pType
     vec4 pColor = mix(rainColor, snowColor, pType);

--- a/src/resources/shaders/legacy/weather/timeofday/frag.glsl
+++ b/src/resources/shaders/legacy/weather/timeofday/frag.glsl
@@ -23,22 +23,80 @@ layout(std140) uniform WeatherBlock
 
 out vec4 vFragmentColor;
 
+// --- Color Space Conversions (Oklab) ---
+
+vec3 srgbToLinear(vec3 c)
+{
+    vec3 low = c / 12.92;
+    vec3 high = pow((c + 0.055) / 1.055, vec3(2.4));
+    return mix(low, high, step(vec3(0.04045), c));
+}
+
+vec3 linearToSrgb(vec3 c)
+{
+    vec3 low = c * 12.92;
+    vec3 high = 1.055 * pow(c, vec3(1.0 / 2.4)) - 0.055;
+    return mix(low, high, step(vec3(0.0031308), c));
+}
+
+vec3 linearToOklab(vec3 c)
+{
+    float l = 0.4122214708 * c.r + 0.5363325363 * c.g + 0.0514459929 * c.b;
+    float m = 0.2119034982 * c.r + 0.6806995451 * c.g + 0.1073969566 * c.b;
+    float s = 0.0883024619 * c.r + 0.2817188376 * c.g + 0.6299787005 * c.b;
+
+    float l_ = pow(l, 1.0 / 3.0);
+    float m_ = pow(m, 1.0 / 3.0);
+    float s_ = pow(s, 1.0 / 3.0);
+
+    return vec3(0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720403 * s_,
+                1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
+                0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_);
+}
+
+vec3 oklabToLinear(vec3 c)
+{
+    float l_ = c.x + 0.3963377774 * c.y + 0.2158037573 * c.z;
+    float m_ = c.x - 0.1055613458 * c.y - 0.0638541728 * c.z;
+    float s_ = c.x - 0.0894841775 * c.y - 1.2914855480 * c.z;
+
+    float l = l_ * l_ * l_;
+    float m = m_ * m_ * m_;
+    float s = s_ * s_ * s_;
+
+    return vec3(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+                -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+                -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s);
+}
+
 void main()
 {
     float uCurrentTime = uTime.x;
     float uTimeOfDayStartTime = uConfig.y;
     float uTransitionDuration = uConfig.z;
 
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDay.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDay.y)];
+    vec4 timeOfDayStartSrgb = uNamedColors[int(uTimeOfDay.x)];
+    vec4 timeOfDayTargetSrgb = uNamedColors[int(uTimeOfDay.y)];
 
-    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
-                                0.0,
-                                1.0);
+    float t = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration, 0.0, 1.0);
+    float timeOfDayLerp = smoothstep(0.0, 1.0, t);
+
+    // Convert start and target colors to Oklab
+    vec3 startOklab = linearToOklab(srgbToLinear(timeOfDayStartSrgb.rgb));
+    vec3 targetOklab = linearToOklab(srgbToLinear(timeOfDayTargetSrgb.rgb));
+
+    // Interpolate in Oklab space
+    vec3 mixedOklab = mix(startOklab, targetOklab, timeOfDayLerp);
+
+    // Convert back to sRGB
+    vec3 mixedSrgb = linearToSrgb(oklabToLinear(mixedOklab));
+
+    // Mix intensity with smoothstep as well
     float currentTimeOfDayIntensity = mix(uTimeOfDay.z, uTimeOfDay.w, timeOfDayLerp);
 
-    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
-    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+    // Final color with alpha
+    float finalAlpha = mix(timeOfDayStartSrgb.a, timeOfDayTargetSrgb.a, timeOfDayLerp);
+    finalAlpha *= currentTimeOfDayIntensity;
 
-    vFragmentColor = uTimeOfDayColor;
+    vFragmentColor = vec4(mixedSrgb, finalAlpha);
 }


### PR DESCRIPTION
The time of day color transition now interpolates in the Oklab color space instead of sRGB. This avoids hue shifts and "muddy" mid-tones during transitions (e.g., Dawn to Dusk). Additionally, the transition factor now uses a `smoothstep` curve instead of a linear clamp, providing a more natural easing effect at the start and end of weather/time changes. These changes are applied consistently across the `timeofday`, `atmosphere`, and `particle` shaders.

---
*PR created automatically by Jules for task [12481284229983702751](https://jules.google.com/task/12481284229983702751) started by @nschimme*

## Summary by Sourcery

Improve time-of-day visual transitions by interpolating colors in Oklab space and easing transition factors with smoothstep across weather-related shaders.

Enhancements:
- Use Oklab color space for time-of-day color blending to reduce hue shifts and desaturation in mid-transition states.
- Apply smoothstep-based easing to time-of-day transition factors in timeofday, atmosphere, and particle shaders for more natural start/end transitions.
- Base atmospheric and particle emissive boosts on smoothly interpolated time-of-day alpha rather than full RGBA colors.