### PR TITLE
Disable mouse wheel interaction for input widgets in Preferences

### DIFF
--- a/src/global/SignalBlocker.cpp
+++ b/src/global/SignalBlocker.cpp
@@ -7,7 +7,17 @@
 
 #include <cassert>
 
+#include <QEvent>
 #include <QWidget>
+
+bool mmqt::applyWheelEventFilter(QObject *const /*obj*/, QEvent *const event)
+{
+    if (event->type() == QEvent::Wheel) {
+        event->ignore();
+        return true;
+    }
+    return false;
+}
 
 SignalBlocker::SignalBlocker(QObject &in)
     : obj{in}

--- a/src/global/SignalBlocker.h
+++ b/src/global/SignalBlocker.h
@@ -5,6 +5,7 @@
 #include "RuleOf5.h"
 #include "utils.h"
 
+#include <QEvent>
 #include <QObject>
 #include <QVector>
 
@@ -23,3 +24,7 @@ public:
     ~SignalBlocker();
     DELETE_CTORS_AND_ASSIGN_OPS(SignalBlocker);
 };
+
+namespace mmqt {
+NODISCARD extern bool applyWheelEventFilter(QObject *obj, QEvent *event);
+}

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -31,8 +31,7 @@ class WheelEventFilter final : public QObject
 public:
     explicit WheelEventFilter(QObject *const parent)
         : QObject(parent)
-    {
-    }
+    {}
 
     bool eventFilter(QObject *const obj, QEvent *const event) override
     {

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -18,9 +18,32 @@
 #include "pathmachinepage.h"
 #include "ui_configdialog.h"
 
+#include <QAbstractSlider>
+#include <QAbstractSpinBox>
+#include <QComboBox>
 #include <QIcon>
 #include <QListWidget>
 #include <QtWidgets>
+
+namespace {
+class WheelEventFilter final : public QObject
+{
+public:
+    explicit WheelEventFilter(QObject *const parent)
+        : QObject(parent)
+    {
+    }
+
+    bool eventFilter(QObject *const obj, QEvent *const event) override
+    {
+        if (event->type() == QEvent::Wheel) {
+            event->ignore();
+            return true;
+        }
+        return QObject::eventFilter(obj, event);
+    }
+};
+} // namespace
 
 ConfigDialog::ConfigDialog(QWidget *const parent)
     : QDialog(parent)
@@ -86,6 +109,17 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
             &GraphicsPage::sig_graphicsSettingsChanged,
             this,
             &ConfigDialog::sig_graphicsSettingsChanged);
+
+    auto *const filter = new WheelEventFilter(this);
+    for (auto *const comboBox : findChildren<QComboBox *>()) {
+        comboBox->installEventFilter(filter);
+    }
+    for (auto *const slider : findChildren<QAbstractSlider *>()) {
+        slider->installEventFilter(filter);
+    }
+    for (auto *const spinBox : findChildren<QAbstractSpinBox *>()) {
+        spinBox->installEventFilter(filter);
+    }
 }
 
 ConfigDialog::~ConfigDialog()

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -7,6 +7,7 @@
 #include "configdialog.h"
 
 #include "../configuration/configuration.h"
+#include "../global/SignalBlocker.h"
 #include "audiopage.h"
 #include "autologpage.h"
 #include "clientpage.h"
@@ -35,11 +36,7 @@ public:
 
     bool eventFilter(QObject *const obj, QEvent *const event) override
     {
-        if (event->type() == QEvent::Wheel) {
-            event->ignore();
-            return true;
-        }
-        return QObject::eventFilter(obj, event);
+        return mmqt::applyWheelEventFilter(obj, event);
     }
 };
 } // namespace

--- a/tests/TestGlobal.cpp
+++ b/tests/TestGlobal.cpp
@@ -14,6 +14,7 @@
 #include "../src/global/LineUtils.h"
 #include "../src/global/RAII.h"
 #include "../src/global/Signal2.h"
+#include "../src/global/SignalBlocker.h"
 #include "../src/global/StringView.h"
 #include "../src/global/TaggedString.h"
 #include "../src/global/TextUtils.h"
@@ -645,6 +646,29 @@ void TestGlobal::unquoteTest()
 void TestGlobal::weakHandleTest()
 {
     test::testWeakHandle();
+}
+
+void TestGlobal::wheelEventFilterTest()
+{
+    QObject obj;
+    QWheelEvent wheelEvent(QPointF(0, 0),
+                           QPointF(0, 0),
+                           QPoint(0, 0),
+                           QPoint(0, 120),
+                           Qt::NoButton,
+                           Qt::NoModifier,
+                           Qt::ScrollBegin,
+                           false);
+
+    wheelEvent.setAccepted(false);
+    QVERIFY(!wheelEvent.isAccepted());
+    bool handled = mmqt::applyWheelEventFilter(&obj, &wheelEvent);
+    QVERIFY(handled);
+    QVERIFY(!wheelEvent.isAccepted()); // should be ignored
+
+    QEvent otherEvent(QEvent::MouseButtonPress);
+    handled = mmqt::applyWheelEventFilter(&obj, &otherEvent);
+    QVERIFY(!handled);
 }
 
 QTEST_MAIN(TestGlobal)

--- a/tests/TestGlobal.h
+++ b/tests/TestGlobal.h
@@ -40,4 +40,5 @@ private Q_SLOTS:
     static void toNumberTest();
     static void unquoteTest();
     static void weakHandleTest();
+    static void wheelEventFilterTest();
 };


### PR DESCRIPTION
This change implements a `WheelEventFilter` in `ConfigDialog` that intercepts and ignores `QEvent::Wheel` for all `QComboBox`, `QAbstractSlider`, and `QAbstractSpinBox` child widgets. By ignoring the event and returning `true` from the event filter, the widget is prevented from handling the wheel event, which is then allowed to propagate to the parent `QScrollArea`, enabling a smoother scrolling experience through the preferences settings without accidental value changes.

---
*PR created automatically by Jules for task [8179053084755429907](https://jules.google.com/task/8179053084755429907) started by @nschimme*

## Summary by Sourcery

Enhancements:
- Add a shared wheel event filter that ignores wheel events for combo boxes, sliders, and spin boxes in the preferences configuration dialog to avoid accidental value changes while scrolling.