### PR TITLE
Mint wip 2026 04 05a

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -8,7 +8,7 @@ This guide describes how to build **MMapper** from source on Linux, macOS, and W
 
 Ensure the following tools are installed:
 
-- A C++17-compatible compiler (e.g., GCC, Clang, MSVC)
+- A C++20-compatible compiler (e.g., GCC 11+, Clang 16+, MSVC 19.29+)
 - [CMake 3.20+](https://cmake.org/)
 - [Ninja](https://ninja-build.org/)
 - [Qt 6.4+](https://www.qt.io/) (6.8.3 recommended) with `QtWebSockets` and `QtMultimedia`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,7 +437,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         endif()
 
         add_compile_options(-Wno-extra-semi-stmt) # enabled only for src/ directory
-        add_compile_options(-Wno-c++20-compat)
 
         # require explicit template parameters when deduction guides are missing
         add_compile_options(-Werror=ctad-maybe-unsupported)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         endif()
 
         add_compile_options(-Weverything)
+        add_compile_options(-Wno-c++20-compat)
         add_compile_options(-Wno-c++98-c++11-compat-binary-literal) # never useful.
         add_compile_options(-Wno-c++98-compat) # never useful.
         add_compile_options(-Wno-c++98-compat-pedantic) # sometimes useful.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mmapper CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -436,6 +436,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         endif()
 
         add_compile_options(-Wno-extra-semi-stmt) # enabled only for src/ directory
+        add_compile_options(-Wno-c++20-compat)
 
         # require explicit template parameters when deduction guides are missing
         add_compile_options(-Werror=ctad-maybe-unsupported)
@@ -461,7 +462,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         add_compile_options(-Werror=shorten-64-to-32)
         add_compile_options(-Werror=sign-conversion) # can warn about hard-to-spot bugs.
         add_compile_options(-Werror=switch)
-        add_compile_options(-Werror=unused-result) # required for c++17 [[nodiscard]]
+        add_compile_options(-Werror=unused-result) # required for [[nodiscard]]
         add_compile_options(-Werror=weak-vtables) # can result in crashes for ODR violations.
 
         # remove noise (most of these cannot be fixed)
@@ -472,6 +473,7 @@ if(MSVC)
     add_definitions(-DNOMINMAX)
     # modernize the __cplusplus value
     add_compile_options(/Zc:__cplusplus)
+    add_compile_options(/Zc:preprocessor)
     add_compile_options(/utf-8)
     add_compile_options(/permissive-)
     if(CMAKE_BUILD_TYPE_UPPER MATCHES "^RELWITHDEBINFO$")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -771,7 +771,7 @@ endif()
 
 set_target_properties(
   mmapper PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -781,7 +781,7 @@ set_target_properties(
 
 set_target_properties(
   mm_global PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -789,7 +789,7 @@ set_target_properties(
 
 set_target_properties(
   mm_map PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -242,6 +242,8 @@ set(mmapper_SRCS
     group/mmapper2group.h
     logger/autologger.cpp
     logger/autologger.h
+    mainwindow/AudioVolumeSlider.cpp
+    mainwindow/AudioVolumeSlider.h
     mainwindow/MapZoomSlider.cpp
     mainwindow/MapZoomSlider.h
     mainwindow/UpdateDialog.cpp

--- a/src/display/Connections.cpp
+++ b/src/display/Connections.cpp
@@ -799,7 +799,7 @@ void ConnectionDrawer::ConnectionFakeGL::drawLineStrip(const std::vector<glm::ve
     const float extension = CONNECTION_LINE_WIDTH * 0.5f;
 
     // Helper lambda to generate a quad between two points with a specific color.
-    auto generateQuad = [&](const glm::vec3 &p1, const glm::vec3 &p2, const Color quad_color) {
+    auto generateQuad = [this](const glm::vec3 &p1, const glm::vec3 &p2, const Color quad_color) {
         auto &verts = deref(m_currentBuffer).quadVerts;
 
         const glm::vec3 segment = p2 - p1;

--- a/src/display/Infomarks.cpp
+++ b/src/display/Infomarks.cpp
@@ -99,7 +99,7 @@ BatchedInfomarksMeshes MapCanvas::getInfomarksMeshes()
     {
         const auto &map = m_data.getCurrentMap();
         const auto &db = map.getInfomarkDb();
-        db.getIdSet().for_each([&](const InfomarkId id) {
+        db.getIdSet().for_each([&db, &result](const InfomarkId id) {
             InfomarkHandle mark{db, id};
             const int layer = mark.getPosition1().z;
             const auto it = result.find(layer);
@@ -125,8 +125,9 @@ BatchedInfomarksMeshes MapCanvas::getInfomarksMeshes()
     for (auto &it : result) {
         const int layer = it.first;
         InfomarksBatch batch{getOpenGL(), getGLFont()};
-        db.getIdSet().for_each(
-            [&](const InfomarkId id) { drawInfomark(batch, InfomarkHandle{db, id}, layer); });
+        db.getIdSet().for_each([this, &batch, &db, layer](const InfomarkId id) {
+            drawInfomark(batch, InfomarkHandle{db, id}, layer);
+        });
         it.second = batch.getMeshes();
     }
 
@@ -370,7 +371,7 @@ void MapCanvas::paintSelectedInfomarks()
 
             const auto &map = m_data.getCurrentMap();
             const InfomarkDb &db = map.getInfomarkDb();
-            db.getIdSet().for_each([&](const InfomarkId id) {
+            db.getIdSet().for_each([&db, &drawSelectionPoints](const InfomarkId id) {
                 InfomarkHandle marker{db, id};
                 drawSelectionPoints(marker);
             });

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -378,8 +378,11 @@ NODISCARD static QImage createTileableValueNoiseImage(int size)
         return fract - std::floor(fract);
     };
 
+    // https://en.wikipedia.org/wiki/Smoothstep#Variations
     // Perlin's quintic curve ($6t^5-15t^4+10t^3$) ensures smooth C2 continuity at grid boundaries
-    auto smooth = [](float t) -> float { return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f); };
+    static auto smootherstep = [](const float t) -> float {
+        return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f);
+    };
 
     for (int y = 0; y < size; ++y) {
         // scanLine avoids QImage's internal per-pixel coordinate-to-pointer overhead
@@ -394,8 +397,8 @@ NODISCARD static QImage createTileableValueNoiseImage(int size)
             float fx = xx - ix;
             float fy = yy - iy;
 
-            float sx = smooth(fx);
-            float sy = smooth(fy);
+            const float sx = smootherstep(fx);
+            const float sy = smootherstep(fy);
 
             // Double modulo ensures positive wrapping for seamless tiling
             auto get_wrapped_hash = [&](int i, int j) {

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -610,7 +610,8 @@ void MapCanvas::initTextures()
             }
         };
 
-        auto initGroup = [&](const std::string_view groupName, auto &&...sources) {
+        auto initGroup = [&maybeCreateArray2](const std::string_view groupName,
+                                              auto &&...sources) -> SharedMMTexture {
             SharedMMTexture pArrayTex;
             auto thing = combine(std::forward<decltype(sources)>(sources)...);
             maybeCreateArray2(groupName, thing, pArrayTex);
@@ -633,12 +634,14 @@ void MapCanvas::initTextures()
                                                  textures.exit_down,
                                                  textures.exit_up);
 
-        auto maybeCreateArray =
-            [&](const std::string_view groupName, auto &thing, SharedMMTexture &pArrayTex) {
-                if (pArrayTex)
-                    return;
-                pArrayTex = initGroup(groupName, thing);
-            };
+        auto maybeCreateArray = [&initGroup](const std::string_view groupName,
+                                             auto &thing,
+                                             SharedMMTexture &pArrayTex) {
+            if (pArrayTex) {
+                return;
+            }
+            pArrayTex = initGroup(groupName, thing);
+        };
 
 #define XTEX(_TYPE, _NAME) maybeCreateArray(#_NAME, textures._NAME, textures._NAME##_Array);
         XFOREACH_MAPCANVAS_TEXTURES(XTEX)

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -367,14 +367,14 @@ NODISCARD static std::vector<QImage> createDottedWallImages(const ExitDirEnum di
     return images;
 }
 
-NODISCARD static QImage createTileableValueNoiseImage(int size)
+NODISCARD static QImage createTileableValueNoiseImage(const int size)
 {
     QImage img(size, size, QImage::Format_RGBA8888);
 
     // Constants 127.1/311.7 provide high-frequency distribution to prevent Moire patterns
-    auto hash = [](float x, float y) -> float {
-        float dot = x * 127.1f + y * 311.7f;
-        float fract = std::sin(dot) * 43758.5453123f;
+    static auto hash = [](const float x, const float y) -> float {
+        const float dot = x * 127.1f + y * 311.7f;
+        const float fract = std::sin(dot) * 43758.5453123f;
         return fract - std::floor(fract);
     };
 
@@ -384,45 +384,45 @@ NODISCARD static QImage createTileableValueNoiseImage(int size)
         return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f);
     };
 
+    // Double modulo ensures positive wrapping for seamless tiling
+    auto get_wrapped_hash = [size](const int i, const int j) -> float {
+        const auto wi = static_cast<float>((i % size + size) % size);
+        const auto wj = static_cast<float>((j % size + size) % size);
+        return hash(wi, wj);
+    };
+
     for (int y = 0; y < size; ++y) {
         // scanLine avoids QImage's internal per-pixel coordinate-to-pointer overhead
         uchar *line = img.scanLine(y);
 
         for (int x = 0; x < size; ++x) {
-            float xx = static_cast<float>(x);
-            float yy = static_cast<float>(y);
+            const auto xx = static_cast<float>(x);
+            const auto yy = static_cast<float>(y);
 
-            float ix = std::floor(xx);
-            float iy = std::floor(yy);
-            float fx = xx - ix;
-            float fy = yy - iy;
+            const float ix = std::floor(xx);
+            const float iy = std::floor(yy);
+            const float fx = xx - ix;
+            const float fy = yy - iy;
 
             const float sx = smootherstep(fx);
             const float sy = smootherstep(fy);
 
-            // Double modulo ensures positive wrapping for seamless tiling
-            auto get_wrapped_hash = [&](int i, int j) {
-                float wi = static_cast<float>((i % size + size) % size);
-                float wj = static_cast<float>((j % size + size) % size);
-                return hash(wi, wj);
-            };
-
-            int iix = static_cast<int>(ix);
-            int iiy = static_cast<int>(iy);
+            const int iix = static_cast<int>(ix);
+            const int iiy = static_cast<int>(iy);
 
             // Fetch corners for bilinear interpolation
-            float a = get_wrapped_hash(iix, iiy);
-            float b = get_wrapped_hash(iix + 1, iiy);
-            float c = get_wrapped_hash(iix, iiy + 1);
-            float d = get_wrapped_hash(iix + 1, iiy + 1);
+            const float a = get_wrapped_hash(iix, iiy);
+            const float b = get_wrapped_hash(iix + 1, iiy);
+            const float c = get_wrapped_hash(iix, iiy + 1);
+            const float d = get_wrapped_hash(iix + 1, iiy + 1);
 
-            float v = glm::lerp(glm::lerp(a, b, sx), glm::lerp(c, d, sx), sy);
+            const float v = glm::lerp(glm::lerp(a, b, sx), glm::lerp(c, d, sx), sy);
 
             // Casting to uchar provides implicit floor and branchless clamping
-            uchar val = static_cast<uchar>(std::clamp(v * 255.0f, 0.0f, 255.0f));
+            const auto val = static_cast<uchar>(std::clamp(v * 255.0f, 0.0f, 255.0f));
 
             // Direct pointer offset for RGBA8888 interleaved memory
-            int offset = x * 4;
+            const int offset = x * 4;
             line[offset] = val;     // R
             line[offset + 1] = val; // G
             line[offset + 2] = val; // B

--- a/src/display/Textures.cpp
+++ b/src/display/Textures.cpp
@@ -24,8 +24,7 @@
 #include <vector>
 
 #include <glm/glm.hpp>
-
-#include <QMessageLogContext>
+#include <glm/gtx/compatibility.hpp>
 
 MMTextureId allocateTextureId()
 {
@@ -379,8 +378,6 @@ NODISCARD static QImage createTileableValueNoiseImage(int size)
         return fract - std::floor(fract);
     };
 
-    auto lerp = [](float a, float b, float t) -> float { return a + t * (b - a); };
-
     // Perlin's quintic curve ($6t^5-15t^4+10t^3$) ensures smooth C2 continuity at grid boundaries
     auto smooth = [](float t) -> float { return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f); };
 
@@ -416,7 +413,7 @@ NODISCARD static QImage createTileableValueNoiseImage(int size)
             float c = get_wrapped_hash(iix, iiy + 1);
             float d = get_wrapped_hash(iix + 1, iiy + 1);
 
-            float v = lerp(lerp(a, b, sx), lerp(c, d, sx), sy);
+            float v = glm::lerp(glm::lerp(a, b, sx), glm::lerp(c, d, sx), sy);
 
             // Casting to uchar provides implicit floor and branchless clamping
             uchar val = static_cast<uchar>(std::clamp(v * 255.0f, 0.0f, 255.0f));

--- a/src/display/Textures.h
+++ b/src/display/Textures.h
@@ -232,9 +232,8 @@ namespace mctp {
 namespace detail {
 // converts from EnumIndexedArray<SharedMMTexture, ...> to EnumIndexedArray<MMTexArrayPosition, ...>
 template<typename T>
-auto typeHack(const T &)
-    -> std::enable_if_t<std::is_same_v<typename T::value_type, SharedMMTexture>,
-                        EnumIndexedArray<MMTexArrayPosition, typename T::index_type, T::SIZE>>;
+    requires(std::is_same_v<typename T::value_type, SharedMMTexture>)
+auto typeHack(const T &) -> EnumIndexedArray<MMTexArrayPosition, typename T::index_type, T::SIZE>;
 
 template<typename T>
 struct NODISCARD Proxy

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -620,7 +620,7 @@ void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current)
 
                 // Handle rooms needing a server ID or that are temporary
                 if (showNeedsServerId) {
-                    current.getRooms().for_each([&](auto id) {
+                    current.getRooms().for_each([&current, &drawQuad](auto id) {
                         if (auto h = current.getRoomHandle(id)) {
                             if (h.isTemporary()) {
                                 drawQuad(h.getRaw(), NamedColorEnum::HIGHLIGHT_TEMPORARY);
@@ -634,9 +634,12 @@ void MapCanvas::Diff::maybeAsyncUpdate(const Map &saved, const Map &current)
                 // Handle changed rooms
                 if (showChanged) {
                     ProgressCounter dummyPc;
-                    Map::foreachChangedRoom(dummyPc, saved, current, [&](const RawRoom &room) {
-                        drawQuad(room, NamedColorEnum::HIGHLIGHT_UNSAVED);
-                    });
+                    Map::foreachChangedRoom(dummyPc,
+                                            saved,
+                                            current,
+                                            [&drawQuad](const RawRoom &room) {
+                                                drawQuad(room, NamedColorEnum::HIGHLIGHT_UNSAVED);
+                                            });
                 }
 
                 if (highlights.empty()) {

--- a/src/global/AnsiOstream.h
+++ b/src/global/AnsiOstream.h
@@ -135,6 +135,10 @@ public:
     void write(char16_t codepoint);
     void write(char32_t codepoint);
     void write(std::string_view sv);
+    void write(std::u8string_view sv)
+    {
+        write(std::string_view{reinterpret_cast<const char *>(sv.data()), sv.size()});
+    }
 
     template<typename T>
     auto write(const T n)

--- a/src/global/AnsiOstream.h
+++ b/src/global/AnsiOstream.h
@@ -141,11 +141,11 @@ public:
     }
 
     template<typename T>
-    auto write(const T n)
-        -> std::enable_if_t<(std::is_integral_v<T> && !std::is_same_v<char32_t, std::decay_t<T>>
-                             && sizeof(char) < sizeof(T))
-                                || std::is_floating_point_v<T>,
-                            void>
+        requires((std::is_integral_v<T> and sizeof(T) > sizeof(char)
+                  and not(std::is_same_v<char16_t, std::decay_t<T>>
+                          or std::is_same_v<char32_t, std::decay_t<T>>))
+                 or std::is_floating_point_v<T>)
+    void write(const T n)
     {
         auto s = std::to_string(n);
         write(std::string_view{s});

--- a/src/global/Array.h
+++ b/src/global/Array.h
@@ -35,6 +35,7 @@ public:
 
 public:
     template<typename First, typename... Types>
+        requires(std::is_same_v<First, Types> && ...)
     explicit constexpr Array(First &&first, Types &&...args)
         : std::array<T, N>{std::forward<First>(first), std::forward<Types>(args)...}
     {
@@ -42,9 +43,7 @@ public:
     }
 };
 
-#if __cpp_deduction_guides >= 201606
-// deducation guide copied from std::array
 template<typename T, typename... U>
-Array(T, U...) -> Array<std::enable_if_t<(std::is_same_v<T, U> && ...), T>, 1 + sizeof...(U)>;
-#endif
+    requires(std::is_same_v<T, U> && ...)
+Array(T, U...) -> Array<T, 1 + sizeof...(U)>;
 } // namespace MMapper

--- a/src/global/Charset-Utf8.cpp
+++ b/src/global/Charset-Utf8.cpp
@@ -552,13 +552,7 @@ NODISCARD static constexpr bool is7bit(const char c) noexcept
 }
 NODISCARD static constexpr bool is7bit(const std::string_view sv) noexcept
 {
-    // NOLINTNEXTLINE (can't use std::all_of() in constexpr in c++17)
-    for (const char c : sv) {
-        if (!is7bit(c)) {
-            return false;
-        }
-    }
-    return true;
+    return std::all_of(sv.begin(), sv.end(), [](char c) { return is7bit(c); });
 }
 
 NODISCARD static constexpr Utf8ValidationEnum validateUtf8(std::string_view sv) noexcept

--- a/src/global/Charset.cpp
+++ b/src/global/Charset.cpp
@@ -348,7 +348,6 @@ ALLOW_DISCARD QString &toAsciiInPlace(QString &str)
 
     // NOTE: 128 (0x80) was not converted to 'z' before.
     for (QChar &qc : str) {
-        // c++17 if statement with initializer
         if (const char ch = mmqt::toLatin1(qc); !isAscii(ch)) {
             qc = QLatin1Char{charset::conversion::latin1ToAscii(ch)};
         }

--- a/src/global/ConfigConsts-Computed.h
+++ b/src/global/ConfigConsts-Computed.h
@@ -4,6 +4,7 @@
 
 #include "ConfigEnums.h"
 
+#include <functional>
 #include <stdexcept>
 #include <string_view>
 
@@ -44,7 +45,7 @@ static inline constexpr PackageEnum CURRENT_PACKAGE = [] {
     throw std::runtime_error("unsupported package type");
 }();
 
-static inline constexpr const PlatformEnum CURRENT_PLATFORM = [] {
+static inline constexpr PlatformEnum CURRENT_PLATFORM = std::invoke([]() consteval -> PlatformEnum {
 #if defined(Q_OS_WIN)
     return PlatformEnum::Windows;
 #elif defined(Q_OS_MAC)
@@ -56,14 +57,15 @@ static inline constexpr const PlatformEnum CURRENT_PLATFORM = [] {
 #else
     throw std::runtime_error("unsupported platform");
 #endif
-}();
+});
 
-static inline constexpr const EnvironmentEnum CURRENT_ENVIRONMENT = [] {
+static inline constexpr EnvironmentEnum CURRENT_ENVIRONMENT = std::invoke(
+    []() consteval -> EnvironmentEnum {
 #if Q_PROCESSOR_WORDSIZE == 4
-    return EnvironmentEnum::Env32Bit;
+        return EnvironmentEnum::Env32Bit;
 #elif Q_PROCESSOR_WORDSIZE == 8
-    return EnvironmentEnum::Env64Bit;
+        return EnvironmentEnum::Env64Bit;
 #else
-    throw std::runtime_error("unsupported environment");
+        throw std::runtime_error("unsupported environment");
 #endif
-}();
+    });

--- a/src/global/EnumIndexedArray.h
+++ b/src/global/EnumIndexedArray.h
@@ -34,6 +34,7 @@ public:
 
 public:
     using base::data;
+    using base::empty;
     using base::size;
 
 public:

--- a/src/global/EnumIndexedArray.h
+++ b/src/global/EnumIndexedArray.h
@@ -82,6 +82,29 @@ public:
             callback(x);
         }
     }
+    template<typename Callback>
+    void for_each(Callback &&callback) const
+    {
+        for (const auto &x : *this) {
+            callback(x);
+        }
+    }
+    template<typename Callback>
+    void for_each2(Callback &&callback)
+    {
+        for (size_t i = 0u; i < SIZE; ++i) {
+            const auto e = static_cast<E>(i);
+            callback(e, at(e));
+        }
+    }
+    template<typename Callback>
+    void for_each2(Callback &&callback) const
+    {
+        for (size_t i = 0u; i < SIZE; ++i) {
+            const auto e = static_cast<E>(i);
+            callback(e, at(e));
+        }
+    }
 
 public:
     NODISCARD bool operator==(const EnumIndexedArray &other) const

--- a/src/global/MakeQPointer.h
+++ b/src/global/MakeQPointer.h
@@ -12,8 +12,8 @@
 
 namespace mmqt {
 template<typename T, typename... Args>
-NODISCARD auto makeQPointer(Args &&...args)
-    -> std::enable_if_t<std::is_base_of_v<QObject, T>, QPointer<T>>
+    requires(std::is_base_of_v<QObject, T>)
+NODISCARD QPointer<T> makeQPointer(Args &&...args)
 {
     auto ptr = std::make_unique<T>(std::forward<Args>(args)...);
     if (ptr->QObject::parent() == nullptr) {

--- a/src/global/NamedColors.cpp
+++ b/src/global/NamedColors.cpp
@@ -59,14 +59,10 @@ public:
         m_initialized[NamedColorEnum::TRANSPARENT] = true;
 
         // Sane defaults for weather colors
-        std::ignore = setColor(NamedColorEnum::WEATHER_DAWN,
-                               Color(102, 76, 51, 25)); // 0.4, 0.3, 0.2, 0.1
-        std::ignore = setColor(NamedColorEnum::WEATHER_DUSK,
-                               Color(76, 51, 102, 51)); // 0.3, 0.2, 0.4, 0.2
-        std::ignore = setColor(NamedColorEnum::WEATHER_NIGHT,
-                               Color(13, 13, 51, 89)); // 0.05, 0.05, 0.2, 0.35
-        std::ignore = setColor(NamedColorEnum::WEATHER_NIGHT_MOON,
-                               Color(13, 13, 64, 77)); // 0.05, 0.05, 0.25, 0.3
+        setColor(NamedColorEnum::WEATHER_DAWN, Color(102, 76, 51, 25)); // 0.4, 0.3, 0.2, 0.1
+        setColor(NamedColorEnum::WEATHER_DUSK, Color(76, 51, 102, 51)); // 0.3, 0.2, 0.4, 0.2
+        setColor(NamedColorEnum::WEATHER_NIGHT, Color(13, 13, 51, 89)); // 0.05, 0.05, 0.2, 0.35
+        setColor(NamedColorEnum::WEATHER_NIGHT_MOON, Color(13, 13, 64, 77)); // 0.05, 0.05, 0.25, 0.3
     }
 
 public:
@@ -74,7 +70,7 @@ public:
 
 public:
     NODISCARD Color getColor(const NamedColorEnum id) { return m_colors.at(getIndex(id)); }
-    NODISCARD bool setColor(const NamedColorEnum id, Color c)
+    ALLOW_DISCARD bool setColor(const NamedColorEnum id, const Color c)
     {
         if (id == NamedColorEnum::DEFAULT || id == NamedColorEnum::TRANSPARENT) {
             return false;

--- a/src/global/TaggedInt.h
+++ b/src/global/TaggedInt.h
@@ -79,15 +79,17 @@ template<typename...>
 struct NODISCARD underlying_helper;
 
 template<typename T>
+    requires(not std::is_enum_v<T>)
 struct NODISCARD underlying_helper<T>
 {
     using type = T;
 };
 
 template<typename T>
-struct NODISCARD underlying_helper<T, std::enable_if_t<std::is_enum_v<T>>>
+    requires(std::is_enum_v<T>)
+struct NODISCARD underlying_helper<T>
 {
-    using type = typename std::underlying_type_t<T>;
+    using type = std::underlying_type_t<T>;
 };
 
 template<typename Crtp_, typename Tag_, typename Type_>

--- a/src/global/emojis.cpp
+++ b/src/global/emojis.cpp
@@ -171,44 +171,18 @@ public:
     class NODISCARD HexPrefixTree final
     {
     private:
-#if defined(__cpp_lib_generic_unordered_lookup) && __cpp_lib_generic_unordered_lookup
-        struct NODISCARD Hash final
-        {
-            using is_transparent = void;
-            size_t operator()(const std::u32string &s) const
-            {
-                return std::hash<std::u32string>{}(s);
-            }
-            size_t operator()(std::u32string_view sv) const
-            {
-                return std::hash<std::u32string_view>{}(sv);
-            }
-        };
-        struct NODISCARD Pred final
-        {
-            using is_transparent = void;
-            bool operator()(const std::u32string &a, const std::u32string &b) const
-            {
-                return a == b;
-            }
-            bool operator()(const std::u32string &a, std::u32string_view b) const { return a == b; }
-            bool operator()(std::u32string_view a, const std::u32string &b) const { return a == b; }
-            bool operator()(std::u32string_view a, std::u32string_view b) const { return a == b; }
-        };
-        using Map = std::unordered_map<std::u32string, std::optional<std::u32string>, Hash, Pred>;
-#else
+        // REVISIT: consider using std::unordered_map
         struct NODISCARD Comp final
         {
             using is_transparent = void;
             using T1 = const std::u32string &;
             using T2 = const std::u32string_view;
-            bool operator()(T1 a, T1 b) const { return a < b; }
-            bool operator()(T1 a, T2 b) const { return a < b; }
-            bool operator()(T2 a, T1 b) const { return a < b; }
+            NODISCARD bool operator()(T1 a, T1 b) const { return a < b; }
+            NODISCARD bool operator()(T1 a, T2 b) const { return a < b; }
+            NODISCARD bool operator()(T2 a, T1 b) const { return a < b; }
             // bool operator()(T2 a, T2 b) const { return a < b; }
         };
         using Map = std::map<std::u32string, std::optional<std::u32string>, Comp>;
-#endif
 
         Map m_map;
 

--- a/src/global/emojis.cpp
+++ b/src/global/emojis.cpp
@@ -172,20 +172,28 @@ public:
     {
     private:
 #if defined(__cpp_lib_generic_unordered_lookup) && __cpp_lib_generic_unordered_lookup
-        static_assert(false, "Not tested; this may need to be fixed.");
-        using HashBase = std::hash<std::u32string_view>;
-        struct NODISCARD Hash final : public HashBase
+        struct NODISCARD Hash final
         {
-            auto operator()(const std::u32string &s) const { return HashBase::operator()(s); }
+            using is_transparent = void;
+            size_t operator()(const std::u32string &s) const
+            {
+                return std::hash<std::u32string>{}(s);
+            }
+            size_t operator()(std::u32string_view sv) const
+            {
+                return std::hash<std::u32string_view>{}(sv);
+            }
         };
         struct NODISCARD Pred final
         {
-            using T1 = const std::u32string &;
-            using T2 = const std::u32string_view;
-            bool operator()(T1 a, T1 b) const { return a == b; }
-            bool operator()(T1 a, T2 b) const { return a == b; }
-            bool operator()(T2 a, T1 b) const { return a == b; }
-            // bool operator()(T2 a, T2 b) const { return a == b; }
+            using is_transparent = void;
+            bool operator()(const std::u32string &a, const std::u32string &b) const
+            {
+                return a == b;
+            }
+            bool operator()(const std::u32string &a, std::u32string_view b) const { return a == b; }
+            bool operator()(std::u32string_view a, const std::u32string &b) const { return a == b; }
+            bool operator()(std::u32string_view a, std::u32string_view b) const { return a == b; }
         };
         using Map = std::unordered_map<std::u32string, std::optional<std::u32string>, Hash, Pred>;
 #else
@@ -604,7 +612,7 @@ NODISCARD QString mmqt::encodeEmojiShortCodes(const QString &s)
 
             // REVISIT: should this include "U+" or not?
             char hex[32];
-            snprintf(hex, sizeof(hex), "[:U+%X:]", c);
+            snprintf(hex, sizeof(hex), "[:U+%X:]", static_cast<unsigned int>(c));
             for (const char ascii : std::string_view{hex}) {
                 m_output += static_cast<char32_t>(static_cast<uint8_t>(ascii));
             }

--- a/src/global/emojis.cpp
+++ b/src/global/emojis.cpp
@@ -643,7 +643,7 @@ static void importEmojis(const QByteArray &bytes, const QString &filename)
     auto &emojis = getEmojis();
     emojis.reset();
     size_t num_output_emojis = 0;
-    auto report = [&](const QString &shortCode, const QString &hex) {
+    auto report = [&emojis](const QString &shortCode, const QString &hex) {
         if (auto opt_emoji = getUnicode(hex)) {
             for (const char32_t c : *opt_emoji) {
                 if (isAsciiOrLatin1ControlCode(c)) {

--- a/src/global/float_cast.h
+++ b/src/global/float_cast.h
@@ -28,33 +28,29 @@ NODISCARD constexpr bool isSameIntValue(const A a, const B b) noexcept
     return a == b;
 }
 
-// This only exists because c++17 std::isnan() is not constexpr;
-// using "f != f" feels like a hack.
 template<typename FloatType>
 NODISCARD constexpr bool isNan(const FloatType f) noexcept
 {
-#if __cplusplus >= 202000L
+#if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
     return std::isnan(f);
+#elif defined(__clang__) || defined(__GNUC__)
+    return __builtin_isnan(f);
 #else
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wfloat-equal"
-#endif
-    return f != f; // NOLINT (this is only true for NaNs)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+    // std::isnan() is not constexpr in all C++20 implementations (e.g. MSVC 2022)
+    return f != f;
 #endif
 }
 
-// this only exists because c++17 std::isfinite() is not constexpr
 template<typename FloatType>
 NODISCARD constexpr bool isFinite(const FloatType f) noexcept
 {
-#if __cplusplus >= 202000L
+#if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
     return std::isfinite(f);
+#elif defined(__clang__) || defined(__GNUC__)
+    return __builtin_isfinite(f);
 #else
-    constexpr auto inf = std::numeric_limits<FloatType>::infinity();
+    // std::isfinite() is not constexpr in all C++20 implementations (e.g. MSVC 2022)
+    const auto inf = std::numeric_limits<FloatType>::infinity();
     return !isNan(f) && -inf < f && f < inf;
 #endif
 }

--- a/src/global/hash.h
+++ b/src/global/hash.h
@@ -7,13 +7,10 @@
 #include <cstdint>
 #include <cstring>
 #include <string_view>
-#include <type_traits>
 
-template<typename T>
-MAYBE_UNUSED NODISCARD static auto numeric_hash(const T val) noexcept
-    -> std::enable_if_t<std::is_arithmetic_v<T>, size_t>
+MAYBE_UNUSED NODISCARD static size_t numeric_hash(const std::integral auto val) noexcept
 {
-    static constexpr const size_t size = sizeof(val);
+    static constexpr size_t size = sizeof(val);
     char buf[size];
     std::memcpy(buf, &val, size);
     return std::hash<std::string_view>()({buf, size});

--- a/src/global/mm_source_location.h
+++ b/src/global/mm_source_location.h
@@ -4,28 +4,10 @@
 
 #include "macros.h"
 
-#include <cstdint>
-
-#if __cplusplus >= 202000L \
-    && __has_builtin(__builtin_source_location) // && __cpp_lib_source_location >= 201907L
 #include <source_location>
+
 namespace mm {
 using source_location = std::source_location;
-}
-#define MM_SOURCE_LOCATION() (std::source_location::current())
-#else
-namespace mm {
-// TODO: replace this with C++20's std::source_location
-struct NODISCARD source_location final
-{
-    const char *m_file_name = "";
-    const char *m_function_name = "";
-    std::uint_least32_t m_line = 0;
-
-    NODISCARD const char *file_name() const { return this->m_file_name; }
-    NODISCARD const char *function_name() const { return this->m_function_name; }
-    NODISCARD std::uint_least32_t line() const { return this->m_line; }
-};
 } // namespace mm
-#define MM_SOURCE_LOCATION() (mm::source_location{__FILE__, __FUNCTION__, __LINE__})
-#endif
+
+#define MM_SOURCE_LOCATION() (std::source_location::current())

--- a/src/global/utils.h
+++ b/src/global/utils.h
@@ -411,16 +411,7 @@ ALLOW_DISCARD static inline size_t erase_if(Container &container, Callback &&cal
 template<typename T, typename Predicate>
 NODISCARD bool listRemoveIf(std::list<T> &list, Predicate &&should_remove)
 {
-    // c++20 version of remove_if() returns # of elements removed, but c++17 doesn't.
-    bool removed = false;
-    list.remove_if([&removed, &should_remove](const T &element) -> bool {
-        if (should_remove(element)) {
-            removed = true;
-            return true;
-        }
-        return false;
-    });
-    return removed;
+    return std::erase_if(list, std::forward<Predicate>(should_remove)) > 0;
 }
 
 template<typename Container, typename Callback>
@@ -449,9 +440,8 @@ NODISCARD static inline auto find_min_computed(const Container &container, Callb
     }
 }
 
-// This can be removed and replaced with std::remove_cvref_t<T> in c++20.
 template<typename T>
-using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+using remove_cvref_t = std::remove_cvref_t<T>;
 
 template<typename T, typename... Ts>
 struct are_distinct : std::conjunction<std::negation<std::is_same<T, Ts>>..., are_distinct<Ts...>>

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -532,7 +532,7 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
         break;
 
     case Qt::ToolTipRole: {
-        const auto getRatioTooltip = [&](int numerator, int denomenator) -> QVariant {
+        const auto getRatioTooltip = [&character, &column, &formatStat](const int numerator, const int denomenator) -> QVariant {
             if (character.getType() == CharacterTypeEnum::NPC) {
                 return QVariant();
             } else {

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -532,7 +532,9 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
         break;
 
     case Qt::ToolTipRole: {
-        const auto getRatioTooltip = [&character, &column, &formatStat](const int numerator, const int denomenator) -> QVariant {
+        const auto getRatioTooltip =
+            [&character, &column, &formatStat](const int numerator,
+                                               const int denomenator) -> QVariant {
             if (character.getType() == CharacterTypeEnum::NPC) {
                 return QVariant();
             } else {

--- a/src/group/mmapper2group.cpp
+++ b/src/group/mmapper2group.cpp
@@ -312,7 +312,7 @@ bool Mmapper2Group::updateChar(SharedGroupChar sharedCh, const JsonObj &obj)
     }
 
     if (!ch.getColor().isValid()) {
-        auto getColor = [&]() -> QColor {
+        auto getColor = [this, &ch]() -> QColor {
             const auto &settings = getConfig().groupManager;
             if (ch.isNpc() && settings.npcColorOverride) {
                 return settings.npcColor;

--- a/src/group/mmapper2group.cpp
+++ b/src/group/mmapper2group.cpp
@@ -30,7 +30,7 @@ Mmapper2Group::Mmapper2Group(QObject *const parent)
     , m_groupManagerApi{std::make_unique<GroupManagerApi>(*this)}
 {}
 
-Mmapper2Group::~Mmapper2Group() {}
+Mmapper2Group::~Mmapper2Group() = default;
 
 SharedGroupChar Mmapper2Group::getSelf()
 {

--- a/src/mainwindow/AudioVolumeSlider.cpp
+++ b/src/mainwindow/AudioVolumeSlider.cpp
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "AudioVolumeSlider.h"
+
+#include "../configuration/configuration.h"
+#include "../global/SignalBlocker.h"
+
+AudioVolumeSlider::AudioVolumeSlider(QWidget *const parent)
+    : QSlider(Qt::Orientation::Horizontal, parent)
+{
+    init();
+}
+
+AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
+    : QSlider(Qt::Orientation::Horizontal, parent)
+    , m_type(type)
+{
+    init();
+}
+
+AudioVolumeSlider::~AudioVolumeSlider() = default;
+
+void AudioVolumeSlider::init()
+{
+    setRange(0, 100);
+    connect(this, &QSlider::valueChanged, this, [this](int value) { updateToConfig(value); });
+
+    setConfig().audio.registerChangeCallback(m_lifetime, [this]() { updateFromConfig(); });
+
+    if constexpr (NO_AUDIO) {
+        setEnabled(false);
+    }
+    setAudioType(m_type);
+}
+
+void AudioVolumeSlider::setAudioType(AudioType type)
+{
+    if (m_type == type && toolTip().length() > 0) {
+        return;
+    }
+
+    m_type = type;
+    updateFromConfig();
+
+    switch (m_type) {
+    case AudioType::Music:
+        setToolTip(tr("Music Volume"));
+        break;
+    case AudioType::Sound:
+        setToolTip(tr("Sound Volume"));
+        break;
+    }
+}
+
+void AudioVolumeSlider::updateFromConfig()
+{
+    int actualVolume = 0;
+    switch (m_type) {
+    case AudioType::Music:
+        actualVolume = getConfig().audio.getMusicVolume();
+        break;
+    case AudioType::Sound:
+        actualVolume = getConfig().audio.getSoundVolume();
+        break;
+    }
+
+    if (value() != actualVolume) {
+        const SignalBlocker block{*this};
+        setValue(actualVolume);
+    }
+}
+
+void AudioVolumeSlider::updateToConfig(int value)
+{
+    auto &audioSettings = setConfig().audio;
+    switch (m_type) {
+    case AudioType::Music:
+        if (audioSettings.getMusicVolume() != value) {
+            audioSettings.setMusicVolume(value);
+            audioSettings.setUnlocked();
+        }
+        break;
+    case AudioType::Sound:
+        if (audioSettings.getSoundVolume() != value) {
+            audioSettings.setSoundVolume(value);
+            audioSettings.setUnlocked();
+        }
+        break;
+    }
+}

--- a/src/mainwindow/AudioVolumeSlider.h
+++ b/src/mainwindow/AudioVolumeSlider.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2024 The MMapper Authors
 
+#include "../global/RuleOf5.h"
 #include "../global/Signal2.h"
 #include "../global/macros.h"
 
@@ -13,17 +14,18 @@ class AudioVolumeSlider final : public QSlider
     Q_PROPERTY(AudioType audioType READ audioType WRITE setAudioType)
 
 public:
-    enum AudioType { Music, Sound };
+    enum class NODISCARD AudioType : uint8_t { Music, Sound };
     Q_ENUM(AudioType)
 
 private:
-    AudioType m_type = AudioType::Music;
     Signal2Lifetime m_lifetime;
+    AudioType m_type = AudioType::Music;
 
 public:
     explicit AudioVolumeSlider(QWidget *parent = nullptr);
     explicit AudioVolumeSlider(AudioType type, QWidget *parent = nullptr);
     ~AudioVolumeSlider() final;
+    DELETE_CTORS_AND_ASSIGN_OPS(AudioVolumeSlider);
 
 public:
     NODISCARD AudioType audioType() const { return m_type; }

--- a/src/mainwindow/AudioVolumeSlider.h
+++ b/src/mainwindow/AudioVolumeSlider.h
@@ -1,0 +1,37 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 The MMapper Authors
+
+#include "../global/Signal2.h"
+#include "../global/macros.h"
+
+#include <QSlider>
+
+class AudioVolumeSlider final : public QSlider
+{
+    Q_OBJECT
+    Q_PROPERTY(AudioType audioType READ audioType WRITE setAudioType)
+
+public:
+    enum AudioType { Music, Sound };
+    Q_ENUM(AudioType)
+
+private:
+    AudioType m_type = AudioType::Music;
+    Signal2Lifetime m_lifetime;
+
+public:
+    explicit AudioVolumeSlider(QWidget *parent = nullptr);
+    explicit AudioVolumeSlider(AudioType type, QWidget *parent = nullptr);
+    ~AudioVolumeSlider() final;
+
+public:
+    NODISCARD AudioType audioType() const { return m_type; }
+    void setAudioType(AudioType type);
+
+    void updateFromConfig();
+
+private:
+    void init();
+    void updateToConfig(int value);
+};

--- a/src/mainwindow/UpdateDialog.cpp
+++ b/src/mainwindow/UpdateDialog.cpp
@@ -28,16 +28,18 @@ namespace { // anonymous
 NODISCARD const char *getArchitectureRegexPattern()
 {
     // See Qt documentation for expected keys
-    const std::array<std::pair<const char *, const char *>, 4> archPatterns = {
+    static const std::array<std::pair<const char *, const char *>, 4> archPatterns = {
         {{"arm64", "(arm64|aarch64)"},
          {"x86_64", "(x86_64|amd64|x64)"},
          {"i386", "(i386|x86(?!_64))"},
          {"arm", "(arm(?!64)|armhf)"}}};
 
-    auto findPattern = [&](const QString &arch) -> const char * {
-        auto it = std::find_if(archPatterns.begin(), archPatterns.end(), [&arch](const auto &pair) {
-            return mmqt::toStdStringUtf8(arch) == pair.first;
-        });
+    static auto findPattern = [](const QString &arch) -> const char * {
+        const auto it = std::find_if(archPatterns.begin(),
+                                     archPatterns.end(),
+                                     [&arch](const auto &pair) {
+                                         return mmqt::toStdStringUtf8(arch) == pair.first;
+                                     });
         return (it != archPatterns.end()) ? it->second : nullptr;
     };
 

--- a/src/mainwindow/findroomsdlg.cpp
+++ b/src/mainwindow/findroomsdlg.cpp
@@ -147,7 +147,7 @@ void FindRoomsDlg::slot_findClicked()
     try {
         RoomFilter filter(text, cs, regex, kind);
         const Map &map = m_mapData.getCurrentMap();
-        map.getRooms().for_each([&](const auto roomId) {
+        map.getRooms().for_each([this, &filter, &map](const auto roomId) {
             const auto &room = map.getRoomHandle(roomId);
             if (!filter.filter(room.getRaw())) {
                 return;

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -33,6 +33,7 @@
 #include "../roompanel/RoomManager.h"
 #include "../roompanel/RoomWidget.h"
 #include "../viewers/TopLevelWindows.h"
+#include "AudioVolumeSlider.h"
 #include "MapZoomSlider.h"
 #include "UpdateDialog.h"
 #include "aboutdialog.h"
@@ -1186,6 +1187,7 @@ void MainWindow::setupMenuBar()
     toolbars->addAction(roomToolBar->toggleViewAction());
     toolbars->addAction(connectionToolBar->toggleViewAction());
     toolbars->addAction(settingsToolBar->toggleViewAction());
+    toolbars->addAction(audioToolBar->toggleViewAction());
     QMenu *sidepanels = viewMenu->addMenu(tr("&Side Panels"));
     sidepanels->addAction(m_dockDialogLog->toggleViewAction());
     sidepanels->addAction(m_dockDialogClient->toggleViewAction());
@@ -1429,6 +1431,15 @@ void MainWindow::setupToolBars()
     settingsToolBar->setObjectName("PreferencesToolBar");
     settingsToolBar->addAction(preferencesAct);
     settingsToolBar->hide();
+
+    audioToolBar = addToolBar(tr("Audio"));
+    audioToolBar->setObjectName("AudioToolBar");
+    audioToolBar->addWidget(
+        new AudioVolumeSlider(AudioVolumeSlider::AudioType::Music, audioToolBar));
+    audioToolBar->addSeparator();
+    audioToolBar->addWidget(
+        new AudioVolumeSlider(AudioVolumeSlider::AudioType::Sound, audioToolBar));
+    audioToolBar->hide();
 }
 
 void MainWindow::setupStatusBar()

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -135,6 +135,7 @@ private:
     QToolBar *roomToolBar = nullptr;
     QToolBar *connectionToolBar = nullptr;
     QToolBar *settingsToolBar = nullptr;
+    QToolBar *audioToolBar = nullptr;
 
     QMenu *fileMenu = nullptr;
     QMenu *editMenu = nullptr;

--- a/src/map/Crtp.h
+++ b/src/map/Crtp.h
@@ -10,9 +10,6 @@
 template<typename CRTP>
 struct NODISCARD ExitFieldsGetters
 {
-protected:
-    ExitFieldsGetters() = default;
-
 private:
     NODISCARD const auto &crtp_get_fields() const
     {
@@ -77,9 +74,6 @@ public:
 template<typename CRTP>
 struct NODISCARD ExitFieldsSetters
 {
-protected:
-    ExitFieldsSetters() = default;
-
 private:
     NODISCARD auto &crtp_get_fields() { return static_cast<CRTP &>(*this).getExitFields(); }
 
@@ -120,9 +114,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomFieldsGetters
 {
-protected:
-    RoomFieldsGetters() = default;
-
 private:
     NODISCARD const auto &crtp_get_fields() const
     {
@@ -139,9 +130,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomFieldsSetters
 {
-protected:
-    RoomFieldsSetters() = default;
-
 private:
     NODISCARD auto &crtp_get_fields() { return static_cast<CRTP &>(*this).getRoomFields(); }
 
@@ -175,9 +163,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomExitFieldsGetters
 {
-protected:
-    RoomExitFieldsGetters() = default;
-
 private:
     // Expect a const reference or a copy (necessary for fat-pointer proxy objects).
     NODISCARD decltype(auto) crtp_get_exit(const ExitDirEnum dir) const
@@ -203,9 +188,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomExitFieldsSetters
 {
-protected:
-    RoomExitFieldsSetters() = default;
-
 private:
     NODISCARD auto &crtp_get_exit(const ExitDirEnum dir)
     {

--- a/src/map/Diff.h
+++ b/src/map/Diff.h
@@ -184,7 +184,8 @@ private:
     }
 
     template<typename E>
-    auto printEnum(const E x) -> std::enable_if_t<std::is_enum_v<E>>
+        requires(std::is_enum_v<E>)
+    void printEnum(const E x)
     {
         m_os << to_string_view(x);
     }

--- a/src/map/ExitFields.h
+++ b/src/map/ExitFields.h
@@ -9,9 +9,6 @@ struct NODISCARD ExitFields final : public ExitFieldsGetters<ExitFields>,
                                     public ExitFieldsSetters<ExitFields>
 {
 public:
-    ExitFields() {}
-
-public:
 #define X_DECL_FIELD(_Type, _Prop, _OptInit) _Type _Prop _OptInit;
     XFOREACH_EXIT_PROPERTY(X_DECL_FIELD)
 #undef X_DECL_FIELD

--- a/src/map/ExitFields.h
+++ b/src/map/ExitFields.h
@@ -9,6 +9,9 @@ struct NODISCARD ExitFields final : public ExitFieldsGetters<ExitFields>,
                                     public ExitFieldsSetters<ExitFields>
 {
 public:
+    ExitFields() {}
+
+public:
 #define X_DECL_FIELD(_Type, _Prop, _OptInit) _Type _Prop _OptInit;
     XFOREACH_EXIT_PROPERTY(X_DECL_FIELD)
 #undef X_DECL_FIELD

--- a/src/map/Map.cpp
+++ b/src/map/Map.cpp
@@ -351,7 +351,7 @@ void Map::printMulti(ProgressCounter &pc, AnsiOstream &os) const
 
     std::set<ExternalRoomId> rooms;
     pc.setNewTask(ProgressMsg{"phase 1: scanning rooms"}, getRoomsCount());
-    getRooms().for_each([&](const RoomId here) {
+    getRooms().for_each([&pc, &rooms, &w](const RoomId here) {
         const auto &room = deref(w.getRoom(here));
         const auto hereExternal = w.convertToExternal(here);
         for (const ExitDirEnum dir : ALL_EXITS_NESWUD) {
@@ -443,7 +443,7 @@ void Map::printUnknown(ProgressCounter &pc, AnsiOstream &os) const
 {
     std::set<ExternalRoomId> set;
     pc.setNewTask(ProgressMsg{"scanning rooms"}, getRoomsCount());
-    getRooms().for_each([&](const RoomId id) {
+    getRooms().for_each([this, &pc, &set](const RoomId id) {
         const auto &room = getRoomHandle(id);
         if (!room.getExit(ExitDirEnum::UNKNOWN).outIsEmpty()
             || !room.getExit(ExitDirEnum::UNKNOWN).inIsEmpty()) {
@@ -1184,7 +1184,7 @@ Map Map::merge(ProgressCounter &pc,
         marks.reserve(currentMap.getMarksCount() + newMarks.size());
 
         pc.setCurrentTask(ProgressMsg{"creating combined map: old rooms"});
-        currentMap.getRooms().for_each([&](const RoomId id) {
+        currentMap.getRooms().for_each([&currentMap, &pc, &rooms](const RoomId id) {
             const RoomHandle &room = currentMap.getRoomHandle(id);
             rooms.emplace_back(room.getRawCopyExternal());
             pc.step();
@@ -1198,7 +1198,7 @@ Map Map::merge(ProgressCounter &pc,
 
         pc.setCurrentTask(ProgressMsg{"creating combined map: old marks"});
         const auto &db = currentMap.getInfomarkDb();
-        db.getIdSet().for_each([&](const auto id) {
+        db.getIdSet().for_each([&db, &marks, &pc](const auto id) {
             marks.emplace_back(db.getRawCopy(id));
             pc.step();
         });
@@ -1233,7 +1233,7 @@ void Map::foreachChangedRoom(ProgressCounter &pc,
                              const std::function<void(const RawRoom &room)> &callback)
 {
     pc.increaseTotalStepsBy(current.getRoomsCount());
-    current.getRooms().for_each([&](const RoomId id) {
+    current.getRooms().for_each([&callback, &current, &pc, &saved](const RoomId id) {
         const auto r = current.findRoomHandle(id);
         if (!r) {
             assert(false);

--- a/src/map/ParseTree.cpp
+++ b/src/map/ParseTree.cpp
@@ -98,7 +98,7 @@ RoomIdSet getRooms(const Map &map, const ParseTree &tree, const ParseEvent &even
 
         RoomIdSet results;
         size_t numReported = 0;
-        set.for_each([&](const RoomId id) {
+        set.for_each([&map, &numReported, &results, &tryReport](const RoomId id) {
             if (const auto optRoom = map.findRoomHandle(id)) {
                 if (tryReport(optRoom)) {
                     results.insert(id);

--- a/src/map/RawExit.cpp
+++ b/src/map/RawExit.cpp
@@ -53,8 +53,10 @@ struct NODISCARD InvariantsHelper final
     }
 
     // Note: This function will cause a ton of compiler errors if you try to call it
-    // with a const ref Exit type, but we can't use std::enable_if_t here.
+    // with a const ref Exit type. The requires() clause should help give a reasonable
+    // error message.
     void enforce()
+        requires(not std::is_const_v<std::remove_reference_t<Exit_>>)
     {
         if (hasActualExitFlag != shouldHaveExitFlag) {
             if (shouldHaveExitFlag) {

--- a/src/map/RawExit.cpp
+++ b/src/map/RawExit.cpp
@@ -7,12 +7,6 @@
 
 namespace detail {
 
-/*
-template<typename T>
-struct is_const_ref : std::bool_constant<!std::is_const_v<std::remove_reference_t<T>>>
-{};
-*/
-
 template<typename Exit_>
 struct NODISCARD InvariantsHelper final
 {

--- a/src/map/RawExit.h
+++ b/src/map/RawExit.h
@@ -14,9 +14,6 @@ struct NODISCARD TaggedRawExit final : public ExitFieldsGetters<TaggedRawExit<Ta
                                        public ExitFieldsSetters<TaggedRawExit<Tag_>>
 {
 public:
-    TaggedRawExit() {}
-
-public:
     using IdType = std::conditional_t<
         std::is_same_v<Tag_, ::tags::RoomIdTag>,
         RoomId,

--- a/src/map/RawExit.h
+++ b/src/map/RawExit.h
@@ -14,6 +14,9 @@ struct NODISCARD TaggedRawExit final : public ExitFieldsGetters<TaggedRawExit<Ta
                                        public ExitFieldsSetters<TaggedRawExit<Tag_>>
 {
 public:
+    TaggedRawExit() {}
+
+public:
     using IdType = std::conditional_t<
         std::is_same_v<Tag_, ::tags::RoomIdTag>,
         RoomId,

--- a/src/map/RawRoom.h
+++ b/src/map/RawRoom.h
@@ -16,9 +16,6 @@ struct NODISCARD TaggedRawRoom final : public RoomFieldsGetters<TaggedRawRoom<Ta
                                        public RoomExitFieldsSetters<TaggedRawRoom<Tag_>>
 {
 public:
-    TaggedRawRoom() {}
-
-public:
     using ExitType = TaggedRawExit<Tag_>;
     using IdType = typename ExitType::IdType;
     using Exits = EnumIndexedArray<ExitType, ExitDirEnum, NUM_EXITS>;

--- a/src/map/RawRoom.h
+++ b/src/map/RawRoom.h
@@ -16,6 +16,9 @@ struct NODISCARD TaggedRawRoom final : public RoomFieldsGetters<TaggedRawRoom<Ta
                                        public RoomExitFieldsSetters<TaggedRawRoom<Tag_>>
 {
 public:
+    TaggedRawRoom() {}
+
+public:
     using ExitType = TaggedRawExit<Tag_>;
     using IdType = typename ExitType::IdType;
     using Exits = EnumIndexedArray<ExitType, ExitDirEnum, NUM_EXITS>;

--- a/src/map/Remapping.cpp
+++ b/src/map/Remapping.cpp
@@ -4,6 +4,7 @@
 #include "Remapping.h"
 
 #include "../global/AnsiOstream.h"
+#include "../global/ConfigConsts.h"
 #include "../global/Timer.h"
 #include "../global/logging.h"
 #include "../global/progresscounter.h"
@@ -166,12 +167,15 @@ Remapping Remapping::computeFrom(const std::vector<ExternalRawRoom> &input)
 
     remapping.m_intToExt.init(intToExt.data(), intToExt.size());
 
-    assert(next.asUint32() == seen.size());
-    assert(next.asUint32() == remapping.m_intToExt.size());
-    assert(next.asUint32() == remapping.m_extToInt.size());
+    if constexpr (IS_DEBUG_BUILD) {
+        assert(next.asUint32() == seen.size());
+        assert(next.asUint32() == remapping.m_intToExt.size());
+        assert(next.asUint32() == remapping.m_extToInt.size());
 
-    remapping.m_extToInt.for_each(
-        [&](const auto &kv) { assert(remapping.m_intToExt.at(kv.second) == kv.first); });
+        remapping.m_extToInt.for_each([&remapping](const auto &kv) {
+            assert(remapping.m_intToExt.at(kv.second) == kv.first);
+        });
+    }
 
     return remapping;
 }
@@ -185,7 +189,7 @@ ExternalRoomId Remapping::getNextExternal() const
     const auto any = m_extToInt.begin()->first;
     ExternalRoomId highest = any;
 
-    m_intToExt.for_each([&](auto x) {
+    m_intToExt.for_each([&highest](const ExternalRoomId x) {
         if (x != INVALID_EXTERNAL_ROOMID) {
             if (x > highest) {
                 highest = x;
@@ -276,7 +280,7 @@ void Remapping::compact(ProgressCounter &pc, const ExternalRoomId firstId)
     ImmUnorderedMap<ExternalRoomId, RoomId> newExtToInt;
 
     pc.increaseTotalStepsBy(m_extToInt.size());
-    m_extToInt.for_each([&](const auto &kv) {
+    m_extToInt.for_each([this, &newExtToInt, &next, &pc](const auto &kv) {
         m_intToExt.set(kv.second, next);
         newExtToInt.set(next, kv.second);
         next = next.next();

--- a/src/map/RoomFields.h
+++ b/src/map/RoomFields.h
@@ -11,6 +11,9 @@ struct NODISCARD RoomFields final : public RoomFieldsGetters<RoomFields>,
                                     public RoomFieldsSetters<RoomFields>
 {
 public:
+    RoomFields() {}
+
+public:
 #define X_DECL_FIELD(_Type, _Prop, _OptInit) _Type _Prop{_OptInit};
     XFOREACH_ROOM_PROPERTY(X_DECL_FIELD)
 #undef X_DECL_FIELD

--- a/src/map/RoomFields.h
+++ b/src/map/RoomFields.h
@@ -11,9 +11,6 @@ struct NODISCARD RoomFields final : public RoomFieldsGetters<RoomFields>,
                                     public RoomFieldsSetters<RoomFields>
 {
 public:
-    RoomFields() {}
-
-public:
 #define X_DECL_FIELD(_Type, _Prop, _OptInit) _Type _Prop{_OptInit};
     XFOREACH_ROOM_PROPERTY(X_DECL_FIELD)
 #undef X_DECL_FIELD

--- a/src/map/SpatialDb.cpp
+++ b/src/map/SpatialDb.cpp
@@ -57,7 +57,7 @@ void SpatialDb::updateBounds(ProgressCounter &pc)
     const auto &c = m_unique.begin()->first;
     m_bounds.emplace(c, c);
     pc.increaseTotalStepsBy(m_unique.size());
-    m_unique.for_each([&](const auto &kv) {
+    m_unique.for_each([this, &pc](const auto &kv) {
         m_bounds->insert(kv.first);
         pc.step();
     });

--- a/src/map/TinyRoomIdSet.cpp
+++ b/src/map/TinyRoomIdSet.cpp
@@ -9,10 +9,9 @@
 #include <array>
 #include <set>
 
-template<typename T,
-         typename U,
-         typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, std::decay_t<U>>>>
-static T convertTo(const U &input)
+template<typename T, typename U>
+    requires(not std::is_same_v<std::decay_t<T>, std::decay_t<U>>)
+NODISCARD static T convertTo(const U &input)
 {
     T copy;
     for (const auto &x : input) {

--- a/src/map/World-BaseMap.cpp
+++ b/src/map/World-BaseMap.cpp
@@ -30,7 +30,7 @@ void World::apply(ProgressCounter &pc, const world_change_types::GenerateBaseMap
     pc.setNewTask(ProgressMsg{"seeding rooms"}, getRoomSet().size());
 
     // Seed rooms
-    const std::unordered_set<ServerRoomId> seeds = {
+    static const std::unordered_set<ServerRoomId> seeds = {
         ServerRoomId{12681340}, // Fountain Square (Harlond)
         ServerRoomId{4831075},  // Cosy Room (Gandalf Intro)
         ServerRoomId{15197529}, // The High Chamber of the Lamp (Valinor)
@@ -41,7 +41,7 @@ void World::apply(ProgressCounter &pc, const world_change_types::GenerateBaseMap
         ServerRoomId{7854852},  // Frozen North
         ServerRoomId{14623711}, // Hidden Island
     };
-    getRoomSet().for_each([&](auto id) {
+    getRoomSet().for_each([this, &baseRooms, &roomsTodo, &pc](const RoomId id) {
         const RawRoom &room = deref(getRoom(id));
         if (room.isPermanent()) {
             const auto serverId = room.getServerId();
@@ -89,7 +89,7 @@ void World::apply(ProgressCounter &pc, const world_change_types::GenerateBaseMap
     {
         pc.setNewTask(ProgressMsg{"removing hidden exits"}, copy.size());
         size_t removedExits = 0;
-        copy.for_each([&](auto id) {
+        copy.for_each([this, &baseRooms, &removedExits, &pc](const RoomId id) {
             if (baseRooms.contains(id)) {
                 // Use a copy instead of a reference, to avoid crashing when trying out different
                 // immer-like backend implementations that use copy-on-write.
@@ -112,7 +112,7 @@ void World::apply(ProgressCounter &pc, const world_change_types::GenerateBaseMap
     {
         pc.setNewTask(ProgressMsg{"removing inaccessible rooms"}, copy.size());
         size_t removedRooms = 0;
-        copy.for_each([&](auto id) {
+        copy.for_each([this, &baseRooms, &pc, &removedRooms](const RoomId id) {
             if (!baseRooms.contains(id)) {
                 removeFromWorld(id, true);
                 ++removedRooms;

--- a/src/map/World.cpp
+++ b/src/map/World.cpp
@@ -739,7 +739,7 @@ void World::checkConsistency(ProgressCounter &counter) const
         if (!getRoomSet().empty()) {
             std::optional<Bounds> computedBounds;
             counter.setNewTask(ProgressMsg{"checking map coordinates"}, getRoomSet().size());
-            getRoomSet().for_each([&](const RoomId id) {
+            getRoomSet().for_each([this, &computedBounds, &counter](const RoomId id) {
                 const Coordinate &coord = getPosition(id);
                 if (!computedBounds) {
                     computedBounds.emplace(coord, coord);
@@ -1461,8 +1461,7 @@ void World::apply(ProgressCounter &pc, const world_change_types::RemoveAllDoorNa
 {
     pc.increaseTotalStepsBy(getRoomSet().size());
     size_t numRemoved = 0;
-    const DoorName none;
-    getRoomSet().for_each([&](const RoomId id) {
+    getRoomSet().for_each([this, &numRemoved, &pc](const RoomId id) {
         for (const ExitDirEnum dir : ALL_EXITS7) {
             const ExitFlags exitFlags = m_rooms.getExitExitFlags(id, dir);
             if (!exitFlags.isExit() || !exitFlags.isDoor()
@@ -1475,6 +1474,7 @@ void World::apply(ProgressCounter &pc, const world_change_types::RemoveAllDoorNa
                 continue;
             }
 
+            static const DoorName none;
             m_rooms.setExitDoorName(id, dir, none);
             numRemoved += 1;
         }
@@ -2031,7 +2031,7 @@ void World::zapRooms_unsafe(ProgressCounter &pc, const RoomIdSet &rooms)
     {
         DECL_TIMER(t2, "finding inbound exits");
         pc.increaseTotalStepsBy(getRoomSet().size());
-        getRoomSet().for_each([&](const RoomId id) {
+        getRoomSet().for_each([this, &rooms, &pc, &sched_removal](const RoomId id) {
             for (const ExitDirEnum dir : ALL_EXITS7) {
                 const ExitDirEnum rev = opposite(dir);
                 for (const RoomId to : m_rooms.getExitOutgoing(id, dir)) {
@@ -2105,33 +2105,89 @@ void World::printStats(ProgressCounter &pc, AnsiOstream &os) const
     m_serverIds.printStats(pc, os);
 
     {
-        size_t numMissingName = 0;
-        size_t numMissingDesc = 0;
-        size_t numMissingBoth = 0;
-        size_t numMissingArea = 0;
-        size_t numMissingServerId = 0;
-        size_t numWithNoConnections = 0;
-        size_t numWithNoExits = 0;
-        size_t numWithNoEntrances = 0;
-        size_t numExits = 0;
-        size_t numDoors = 0;
-        size_t numHidden = 0;
-        size_t numDoorNames = 0;
-        size_t numHiddenDoorNames = 0;
-        size_t numLoopExits = 0;
-        size_t numConnections = 0;
-        size_t numMultipleOut = 0;
-        size_t numMultipleIn = 0;
+        static constexpr auto green = getRawAnsi(AnsiColor16Enum::green);
 
-        size_t adj1 = 0;
-        size_t adj2 = 0;
-        size_t non1 = 0;
-        size_t non2 = 0;
-        size_t loop1 = 0;
-        size_t loop2 = 0;
+        static auto C = [](auto x) {
+            static_assert(std::is_integral_v<decltype(x)>);
+            return ColoredValue{green, x};
+        };
+
+        struct NODISCARD Stats final
+        {
+            size_t numMissingName = 0;
+            size_t numMissingDesc = 0;
+            size_t numMissingBoth = 0;
+            size_t numMissingArea = 0;
+            size_t numMissingServerId = 0;
+            size_t numWithNoConnections = 0;
+            size_t numWithNoExits = 0;
+            size_t numWithNoEntrances = 0;
+            size_t numExits = 0;
+            size_t numDoors = 0;
+            size_t numHidden = 0;
+            size_t numDoorNames = 0;
+            size_t numHiddenDoorNames = 0;
+            size_t numLoopExits = 0;
+            size_t numConnections = 0;
+            size_t numMultipleOut = 0;
+            size_t numMultipleIn = 0;
+
+            size_t adj1 = 0;
+            size_t adj2 = 0;
+            size_t non1 = 0;
+            size_t non2 = 0;
+            size_t loop1 = 0;
+            size_t loop2 = 0;
+
+            void print(AnsiOstream &aos) const
+            {
+                aos << "  missing server id: " << C(numMissingServerId) << ".\n";
+                aos << "  missing area:      " << C(numMissingArea) << ".\n";
+                aos << "\n";
+
+                // REVISIT: provide a way to identify and fix rooms with missing name and desc?
+                aos << "  with no name and no desc: " << C(numMissingBoth) << ".\n";
+                aos << "  with name but no desc:    " << C(numMissingDesc - numMissingBoth)
+                    << ".\n";
+                aos << "  with desc but no name:    " << C(numMissingName - numMissingBoth)
+                    << ".\n";
+                aos << "\n";
+                aos << "  with no connections:         " << C(numWithNoConnections) << ".\n";
+                aos << "  with entrances but no exits: " << C(numWithNoExits - numWithNoConnections)
+                    << ".\n";
+                aos << "  with exits but no entrances: "
+                    << C(numWithNoEntrances - numWithNoConnections) << ".\n";
+                aos << "\n";
+                aos << "Total exits: " << C(numExits) << ".\n";
+                aos << "\n";
+                aos << "  doors:  " << C(numDoors) << " (with names: " << C(numDoorNames) << ").\n";
+                aos << "  hidden: " << C(numHidden) << " (with names: " << C(numHiddenDoorNames)
+                    << ").\n";
+                aos << "  loops:  " << C(numLoopExits) << ".\n";
+                aos << "\n";
+                aos << "  with multiple outputs: " << C(numMultipleOut) << ".\n";
+                aos << "  with multiple inputs:  " << C(numMultipleIn) << ".\n";
+                aos << "\n";
+                aos << "Total connections: " << C(numConnections) << ".\n";
+                aos << "\n";
+                aos << "  adjacent 1-way:     " << C(adj1) << ".\n";
+                aos << "  adjacent 2-way:     " << C(adj2) << ".\n";
+                aos << "  looping 1-way:      " << C(loop1) << ".\n";
+                aos << "  looping 2-way:      " << C(loop2) << ".\n";
+                aos << "  non-adjacent 1-way: " << C(non1) << ".\n";
+                aos << "  non-adjacent 2-way: " << C(non2) << ".\n";
+                aos << "\n";
+                aos << "  total 1-way:        " << C(non1 + adj1 + loop1) << ".\n";
+                aos << "  total 2-way:        " << C(non2 + adj2 + loop2) << ".\n";
+                aos << "  total adjacent:     " << C(adj1 + adj2) << ".\n";
+                aos << "  total looping:      " << C(loop1 + loop2) << ".\n";
+                aos << "  total non-adjacent: " << C(non1 + non2 + loop1 + loop2) << ".\n";
+            }
+        };
+        Stats stats;
 
         std::optional<Bounds> optBounds;
-        getRoomSet().for_each([&](const RoomId id) {
+        getRoomSet().for_each([this, &stats, &optBounds](const RoomId id) {
             const RawRoom *const pRoom = getRoom(id);
             if (pRoom == nullptr) {
                 std::abort();
@@ -2147,27 +2203,27 @@ void World::printStats(ProgressCounter &pc, AnsiOstream &os) const
 
             const bool isMissingServerId = room.getServerId() == INVALID_SERVER_ROOMID;
             if (isMissingServerId) {
-                ++numMissingServerId;
+                ++stats.numMissingServerId;
             }
 
             const bool isMissingArea = room.getArea().empty();
             if (isMissingArea) {
-                ++numMissingArea;
+                ++stats.numMissingArea;
             }
 
             const bool isMissingName = getRoomName(id).empty();
             const bool isMissingDesc = getRoomDescription(id).empty();
 
             if (isMissingName) {
-                ++numMissingName;
+                ++stats.numMissingName;
             }
 
             if (isMissingDesc) {
-                ++numMissingDesc;
+                ++stats.numMissingDesc;
             }
 
             if (isMissingName && isMissingDesc) {
-                ++numMissingBoth;
+                ++stats.numMissingBoth;
             }
 
             bool hasExits = false;
@@ -2177,20 +2233,20 @@ void World::printStats(ProgressCounter &pc, AnsiOstream &os) const
                 const auto &e = getExitExitFlags(id, dir);
 
                 if (e.isExit()) {
-                    ++numExits;
+                    ++stats.numExits;
                 }
 
                 if (e.isDoor()) {
-                    ++numDoors;
+                    ++stats.numDoors;
                     if (!getExitDoorName(id, dir).empty()) {
-                        ++numDoorNames;
+                        ++stats.numDoorNames;
                     }
                 }
 
                 if (getExitDoorFlags(id, dir).isHidden()) {
-                    numHidden += 1;
+                    stats.numHidden += 1;
                     if (!getExitDoorName(id, dir).empty()) {
-                        ++numHiddenDoorNames;
+                        ++stats.numHiddenDoorNames;
                     }
                 }
 
@@ -2206,18 +2262,18 @@ void World::printStats(ProgressCounter &pc, AnsiOstream &os) const
                 }
 
                 const auto outSize = outset.size();
-                numConnections += outSize;
+                stats.numConnections += outSize;
 
                 if (outSize > 1) {
-                    ++numMultipleOut;
+                    ++stats.numMultipleOut;
                 }
 
                 if (inset.size() > 1) {
-                    ++numMultipleIn;
+                    ++stats.numMultipleIn;
                 }
 
                 if (outset.contains(id)) {
-                    ++numLoopExits;
+                    ++stats.numLoopExits;
                 }
 
                 const ExitDirEnum rev = opposite(dir);
@@ -2228,79 +2284,35 @@ void World::printStats(ProgressCounter &pc, AnsiOstream &os) const
                         const bool twoWay = getOutgoing(to, rev).contains(id);
 
                         if (looping) {
-                            (twoWay ? loop2 : loop1) += 1;
+                            (twoWay ? stats.loop2 : stats.loop1) += 1;
                         } else if (adjacent) {
-                            (twoWay ? adj2 : adj1) += 1;
+                            (twoWay ? stats.adj2 : stats.adj1) += 1;
                         } else {
-                            (twoWay ? non2 : non1) += 1;
+                            (twoWay ? stats.non2 : stats.non1) += 1;
                         }
                     }
                 }
             }
 
             if (!hasEntrances && !hasExits) {
-                ++numWithNoConnections;
+                ++stats.numWithNoConnections;
             }
 
             if (!hasEntrances) {
-                ++numWithNoEntrances;
+                ++stats.numWithNoEntrances;
             }
 
             if (!hasExits) {
-                ++numWithNoExits;
+                ++stats.numWithNoExits;
             }
         });
-
-        static constexpr auto green = getRawAnsi(AnsiColor16Enum::green);
-
-        auto C = [](auto x) {
-            static_assert(std::is_integral_v<decltype(x)>);
-            return ColoredValue{green, x};
-        };
 
         os << "\n";
         os << "Total areas: " << C(m_areaInfos.numAreas()) << ".\n";
         os << "\n";
         os << "Total rooms: " << C(getRoomSet().size()) << ".\n";
         os << "\n";
-        os << "  missing server id: " << C(numMissingServerId) << ".\n";
-        os << "  missing area:      " << C(numMissingArea) << ".\n";
-        os << "\n";
-
-        // REVISIT: provide a way to identify and fix rooms with missing name and desc?
-        os << "  with no name and no desc: " << C(numMissingBoth) << ".\n";
-        os << "  with name but no desc:    " << C(numMissingDesc - numMissingBoth) << ".\n";
-        os << "  with desc but no name:    " << C(numMissingName - numMissingBoth) << ".\n";
-        os << "\n";
-        os << "  with no connections:         " << C(numWithNoConnections) << ".\n";
-        os << "  with entrances but no exits: " << C(numWithNoExits - numWithNoConnections)
-           << ".\n";
-        os << "  with exits but no entrances: " << C(numWithNoEntrances - numWithNoConnections)
-           << ".\n";
-        os << "\n";
-        os << "Total exits: " << C(numExits) << ".\n";
-        os << "\n";
-        os << "  doors:  " << C(numDoors) << " (with names: " << C(numDoorNames) << ").\n";
-        os << "  hidden: " << C(numHidden) << " (with names: " << C(numHiddenDoorNames) << ").\n";
-        os << "  loops:  " << C(numLoopExits) << ".\n";
-        os << "\n";
-        os << "  with multiple outputs: " << C(numMultipleOut) << ".\n";
-        os << "  with multiple inputs:  " << C(numMultipleIn) << ".\n";
-        os << "\n";
-        os << "Total connections: " << C(numConnections) << ".\n";
-        os << "\n";
-        os << "  adjacent 1-way:     " << C(adj1) << ".\n";
-        os << "  adjacent 2-way:     " << C(adj2) << ".\n";
-        os << "  looping 1-way:      " << C(loop1) << ".\n";
-        os << "  looping 2-way:      " << C(loop2) << ".\n";
-        os << "  non-adjacent 1-way: " << C(non1) << ".\n";
-        os << "  non-adjacent 2-way: " << C(non2) << ".\n";
-        os << "\n";
-        os << "  total 1-way:        " << C(non1 + adj1 + loop1) << ".\n";
-        os << "  total 2-way:        " << C(non2 + adj2 + loop2) << ".\n";
-        os << "  total adjacent:     " << C(adj1 + adj2) << ".\n";
-        os << "  total looping:      " << C(loop1 + loop2) << ".\n";
-        os << "  total non-adjacent: " << C(non1 + non2 + loop1 + loop2) << ".\n";
+        stats.print(os);
     }
 
     m_spatialDb.printStats(pc, os);

--- a/src/mapfrontend/mapfrontend.cpp
+++ b/src/mapfrontend/mapfrontend.cpp
@@ -184,7 +184,7 @@ RoomIdSet MapFrontend::findAllRooms(const Coordinate &input_min, const Coordinat
     Bounds bounds{input_min, input_max};
     RoomIdSet result;
     const auto &map = getCurrentMap();
-    map.getRooms().for_each([&](const RoomId id) {
+    map.getRooms().for_each([&bounds, &map, &result](const RoomId id) {
         const auto &r = map.getRoomHandle(id);
         if (bounds.contains(r.getPosition())) {
             result.insert(r.getId());
@@ -268,7 +268,7 @@ bool MapFrontend::applySingleChange(ProgressCounter &pc, const Change &change)
         log << "[MapFrontend::applySingleChange] ";
         getCurrentMap().printChange(log, change);
     }
-    return applyChangesInternal(pc, [&](Map &map, ProgressCounter &counter) {
+    return applyChangesInternal(pc, [&change](Map &map, ProgressCounter &counter) {
         return map.applySingleChange(counter, change);
     });
 }
@@ -286,7 +286,7 @@ bool MapFrontend::applyChanges(ProgressCounter &pc, const ChangeList &changes)
         log << "[MapFrontend::applyChanges] ";
         getCurrentMap().printChanges(log, changes.getChanges(), "\n");
     }
-    return applyChangesInternal(pc, [&](Map &map, ProgressCounter &counter) {
+    return applyChangesInternal(pc, [&changes](Map &map, ProgressCounter &counter) {
         return map.apply(counter, changes);
     });
 }

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -846,7 +846,7 @@ void XmlMapStorage::saveMarkers(QXmlStreamWriter &stream, const InfomarkDb &db)
     }
 
     ProgressCounter &progressCounter = getProgressCounter();
-    db.getIdSet().for_each([&db, &stream, &progressCounter](const InfomarkId id) {
+    db.getIdSet().for_each([&db, &progressCounter, &stream](const InfomarkId id) {
         saveMarker(stream, db.getRawCopy(id));
         progressCounter.step();
     });

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -761,7 +761,7 @@ void XmlMapStorage::saveRooms(QXmlStreamWriter &stream, const ImmRoomIdSet &room
     const Map &map = m_saving->map.mapPair.modified;
     ProgressCounter &progressCounter = getProgressCounter();
 
-    roomList.for_each([&](const RoomId id) {
+    roomList.for_each([&map, &progressCounter, &stream](const RoomId id) {
         if (auto handle = map.getRoomHandle(id)) {
             saveRoom(stream, handle.getRawCopyExternal());
         }
@@ -846,7 +846,7 @@ void XmlMapStorage::saveMarkers(QXmlStreamWriter &stream, const InfomarkDb &db)
     }
 
     ProgressCounter &progressCounter = getProgressCounter();
-    db.getIdSet().for_each([&](const InfomarkId id) {
+    db.getIdSet().for_each([&db, &stream, &progressCounter](const InfomarkId id) {
         saveMarker(stream, db.getRawCopy(id));
         progressCounter.step();
     });

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -39,20 +39,30 @@
 
 // ---------------------------- XmlMapStorage::TypeEnum ------------------------
 // list know enum types
+//
+// Each called X(_x) should use:
+//
+// TYPE_NAME_ENUM_VALUE(_x), or
+// TYPE_NAME_ENUM_TYPE(_x) to construct the enum type name, or
+// TYPE_NAME_STRING(_x) to construct the string representing the type name.
 #define XFOREACH_TYPE_ENUM(X) \
-    X(RoomAlignEnum) \
-    X(DoorFlagEnum) \
-    X(ExitFlagEnum) \
-    X(RoomLightEnum) \
-    X(RoomLoadFlagEnum) \
-    X(InfomarkClassEnum) \
-    X(InfomarkTypeEnum) \
-    X(RoomMobFlagEnum) \
-    X(RoomPortableEnum) \
-    X(RoomRidableEnum) \
-    X(RoomSundeathEnum) \
-    X(RoomTerrainEnum) \
-    X(TypeEnum)
+    X(RoomAlign) \
+    X(DoorFlag) \
+    X(ExitFlag) \
+    X(RoomLight) \
+    X(RoomLoadFlag) \
+    X(InfomarkClass) \
+    X(InfomarkType) \
+    X(RoomMobFlag) \
+    X(RoomPortable) \
+    X(RoomRidable) \
+    X(RoomSundeath) \
+    X(RoomTerrain) \
+    X(Type)
+
+#define TYPE_NAME_ENUM_VALUE(_x) (TypeEnum::_x)
+#define TYPE_NAME_ENUM_TYPE(_x) _x##Enum
+#define TYPE_NAME_C_STRING(_x) (#_x "Enum")
 
 namespace { // anonymous
 
@@ -65,6 +75,44 @@ enum class NODISCARD TypeEnum : uint32_t {
 #define X_ADD(X) +1 // NOLINT
 constexpr const size_t NUM_XMLMAPSTORAGE_TYPE = (XFOREACH_TYPE_ENUM(X_ADD));
 #undef X_ADD
+
+// define a bunch of methods
+//   static constexpr TypeEnum enumToType(RoomAlignEnum) { return TypeEnum::RoomAlign; }
+//   static constexpr TypeEnum enumToType(DoorFlagEnum)  { return TypeEnum::DoorFlag;  }
+//   ...
+// converting an enumeration type to its corresponding TypeEnum value,
+// which can be used as argument in enumToString() and stringToEnum()
+#define X_DECL(_x) \
+    NODISCARD constexpr TypeEnum enumToType(TYPE_NAME_ENUM_TYPE(_x)) \
+    { \
+        return TYPE_NAME_ENUM_VALUE(_x); \
+    }
+XFOREACH_TYPE_ENUM(X_DECL)
+#undef X_DECL
+
+NODISCARD constexpr const char *to_c_string(const TypeEnum val)
+{
+#define X_CASE(_x) \
+    case TYPE_NAME_ENUM_VALUE(_x): \
+        return TYPE_NAME_C_STRING(_x);
+    //
+    switch (val) {
+        XFOREACH_TYPE_ENUM(X_CASE)
+    }
+    return "unknown";
+#undef X_CASE
+}
+
+static_assert(enumToType(RoomAlignEnum::UNDEFINED) == TypeEnum::RoomAlign);
+static_assert(enumToType(RoomTerrainEnum::UNDEFINED) == TypeEnum::RoomTerrain);
+
+static_assert(enumToType(TypeEnum::RoomAlign) == TypeEnum::Type);
+static_assert(enumToType(TypeEnum::RoomTerrain) == TypeEnum::Type);
+static_assert(enumToType(TypeEnum::Type) == TypeEnum::Type);
+
+static_assert(to_c_string(TypeEnum::RoomAlign) == std::string_view{"RoomAlignEnum"});
+static_assert(to_c_string(TypeEnum::RoomTerrain) == std::string_view{"RoomTerrainEnum"});
+static_assert(to_c_string(TypeEnum::Type) == std::string_view{"TypeEnum"});
 
 // ---------------------------- XmlMapStorage::Converter -----------------------
 class NODISCARD Converter final
@@ -100,40 +148,22 @@ public:
     {
         static_assert(std::is_enum_v<ENUM>, "template type ENUM must be an enumeration");
         if constexpr (std::is_same_v<ENUM, TypeEnum>) {
-#define X_CASE(x) \
-    case TypeEnum::x: \
-        return #x;
-            //
-            switch (val) {
-                XFOREACH_TYPE_ENUM(X_CASE)
-            }
-            return "unknown";
-#undef X_CASE
+            return ::to_c_string(val);
         } else {
             return enumToString(enumToType(val), static_cast<uint32_t>(val));
         }
     }
 
 private:
-    // define a bunch of methods
-    //   static constexpr TypeEnum enumToType(RoomAlignEnum) { return TypeEnum::RoomAlignEnum; }
-    //   static constexpr TypeEnum enumToType(DoorFlagEnum)  { return TypeEnum::DoorFlagEnum;  }
-    //   ...
-    // converting an enumeration type to its corresponding Type value,
-    // which can be used as argument in enumToString() and stringToEnum()
-#define X_DECL(X) \
-    MAYBE_UNUSED NODISCARD static constexpr TypeEnum enumToType(X) { return TypeEnum::X; }
-    XFOREACH_TYPE_ENUM(X_DECL)
-#undef X_DECL
-
     NODISCARD std::optional<uint32_t> stringToEnum(TypeEnum type, QStringView str) const;
     NODISCARD const QString &enumToString(TypeEnum type, uint32_t val) const;
 };
 
 Converter::Converter()
     : m_enumToStrings{
-#define X_DECL(X) /* */ {#X},
-#define X_DECL2(X, ...) {#X},
+#define X_DECL(_x) /* */ {#_x},
+#define X_DECL2(_x, ...) {#_x},
+#define X_DECL3(_x) {TYPE_NAME_C_STRING(_x)},
           /* these must match the enum types listed in XFOREACH_TYPE_ENUM above */
           {XFOREACH_RoomAlignEnum(X_DECL)},
           {XFOREACH_DOOR_FLAG(X_DECL2)},
@@ -147,9 +177,10 @@ Converter::Converter()
           {XFOREACH_RoomRidableEnum(X_DECL)},
           {XFOREACH_RoomSundeathEnum(X_DECL)},
           {XFOREACH_RoomTerrainEnum(X_DECL)},
-          {XFOREACH_TYPE_ENUM(X_DECL)},
+          {XFOREACH_TYPE_ENUM(X_DECL3)},
 #undef X_DECL
 #undef X_DECL2
+#undef X_DECL3
       }
 {
     if (m_enumToStrings.size() != NUM_XMLMAPSTORAGE_TYPE) {

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -39,7 +39,6 @@
 
 // clang-format off
 
-
 // ---------------------------- XmlMapStorage::TypeEnum ------------------------
 // list know enum types
 //
@@ -101,6 +100,11 @@ enum class NODISCARD TypeEnum : uint32_t {
 constexpr const size_t NUM_XMLMAPSTORAGE_TYPE = (XFOREACH_TYPE_ENUM(X_ADD));
 #undef X_ADD
 
+NODISCARD bool isValid(const TypeEnum type)
+{
+    return static_cast<uint32_t>(type) < NUM_XMLMAPSTORAGE_TYPE;
+}
+
 #define X_SEP() ,
 #define X_DECL(_x, _xfor, _xdecl) _x
 enum class NODISCARD SanityCheckEnum : uint32_t { XFOREACH_CONVERTER(X_DECL, X_SEP) };
@@ -114,6 +118,14 @@ enum class NODISCARD SanityCheckEnum : uint32_t { XFOREACH_CONVERTER(X_DECL, X_S
 XFOREACH_CONVERTER(X_CHECK, X_SEP);
 #undef X_CHECK
 #undef X_SEP
+
+#define X_SEP()
+#define X_ADD(_x, _xfor, _xdecl) +1 // NOLINT
+constexpr const size_t NUM_SANITYCHECK = (XFOREACH_CONVERTER(X_ADD, X_SEP));
+#undef X_ADD
+#undef X_SEP
+
+static_assert(NUM_SANITYCHECK == NUM_XMLMAPSTORAGE_TYPE);
 
 // define a bunch of methods
 //   static constexpr TypeEnum enumToType(RoomAlignEnum) { return TypeEnum::RoomAlign; }
@@ -153,15 +165,20 @@ static_assert(to_c_string(TypeEnum::RoomAlign) == std::string_view{"RoomAlignEnu
 static_assert(to_c_string(TypeEnum::RoomTerrain) == std::string_view{"RoomTerrainEnum"});
 static_assert(to_c_string(TypeEnum::Type) == std::string_view{"TypeEnum"});
 
-NODISCARD std::vector<std::vector<QString>> make_enum_to_strings_table()
+template<typename T>
+using TypeEnumArray = EnumIndexedArray<T, TypeEnum, NUM_XMLMAPSTORAGE_TYPE>;
+
+using EnumToStrings = TypeEnumArray<std::vector<QString>>;
+
+NODISCARD EnumToStrings initEnumToStrings()
 {
 #define X_SEP() ,
 #define X_DECL_SINGLE(_x) /*QString*/ {#_x},
 #define X_DECL_MULTI(_x, ...) /*QString*/ {#_x},
 #define X_DECL_TYPE_ENUM(_x) /*QString*/ {TYPE_NAME_C_STRING(_x)},
-#define X_CONVERT(_x, _xfor, _xdecl) /*std::vector<QString>*/ {_xfor(_xdecl)}
+#define X_CONVERT(_x, _xfor, _xdecl) (std::vector<QString>{_xfor(_xdecl)})
 
-    return {XFOREACH_CONVERTER(X_CONVERT, X_SEP)};
+    return EnumToStrings{XFOREACH_CONVERTER(X_CONVERT, X_SEP)};
 
 #undef X_DECL_SINGLE
 #undef X_DECL_MULTI
@@ -174,12 +191,13 @@ NODISCARD std::vector<std::vector<QString>> make_enum_to_strings_table()
 class NODISCARD Converter final
 {
 private:
-    std::vector<std::vector<QString>> m_enumToStrings = make_enum_to_strings_table();
-    std::vector<QHash<QStringView, uint32_t>> m_stringToEnums;
+    EnumToStrings m_enumToStrings = initEnumToStrings();
+    TypeEnumArray<QHash<QStringView, uint32_t>> m_stringToEnums;
 
 public:
-    Converter();
+    explicit Converter();
     ~Converter() = default;
+    DELETE_CTORS_AND_ASSIGN_OPS(Converter);
 
     // parse string containing a signed or unsigned number.
     template<typename T>
@@ -222,8 +240,8 @@ Converter::Converter()
     }
 
     // create the maps string -> enum value for each enum type listed above
-    for (auto &vec : m_enumToStrings) {
-        auto &map = m_stringToEnums.emplace_back();
+    m_enumToStrings.for_each2([this](const TypeEnum e, auto &vec) {
+        auto &map = m_stringToEnums[e];
         uint32_t val = 0;
         for (auto &str : vec) {
             if (str == "UNDEFINED") {
@@ -237,22 +255,20 @@ Converter::Converter()
             }
             ++val;
         }
-    }
+    });
 }
 
 const QString &Converter::enumToString(const TypeEnum type, const uint32_t val) const
 {
-    const auto index = static_cast<uint32_t>(type);
-    if (index < m_enumToStrings.size()) {
-        const auto &tmp = m_enumToStrings[index];
-        if (val < tmp.size()) {
+    if (isValid(type)) {
+        if (const auto &tmp = m_enumToStrings[type]; val < tmp.size()) {
             return tmp[val];
         }
     }
 
     qWarning().noquote().nospace()
-        << "Attempt to save an invalid enum type = " << toString(type) << ", value = " << val
-        << ". Either the current map is damaged, or there is a bug";
+        << "WARNING: Attempt to save an invalid enum type = " << toString(type)
+        << ", value = " << val << ". Either the current map is damaged, or there is a bug.";
 
     static const QString g_empty{};
     assert(g_empty.isEmpty());
@@ -261,11 +277,9 @@ const QString &Converter::enumToString(const TypeEnum type, const uint32_t val) 
 
 std::optional<uint32_t> Converter::stringToEnum(const TypeEnum type, const QStringView str) const
 {
-    const auto index = static_cast<uint32_t>(type);
-    if (index < m_stringToEnums.size()) {
-        const auto &tmp = m_stringToEnums[index];
-        const auto iter = tmp.find(str);
-        if (iter != tmp.end()) {
+    if (isValid(type)) {
+        const auto &tmp = m_stringToEnums[type];
+        if (const auto iter = tmp.find(str); iter != tmp.end()) {
             return iter.value();
         }
     }

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -37,6 +37,9 @@
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 
+// clang-format off
+
+
 // ---------------------------- XmlMapStorage::TypeEnum ------------------------
 // list know enum types
 //
@@ -45,6 +48,9 @@
 // TYPE_NAME_ENUM_VALUE(_x), or
 // TYPE_NAME_ENUM_TYPE(_x) to construct the enum type name, or
 // TYPE_NAME_STRING(_x) to construct the string representing the type name.
+//
+// Caution: these must match XFOREACH_CONVERTER defined below; the reason we can't just have
+// a single mscro is because XFOREACH_CONVERTER calls this but macros can't be recursive.
 #define XFOREACH_TYPE_ENUM(X) \
     X(RoomAlign) \
     X(DoorFlag) \
@@ -59,6 +65,25 @@
     X(RoomSundeath) \
     X(RoomTerrain) \
     X(Type)
+
+// Caution: these must match the enum types listed in XFOREACH_TYPE_ENUM above.
+// X(_x, _xfor, _xdecl)
+#define XFOREACH_CONVERTER(X, X_SEP) \
+    X(RoomAlign, XFOREACH_RoomAlignEnum, X_DECL_SINGLE) X_SEP() \
+    X(DoorFlag, XFOREACH_DOOR_FLAG, X_DECL_MULTI) X_SEP() \
+    X(ExitFlag, XFOREACH_EXIT_FLAG, X_DECL_MULTI) X_SEP() \
+    X(RoomLight, XFOREACH_RoomLightEnum, X_DECL_SINGLE) X_SEP() \
+    X(RoomLoadFlag, XFOREACH_ROOM_LOAD_FLAG, X_DECL_SINGLE) X_SEP() \
+    X(InfomarkClass, XFOREACH_INFOMARK_CLASS, X_DECL_SINGLE) X_SEP() \
+    X(InfomarkType, XFOREACH_INFOMARK_TYPE, X_DECL_SINGLE) X_SEP() \
+    X(RoomMobFlag, XFOREACH_ROOM_MOB_FLAG, X_DECL_SINGLE) X_SEP() \
+    X(RoomPortable, XFOREACH_RoomPortableEnum, X_DECL_SINGLE) X_SEP() \
+    X(RoomRidable, XFOREACH_RoomRidableEnum, X_DECL_SINGLE) X_SEP() \
+    X(RoomSundeath, XFOREACH_RoomSundeathEnum, X_DECL_SINGLE) X_SEP() \
+    X(RoomTerrain, XFOREACH_RoomTerrainEnum, X_DECL_SINGLE) X_SEP() \
+    X(Type, XFOREACH_TYPE_ENUM, X_DECL_TYPE_ENUM)
+
+// clang-format on
 
 #define TYPE_NAME_ENUM_VALUE(_x) (TypeEnum::_x)
 #define TYPE_NAME_ENUM_TYPE(_x) _x##Enum
@@ -75,6 +100,20 @@ enum class NODISCARD TypeEnum : uint32_t {
 #define X_ADD(X) +1 // NOLINT
 constexpr const size_t NUM_XMLMAPSTORAGE_TYPE = (XFOREACH_TYPE_ENUM(X_ADD));
 #undef X_ADD
+
+#define X_SEP() ,
+#define X_DECL(_x, _xfor, _xdecl) _x
+enum class NODISCARD SanityCheckEnum : uint32_t { XFOREACH_CONVERTER(X_DECL, X_SEP) };
+#undef X_DECL
+#undef X_SEP
+
+#define X_SEP() ;
+#define X_CHECK(_x, _xfor, _xdecl) \
+    static_assert(static_cast<uint32_t>(SanityCheckEnum::_x) \
+                  == static_cast<uint32_t>(TYPE_NAME_ENUM_VALUE(_x)))
+XFOREACH_CONVERTER(X_CHECK, X_SEP);
+#undef X_CHECK
+#undef X_SEP
 
 // define a bunch of methods
 //   static constexpr TypeEnum enumToType(RoomAlignEnum) { return TypeEnum::RoomAlign; }
@@ -114,11 +153,28 @@ static_assert(to_c_string(TypeEnum::RoomAlign) == std::string_view{"RoomAlignEnu
 static_assert(to_c_string(TypeEnum::RoomTerrain) == std::string_view{"RoomTerrainEnum"});
 static_assert(to_c_string(TypeEnum::Type) == std::string_view{"TypeEnum"});
 
+NODISCARD std::vector<std::vector<QString>> make_enum_to_strings_table()
+{
+#define X_SEP() ,
+#define X_DECL_SINGLE(_x) /*QString*/ {#_x},
+#define X_DECL_MULTI(_x, ...) /*QString*/ {#_x},
+#define X_DECL_TYPE_ENUM(_x) /*QString*/ {TYPE_NAME_C_STRING(_x)},
+#define X_CONVERT(_x, _xfor, _xdecl) /*std::vector<QString>*/ {_xfor(_xdecl)}
+
+    return {XFOREACH_CONVERTER(X_CONVERT, X_SEP)};
+
+#undef X_DECL_SINGLE
+#undef X_DECL_MULTI
+#undef X_DECL_TYPE_ENUM
+#undef X_CONVERT
+#undef X_SEP
+}
+
 // ---------------------------- XmlMapStorage::Converter -----------------------
 class NODISCARD Converter final
 {
 private:
-    std::vector<std::vector<QString>> m_enumToStrings;
+    std::vector<std::vector<QString>> m_enumToStrings = make_enum_to_strings_table();
     std::vector<QHash<QStringView, uint32_t>> m_stringToEnums;
 
 public:
@@ -160,28 +216,6 @@ private:
 };
 
 Converter::Converter()
-    : m_enumToStrings{
-#define X_DECL(_x) /* */ {#_x},
-#define X_DECL2(_x, ...) {#_x},
-#define X_DECL3(_x) {TYPE_NAME_C_STRING(_x)},
-          /* these must match the enum types listed in XFOREACH_TYPE_ENUM above */
-          {XFOREACH_RoomAlignEnum(X_DECL)},
-          {XFOREACH_DOOR_FLAG(X_DECL2)},
-          {XFOREACH_EXIT_FLAG(X_DECL2)},
-          {XFOREACH_RoomLightEnum(X_DECL)},
-          {XFOREACH_ROOM_LOAD_FLAG(X_DECL)},
-          {XFOREACH_INFOMARK_CLASS(X_DECL)},
-          {XFOREACH_INFOMARK_TYPE(X_DECL)},
-          {XFOREACH_ROOM_MOB_FLAG(X_DECL)},
-          {XFOREACH_RoomPortableEnum(X_DECL)},
-          {XFOREACH_RoomRidableEnum(X_DECL)},
-          {XFOREACH_RoomSundeathEnum(X_DECL)},
-          {XFOREACH_RoomTerrainEnum(X_DECL)},
-          {XFOREACH_TYPE_ENUM(X_DECL3)},
-#undef X_DECL
-#undef X_DECL2
-#undef X_DECL3
-      }
 {
     if (m_enumToStrings.size() != NUM_XMLMAPSTORAGE_TYPE) {
         throw std::runtime_error("XmlMapStorage internal error: enum names do not match enum types");
@@ -981,3 +1015,4 @@ void XmlMapStorage::saveRoomMobFlags(QXmlStreamWriter &stream, const RoomMobFlag
 }
 
 #undef XFOREACH_TYPE_ENUM
+#undef XFOREACH_CONVERTER

--- a/src/mapstorage/mapstorage.cpp
+++ b/src/mapstorage/mapstorage.cpp
@@ -606,7 +606,7 @@ bool MapStorage::virt_saveData(const MapLoadData &mapData)
     roomList.reserve(map.getRoomsCount());
 
     progressCounter.setNewTask(ProgressMsg{"scanning rooms"}, map.getRooms().size());
-    map.getRooms().for_each([&](const RoomId id) {
+    map.getRooms().for_each([&map, &roomList](const RoomId id) {
         const auto &room = map.getRoomHandle(id);
         if (!room.isTemporary()) {
             roomList.push_back(room);
@@ -643,7 +643,7 @@ bool MapStorage::virt_saveData(const MapLoadData &mapData)
     // save items
     progressCounter.setNewTask(ProgressMsg{"saving markers"}, marksCount);
     auto &db = map.getInfomarkDb();
-    db.getIdSet().for_each([&](const InfomarkId id) {
+    db.getIdSet().for_each([&db, &progressCounter, &stream](const InfomarkId id) {
         saveMark(db.getRawCopy(id), stream);
         progressCounter.step();
     });

--- a/src/media/DescriptionWidget.cpp
+++ b/src/media/DescriptionWidget.cpp
@@ -88,7 +88,7 @@ QSize DescriptionWidget::sizeHint() const
 
 void DescriptionWidget::updateBackground()
 {
-    const auto loadAndCacheImage = [&](const QString &imagePath) -> QImage * {
+    const auto loadAndCacheImage = [this](const QString &imagePath) -> QImage * {
         if (imagePath.isEmpty()) {
             return nullptr;
         }
@@ -121,19 +121,21 @@ void DescriptionWidget::updateBackground()
         }
     };
 
-    QImage *const baseImage = loadAndCacheImage(m_fileName);
-    if (!baseImage || baseImage->isNull()) {
+    QImage *const pBaseImage = loadAndCacheImage(m_fileName);
+    if (!pBaseImage || pBaseImage->isNull()) {
         m_label->clear();
         return;
     }
 
+    auto &baseImage = *pBaseImage;
+
     // Decide if widget is padded
     const QSize widgetSize = size();
-    const auto hasRoomRightOfTextEdit = std::invoke([&]() -> bool {
+    const auto hasRoomRightOfTextEdit = std::invoke([this, &baseImage, widgetSize]() -> bool {
         const QRect textEditGeometry = m_textEdit->geometry();
         const int spaceRightOfTextEdit = widgetSize.width()
                                          - (textEditGeometry.x() + textEditGeometry.width());
-        return baseImage->width() <= spaceRightOfTextEdit;
+        return baseImage.width() <= spaceRightOfTextEdit;
     });
     const int topPadding = hasRoomRightOfTextEdit
                                ? 0
@@ -144,27 +146,28 @@ void DescriptionWidget::updateBackground()
     resultImage.fill(Qt::transparent);
     QPainter painter(&resultImage);
     painter.setRenderHint(QPainter::SmoothPixmapTransform);
-    const RAIICallback painterEndRAII{[&]() {
-        const QSize imageFitSize(widgetSize.width(), widgetSize.height() - topPadding);
-        const QImage scaledImageForCenter = baseImage->scaled(imageFitSize,
-                                                              Qt::KeepAspectRatio,
-                                                              Qt::SmoothTransformation);
-        const QPoint center((widgetSize.width() - scaledImageForCenter.width()) / 2,
-                            (widgetSize.height() - scaledImageForCenter.height()) / 2
-                                + (hasRoomRightOfTextEdit ? 0 : topPadding / 2));
-        painter.drawImage(center, scaledImageForCenter);
-        painter.end();
-        m_label->setPixmap(QPixmap::fromImage(resultImage));
-    }};
+    const RAIICallback painterEndRAII{
+        [this, &baseImage, &painter, &resultImage, hasRoomRightOfTextEdit, topPadding, widgetSize]() {
+            const QSize imageFitSize(widgetSize.width(), widgetSize.height() - topPadding);
+            const QImage scaledImageForCenter = baseImage.scaled(imageFitSize,
+                                                                 Qt::KeepAspectRatio,
+                                                                 Qt::SmoothTransformation);
+            const QPoint center((widgetSize.width() - scaledImageForCenter.width()) / 2,
+                                (widgetSize.height() - scaledImageForCenter.height()) / 2
+                                    + (hasRoomRightOfTextEdit ? 0 : topPadding / 2));
+            painter.drawImage(center, scaledImageForCenter);
+            painter.end();
+            m_label->setPixmap(QPixmap::fromImage(resultImage));
+        }};
 
     // Blur background
     const QSize downscaledBlurSourceSize = QSize(std::max(1, widgetSize.width() / DOWNSCALE_FACTOR),
                                                  std::max(1,
                                                           widgetSize.height() / DOWNSCALE_FACTOR));
     QImage blurSource = baseImage
-                            ->scaled(downscaledBlurSourceSize,
-                                     Qt::IgnoreAspectRatio,
-                                     Qt::SmoothTransformation)
+                            .scaled(downscaledBlurSourceSize,
+                                    Qt::IgnoreAspectRatio,
+                                    Qt::SmoothTransformation)
                             .convertToFormat(QImage::Format_ARGB32_Premultiplied);
 
     if (blurSource.isNull() || blurSource.width() == 0 || blurSource.height() == 0) {
@@ -181,7 +184,7 @@ void DescriptionWidget::updateBackground()
         return;
     }
 
-    const auto stackBlur = [&](QImage &image, int radius) {
+    static const auto stackBlur = [](QImage &image, const int radius) {
         const int w = image.width();
         const int h = image.height();
         const int div = 2 * radius + 1;

--- a/src/media/DescriptionWidget.h
+++ b/src/media/DescriptionWidget.h
@@ -19,8 +19,8 @@ class NODISCARD_QOBJECT DescriptionWidget final : public QWidget
 private:
     MediaLibrary &m_library;
 
-    QLabel *m_label;
-    QTextEdit *m_textEdit;
+    QLabel *m_label = nullptr;
+    QTextEdit *m_textEdit = nullptr;
 
 private:
     QCache<QString, QImage> m_imageCache;

--- a/src/media/MediaLibrary.h
+++ b/src/media/MediaLibrary.h
@@ -33,8 +33,8 @@ private:
 public:
     explicit MediaLibrary(QObject *parent = nullptr);
 
-    QString findAudio(const QString &subDir, const QString &name) const;
-    QString findImage(const QString &subDir, const QString &name) const;
+    NODISCARD QString findAudio(const QString &subDir, const QString &name) const;
+    NODISCARD QString findImage(const QString &subDir, const QString &name) const;
 
     void fetchAsync(const QString &path, std::function<void(const QByteArray &)> callback);
 

--- a/src/media/MusicManager.cpp
+++ b/src/media/MusicManager.cpp
@@ -124,7 +124,7 @@ void MusicManager::shutdown()
 #endif
 }
 
-void MusicManager::playMusic(const QString &musicFile)
+void MusicManager::playMusic(MAYBE_UNUSED const QString &musicFile)
 {
 #ifndef MMAPPER_NO_AUDIO
     if (musicFile.isEmpty() || NO_AUDIO) {

--- a/src/media/MusicManager.h
+++ b/src/media/MusicManager.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
+#include "../global/RuleOf5.h"
 #include "../global/macros.h"
 
 #include <QCache>
@@ -52,6 +53,7 @@ private:
 public:
     explicit MusicManager(MediaLibrary &library, QObject *parent = nullptr);
     ~MusicManager() override;
+    DELETE_CTORS_AND_ASSIGN_OPS(MusicManager);
 
     void playMusic(const QString &musicFile);
     void stopMusic();

--- a/src/media/MusicManager.h
+++ b/src/media/MusicManager.h
@@ -37,7 +37,7 @@ private:
         float fadeVolume = 0.0f;
     };
 
-    MusicChannel m_channels[2];
+    MusicChannel m_channels[2]; // TODO: use std::array or MMapper::Array
     int m_activeChannel = 0;
     QCache<QString, qint64> m_cachedPositions;
     QCache<QString, QTemporaryFile> m_wasmFiles;

--- a/src/media/SfxManager.cpp
+++ b/src/media/SfxManager.cpp
@@ -98,7 +98,7 @@ void SfxManager::playFromData(const QByteArray &data, const QString &soundName)
 #endif
 }
 
-void SfxManager::startEffect(const QUrl &url, const QString &tmpToDelete)
+void SfxManager::startEffect(MAYBE_UNUSED const QUrl &url, MAYBE_UNUSED const QString &tmpToDelete)
 {
 #ifndef MMAPPER_NO_AUDIO
     auto *effect = new QMediaPlayer(this);

--- a/src/media/SfxManager.h
+++ b/src/media/SfxManager.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
+#include "../global/RuleOf5.h"
 #include "../global/macros.h"
 
 #include <QObject>
@@ -22,13 +23,14 @@ class NODISCARD_QOBJECT SfxManager final : public QObject
 
 private:
 #ifndef MMAPPER_NO_AUDIO
-    QAudioOutput *m_output;
+    QAudioOutput *m_output = nullptr;
 #endif
     MediaLibrary &m_library;
 
 public:
     explicit SfxManager(MediaLibrary &library, QObject *parent = nullptr);
     ~SfxManager() override;
+    DELETE_CTORS_AND_ASSIGN_OPS(SfxManager);
 
     void shutdown();
     void playSound(const QString &soundName);

--- a/src/observer/gameobserver.h
+++ b/src/observer/gameobserver.h
@@ -55,10 +55,10 @@ public:
     void observeGainedLevel() { sig2_gainedLevel.invoke(); }
 
 public:
-    MumeTimeEnum getTimeOfDay() const { return m_timeOfDay; }
-    MumeMoonPhaseEnum getMoonPhase() const { return m_moonPhase; }
-    MumeMoonVisibilityEnum getMoonVisibility() const { return m_moonVisibility; }
-    MumeSeasonEnum getSeason() const { return m_season; }
-    PromptWeatherEnum getWeather() const { return m_weather; }
-    PromptFogEnum getFog() const { return m_fog; }
+    NODISCARD MumeTimeEnum getTimeOfDay() const { return m_timeOfDay; }
+    NODISCARD MumeMoonPhaseEnum getMoonPhase() const { return m_moonPhase; }
+    NODISCARD MumeMoonVisibilityEnum getMoonVisibility() const { return m_moonVisibility; }
+    NODISCARD MumeSeasonEnum getSeason() const { return m_season; }
+    NODISCARD PromptWeatherEnum getWeather() const { return m_weather; }
+    NODISCARD PromptFogEnum getFog() const { return m_fog; }
 };

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -157,8 +157,9 @@ NODISCARD std::optional<GLContextCheckResult> probeCompat(
         // Filter compatVersions to only include versions <= coreResult
         compatVersionsToTest.erase(std::remove_if(compatVersionsToTest.begin(),
                                                   compatVersionsToTest.end(),
-                                                  [&](const GLVersion &ver) {
-                                                      return ver > coreResult->version;
+                                                  [resultVer = coreResult->version](
+                                                      const GLVersion &ver) {
+                                                      return ver > resultVer;
                                                   }),
                                    compatVersionsToTest.end());
     }

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -171,12 +171,10 @@ NODISCARD std::optional<GLContextCheckResult> probeCompat(
                                                                version,
                                                                QSurfaceFormat::CompatibilityProfile);
         if (contextCheckResult.valid) {
-            if (contextCheckResult.valid) {
-                compatResult = contextCheckResult;
-                MMLOG_DEBUG() << "[GL Probe] Found highest supported Compat version: "
-                              << compatResult->version;
-                break;
-            }
+            compatResult = contextCheckResult;
+            MMLOG_DEBUG() << "[GL Probe] Found highest supported Compat version: "
+                          << compatResult->version;
+            break;
         }
     }
     return compatResult;

--- a/src/opengl/UboBlocks.h
+++ b/src/opengl/UboBlocks.h
@@ -99,7 +99,7 @@ XFOREACH_SHARED_VBO(X_ASSERT)
 #undef X_ASSERT
 
 template<SharedVboEnum T>
-  using BlockType_t = typename BlockType<T>::type;
+using BlockType_t = typename BlockType<T>::type;
 
 template<std::size_t... Is>
 auto MakeSharedVboBlocksHelper(std::index_sequence<Is...>)

--- a/src/opengl/UboBlocks.h
+++ b/src/opengl/UboBlocks.h
@@ -98,9 +98,12 @@ XFOREACH_SHARED_VBO(X_TYPE)
 XFOREACH_SHARED_VBO(X_ASSERT)
 #undef X_ASSERT
 
+template<SharedVboEnum T>
+  using BlockType_t = typename BlockType<T>::type;
+
 template<std::size_t... Is>
 auto MakeSharedVboBlocksHelper(std::index_sequence<Is...>)
-    -> std::tuple<typename BlockType<static_cast<SharedVboEnum>(Is)>::type...>;
+    -> std::tuple<BlockType_t<static_cast<SharedVboEnum>(Is)>...>;
 
 using SharedVboBlocks = decltype(MakeSharedVboBlocksHelper(
     std::make_index_sequence<NUM_SHARED_VBOS>{}));

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -68,7 +68,7 @@ public:
     /**
      * @brief Marks a UBO block as dirty by resetting its bound state.
      */
-    void invalidate(SharedVboEnum block) { m_boundBuffers[block] = std::nullopt; }
+    void invalidate(const SharedVboEnum block) { m_boundBuffers[block] = std::nullopt; }
 
     /**
      * @brief Marks all UBO blocks as dirty.
@@ -87,7 +87,7 @@ public:
      *                        will trigger a debug assertion. Set to true only when an
      *                        overwrite is intentional.
      */
-    void registerRebuildFunction(SharedVboEnum block,
+    void registerRebuildFunction(const SharedVboEnum block,
                                  RebuildFunction func,
                                  bool allowOverwrite = false)
     {
@@ -102,12 +102,15 @@ public:
     /**
      * @brief Unregisters a rebuild function for a UBO block.
      */
-    void unregisterRebuildFunction(SharedVboEnum block) { m_rebuildFunctions[block] = nullptr; }
+    void unregisterRebuildFunction(const SharedVboEnum block)
+    {
+        m_rebuildFunctions[block] = nullptr;
+    }
 
     /**
      * @brief Checks if a UBO block is currently dirty/invalid.
      */
-    NODISCARD bool isInvalid(SharedVboEnum block) const
+    NODISCARD bool isInvalid(const SharedVboEnum block) const
     {
         return !m_boundBuffers[block].has_value();
     }
@@ -116,7 +119,7 @@ public:
      * @brief Rebuilds the UBO if it's invalid using the registered rebuild function.
      * @return The bound buffer ID, or 0 if failed.
      */
-    ALLOW_DISCARD GLuint updateIfInvalid(Functions &gl, SharedVboEnum block)
+    ALLOW_DISCARD GLuint updateIfInvalid(Functions &gl, const SharedVboEnum block)
     {
         if (const auto bound = m_boundBuffers[block]) {
             return *bound;
@@ -153,7 +156,9 @@ public:
      * Overload for bulk vector data.
      */
     template<typename T, typename A>
-    ALLOW_DISCARD GLuint update(Functions &gl, SharedVboEnum block, const std::vector<T, A> &data)
+    ALLOW_DISCARD GLuint update(Functions &gl,
+                                const SharedVboEnum block,
+                                const std::vector<T, A> &data)
     {
         VBO &vbo = getOrCreateVbo(gl, block);
         gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW);
@@ -168,7 +173,7 @@ public:
      * Overload for single trivially-copyable objects.
      */
     template<typename T>
-    ALLOW_DISCARD GLuint update(Functions &gl, SharedVboEnum block, const T &data)
+    ALLOW_DISCARD GLuint update(Functions &gl, const SharedVboEnum block, const T &data)
     {
         VBO &vbo = getOrCreateVbo(gl, block);
         gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW);
@@ -249,7 +254,7 @@ public:
      * @brief Binds the UBO to its assigned point.
      * If invalid and a rebuild function is registered, it will be updated first.
      */
-    void bind(Functions &gl, SharedVboEnum block)
+    void bind(Functions &gl, const SharedVboEnum block)
     {
         const GLuint buffer = updateIfInvalid(gl, block);
 
@@ -267,7 +272,7 @@ public:
     }
 
 private:
-    NODISCARD VBO &getOrCreateVbo(Functions &gl, SharedVboEnum block)
+    NODISCARD VBO &getOrCreateVbo(Functions &gl, const SharedVboEnum block)
     {
         const auto sharedVbo = gl.getSharedVbos().get(block);
         VBO &vbo = deref(sharedVbo);
@@ -287,7 +292,7 @@ private:
      * are 0-based, contiguous, and directly correspond to UBO binding indices in
      * shader blocks.
      */
-    NODISCARD GLuint bind_internal(Functions &gl, SharedVboEnum block, GLuint buffer)
+    NODISCARD GLuint bind_internal(Functions &gl, const SharedVboEnum block, const GLuint buffer)
     {
         const auto bindingIndex = getUboBindingIndex(block);
         assert(static_cast<std::size_t>(bindingIndex) < m_boundBuffers.size());

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -34,6 +34,14 @@ class NODISCARD UboManager final
 public:
     using RebuildFunction = std::function<void(Functions &gl)>;
 
+private:
+    EnumIndexedArray<RebuildFunction, SharedVboEnum> m_rebuildFunctions;
+    EnumIndexedArray<std::optional<GLuint>, SharedVboEnum> m_boundBuffers;
+
+    // Tuple of all block types for shadow storage.
+    SharedVboBlocks m_shadowBlocks;
+
+public:
     UboManager() { invalidateAll(); }
     ~UboManager() = default;
     DELETE_CTORS_AND_ASSIGN_OPS(UboManager);
@@ -43,7 +51,7 @@ public:
      * @brief Accesses the CPU-side shadow copy of a UBO block by its enum.
      */
     template<SharedVboEnum Block>
-    typename BlockType<Block>::type &get()
+    NODISCARD typename BlockType<Block>::type &get()
     {
         return std::get<typename BlockType<Block>::type>(m_shadowBlocks);
     }
@@ -52,7 +60,7 @@ public:
      * @brief Accesses the CPU-side shadow copy of a UBO block by its enum (const).
      */
     template<SharedVboEnum Block>
-    const typename BlockType<Block>::type &get() const
+    NODISCARD const typename BlockType<Block>::type &get() const
     {
         return std::get<typename BlockType<Block>::type>(m_shadowBlocks);
     }
@@ -99,13 +107,13 @@ public:
     /**
      * @brief Checks if a UBO block is currently dirty/invalid.
      */
-    bool isInvalid(SharedVboEnum block) const { return !m_boundBuffers[block].has_value(); }
+    NODISCARD bool isInvalid(SharedVboEnum block) const { return !m_boundBuffers[block].has_value(); }
 
     /**
      * @brief Rebuilds the UBO if it's invalid using the registered rebuild function.
      * @return The bound buffer ID, or 0 if failed.
      */
-    GLuint updateIfInvalid(Functions &gl, SharedVboEnum block)
+    ALLOW_DISCARD GLuint updateIfInvalid(Functions &gl, SharedVboEnum block)
     {
         if (const auto bound = m_boundBuffers[block]) {
             return *bound;
@@ -142,7 +150,7 @@ public:
      * Overload for bulk vector data.
      */
     template<typename T, typename A>
-    GLuint update(Functions &gl, SharedVboEnum block, const std::vector<T, A> &data)
+    ALLOW_DISCARD GLuint update(Functions &gl, SharedVboEnum block, const std::vector<T, A> &data)
     {
         VBO &vbo = getOrCreateVbo(gl, block);
         static_cast<void>(
@@ -158,7 +166,7 @@ public:
      * Overload for single trivially-copyable objects.
      */
     template<typename T>
-    GLuint update(Functions &gl, SharedVboEnum block, const T &data)
+    ALLOW_DISCARD GLuint update(Functions &gl, SharedVboEnum block, const T &data)
     {
         VBO &vbo = getOrCreateVbo(gl, block);
         gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW);
@@ -171,7 +179,7 @@ public:
      * Also updates the shadow copy.
      */
     template<SharedVboEnum Block>
-    GLuint update(Functions &gl, const typename BlockType<Block>::type &data)
+    ALLOW_DISCARD GLuint update(Functions &gl, const typename BlockType<Block>::type &data)
     {
         get<Block>() = data;
         return update(gl, Block, data);
@@ -181,7 +189,7 @@ public:
      * @brief Syncs the entire shadow copy of a block to the GPU.
      */
     template<SharedVboEnum Block>
-    GLuint sync(Functions &gl)
+    ALLOW_DISCARD GLuint sync(Functions &gl)
     {
         return update(gl, Block, get<Block>());
     }
@@ -221,7 +229,7 @@ public:
         gl.glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
         // Ensure it's bound to the correct point.
-        bind_internal(gl, Block, vbo.get());
+        std::ignore = bind_internal(gl, Block, vbo.get());
     }
 
     /**
@@ -257,7 +265,7 @@ public:
     }
 
 private:
-    VBO &getOrCreateVbo(Functions &gl, SharedVboEnum block)
+    NODISCARD VBO &getOrCreateVbo(Functions &gl, SharedVboEnum block)
     {
         const auto sharedVbo = gl.getSharedVbos().get(block);
         VBO &vbo = deref(sharedVbo);
@@ -277,7 +285,7 @@ private:
      * are 0-based, contiguous, and directly correspond to UBO binding indices in
      * shader blocks.
      */
-    GLuint bind_internal(Functions &gl, SharedVboEnum block, GLuint buffer)
+    NODISCARD GLuint bind_internal(Functions &gl, SharedVboEnum block, GLuint buffer)
     {
         const auto bindingIndex = getUboBindingIndex(block);
         assert(static_cast<std::size_t>(bindingIndex) < m_boundBuffers.size());
@@ -289,13 +297,6 @@ private:
         }
         return buffer;
     }
-
-private:
-    EnumIndexedArray<RebuildFunction, SharedVboEnum> m_rebuildFunctions;
-    EnumIndexedArray<std::optional<GLuint>, SharedVboEnum> m_boundBuffers;
-
-    // Tuple of all block types for shadow storage.
-    SharedVboBlocks m_shadowBlocks;
 };
 
 } // namespace Legacy

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -156,8 +156,7 @@ public:
     ALLOW_DISCARD GLuint update(Functions &gl, SharedVboEnum block, const std::vector<T, A> &data)
     {
         VBO &vbo = getOrCreateVbo(gl, block);
-        static_cast<void>(
-            gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW));
+        gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW);
         return bind_internal(gl, block, vbo.get());
     }
 

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -32,7 +32,7 @@ namespace Legacy {
 class UboManager final
 {
 public:
-    using RebuildFunction = std::function<void(Legacy::Functions &gl)>;
+    using RebuildFunction = std::function<void(Functions &gl)>;
 
     UboManager() { invalidateAll(); }
     DELETE_CTORS_AND_ASSIGN_OPS(UboManager);
@@ -41,25 +41,25 @@ public:
     /**
      * @brief Accesses the CPU-side shadow copy of a UBO block by its enum.
      */
-    template<Legacy::SharedVboEnum Block>
-    typename Legacy::BlockType<Block>::type &get()
+    template<SharedVboEnum Block>
+    typename BlockType<Block>::type &get()
     {
-        return std::get<typename Legacy::BlockType<Block>::type>(m_shadowBlocks);
+        return std::get<typename BlockType<Block>::type>(m_shadowBlocks);
     }
 
     /**
      * @brief Accesses the CPU-side shadow copy of a UBO block by its enum (const).
      */
-    template<Legacy::SharedVboEnum Block>
-    const typename Legacy::BlockType<Block>::type &get() const
+    template<SharedVboEnum Block>
+    const typename BlockType<Block>::type &get() const
     {
-        return std::get<typename Legacy::BlockType<Block>::type>(m_shadowBlocks);
+        return std::get<typename BlockType<Block>::type>(m_shadowBlocks);
     }
 
     /**
      * @brief Marks a UBO block as dirty by resetting its bound state.
      */
-    void invalidate(Legacy::SharedVboEnum block) { m_boundBuffers[block] = std::nullopt; }
+    void invalidate(SharedVboEnum block) { m_boundBuffers[block] = std::nullopt; }
 
     /**
      * @brief Marks all UBO blocks as dirty.
@@ -78,7 +78,7 @@ public:
      *                        will trigger a debug assertion. Set to true only when an
      *                        overwrite is intentional.
      */
-    void registerRebuildFunction(Legacy::SharedVboEnum block,
+    void registerRebuildFunction(SharedVboEnum block,
                                  RebuildFunction func,
                                  bool allowOverwrite = false)
     {
@@ -93,21 +93,18 @@ public:
     /**
      * @brief Unregisters a rebuild function for a UBO block.
      */
-    void unregisterRebuildFunction(Legacy::SharedVboEnum block)
-    {
-        m_rebuildFunctions[block] = nullptr;
-    }
+    void unregisterRebuildFunction(SharedVboEnum block) { m_rebuildFunctions[block] = nullptr; }
 
     /**
      * @brief Checks if a UBO block is currently dirty/invalid.
      */
-    bool isInvalid(Legacy::SharedVboEnum block) const { return !m_boundBuffers[block].has_value(); }
+    bool isInvalid(SharedVboEnum block) const { return !m_boundBuffers[block].has_value(); }
 
     /**
      * @brief Rebuilds the UBO if it's invalid using the registered rebuild function.
      * @return The bound buffer ID, or 0 if failed.
      */
-    GLuint updateIfInvalid(Legacy::Functions &gl, Legacy::SharedVboEnum block)
+    GLuint updateIfInvalid(Functions &gl, SharedVboEnum block)
     {
         if (const auto bound = m_boundBuffers[block]) {
             return *bound;
@@ -115,7 +112,7 @@ public:
 
         const auto &func = m_rebuildFunctions[block];
         if (!func) {
-            const char *name = Legacy::Functions::getUniformBlockName(block);
+            const char *name = Functions::getUniformBlockName(block);
             MMLOG_ERROR() << "UboManager::updateIfInvalid: UBO block '" << name
                           << "' is invalid and no rebuild function is registered";
             throw std::runtime_error("UBO block '" + std::string(name)
@@ -128,7 +125,7 @@ public:
             return *bound;
         }
 
-        const char *name = Legacy::Functions::getUniformBlockName(block);
+        const char *name = Functions::getUniformBlockName(block);
         MMLOG_ERROR() << "UboManager::updateIfInvalid: rebuild function failed to call "
                          "update() for block '"
                       << name << "'";
@@ -144,9 +141,9 @@ public:
      * Overload for bulk vector data.
      */
     template<typename T, typename A>
-    GLuint update(Legacy::Functions &gl, Legacy::SharedVboEnum block, const std::vector<T, A> &data)
+    GLuint update(Functions &gl, SharedVboEnum block, const std::vector<T, A> &data)
     {
-        Legacy::VBO &vbo = getOrCreateVbo(gl, block);
+        VBO &vbo = getOrCreateVbo(gl, block);
         static_cast<void>(
             gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW));
         return bind_internal(gl, block, vbo.get());
@@ -160,9 +157,9 @@ public:
      * Overload for single trivially-copyable objects.
      */
     template<typename T>
-    GLuint update(Legacy::Functions &gl, Legacy::SharedVboEnum block, const T &data)
+    GLuint update(Functions &gl, SharedVboEnum block, const T &data)
     {
-        Legacy::VBO &vbo = getOrCreateVbo(gl, block);
+        VBO &vbo = getOrCreateVbo(gl, block);
         gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW);
         return bind_internal(gl, block, vbo.get());
     }
@@ -172,8 +169,8 @@ public:
      * Enforces the correct data structure for the given block identifier.
      * Also updates the shadow copy.
      */
-    template<Legacy::SharedVboEnum Block>
-    GLuint update(Legacy::Functions &gl, const typename Legacy::BlockType<Block>::type &data)
+    template<SharedVboEnum Block>
+    GLuint update(Functions &gl, const typename BlockType<Block>::type &data)
     {
         get<Block>() = data;
         return update(gl, Block, data);
@@ -182,8 +179,8 @@ public:
     /**
      * @brief Syncs the entire shadow copy of a block to the GPU.
      */
-    template<Legacy::SharedVboEnum Block>
-    GLuint sync(Legacy::Functions &gl)
+    template<SharedVboEnum Block>
+    GLuint sync(Functions &gl)
     {
         return update(gl, Block, get<Block>());
     }
@@ -193,10 +190,10 @@ public:
      * @param gl       Legacy functions.
      * @param members  Pointers to the members in the block struct.
      */
-    template<Legacy::SharedVboEnum Block, typename T, typename... Us>
-    void syncFields(Legacy::Functions &gl, Us T::*...members)
+    template<SharedVboEnum Block, typename T, typename... Us>
+    void syncFields(Functions &gl, Us T::*...members)
     {
-        using BlockType = typename Legacy::BlockType<Block>::type;
+        using BlockType = typename BlockType<Block>::type;
         static_assert(std::is_same_v<T, BlockType>, "Members must belong to the correct block type");
         static_assert(std::is_standard_layout_v<BlockType>,
                       "Block type must have standard layout for offset calculation");
@@ -209,7 +206,7 @@ public:
         }
 
         const auto &blockData = get<Block>();
-        Legacy::VBO &vbo = getOrCreateVbo(gl, Block);
+        VBO &vbo = getOrCreateVbo(gl, Block);
         gl.glBindBuffer(GL_UNIFORM_BUFFER, vbo.get());
 
         (gl.glBufferSubData(GL_UNIFORM_BUFFER,
@@ -231,8 +228,8 @@ public:
      * @param gl      Legacy functions.
      * @param member  Pointer to the member in the block struct.
      */
-    template<Legacy::SharedVboEnum Block, typename T, typename U>
-    void syncField(Legacy::Functions &gl, U T::*member)
+    template<SharedVboEnum Block, typename T, typename U>
+    void syncField(Functions &gl, U T::*member)
     {
         syncFields<Block>(gl, member);
     }
@@ -241,7 +238,7 @@ public:
      * @brief Binds the UBO to its assigned point.
      * If invalid and a rebuild function is registered, it will be updated first.
      */
-    void bind(Legacy::Functions &gl, Legacy::SharedVboEnum block)
+    void bind(Functions &gl, SharedVboEnum block)
     {
         const GLuint buffer = updateIfInvalid(gl, block);
 
@@ -259,10 +256,10 @@ public:
     }
 
 private:
-    Legacy::VBO &getOrCreateVbo(Legacy::Functions &gl, Legacy::SharedVboEnum block)
+    VBO &getOrCreateVbo(Functions &gl, SharedVboEnum block)
     {
         const auto sharedVbo = gl.getSharedVbos().get(block);
-        Legacy::VBO &vbo = deref(sharedVbo);
+        VBO &vbo = deref(sharedVbo);
 
         if (!vbo) {
             vbo.emplace(gl.shared_from_this());
@@ -275,13 +272,13 @@ private:
      * @brief Binds the UBO to its assigned point.
      * @return The bound buffer ID.
      *
-     * Note: This implementation explicitly assumes that Legacy::SharedVboEnum values
+     * Note: This implementation explicitly assumes that SharedVboEnum values
      * are 0-based, contiguous, and directly correspond to UBO binding indices in
      * shader blocks.
      */
-    GLuint bind_internal(Legacy::Functions &gl, Legacy::SharedVboEnum block, GLuint buffer)
+    GLuint bind_internal(Functions &gl, SharedVboEnum block, GLuint buffer)
     {
-        const auto bindingIndex = Legacy::getUboBindingIndex(block);
+        const auto bindingIndex = getUboBindingIndex(block);
         assert(static_cast<std::size_t>(bindingIndex) < m_boundBuffers.size());
 
         auto &bound = m_boundBuffers[block];
@@ -293,11 +290,11 @@ private:
     }
 
 private:
-    EnumIndexedArray<RebuildFunction, Legacy::SharedVboEnum> m_rebuildFunctions;
-    EnumIndexedArray<std::optional<GLuint>, Legacy::SharedVboEnum> m_boundBuffers;
+    EnumIndexedArray<RebuildFunction, SharedVboEnum> m_rebuildFunctions;
+    EnumIndexedArray<std::optional<GLuint>, SharedVboEnum> m_boundBuffers;
 
     // Tuple of all block types for shadow storage.
-    Legacy::SharedVboBlocks m_shadowBlocks;
+    SharedVboBlocks m_shadowBlocks;
 };
 
 } // namespace Legacy

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -35,6 +35,7 @@ public:
     using RebuildFunction = std::function<void(Functions &gl)>;
 
     UboManager() { invalidateAll(); }
+    ~UboManager() = default;
     DELETE_CTORS_AND_ASSIGN_OPS(UboManager);
 
 public:

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -29,7 +29,7 @@ namespace Legacy {
  *
  * Note: This class is not thread-safe.
  */
-class UboManager final
+class NODISCARD UboManager final
 {
 public:
     using RebuildFunction = std::function<void(Functions &gl)>;

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -51,18 +51,18 @@ public:
      * @brief Accesses the CPU-side shadow copy of a UBO block by its enum.
      */
     template<SharedVboEnum Block>
-    NODISCARD typename BlockType<Block>::type &get()
+    NODISCARD BlockType_t<Block> &get()
     {
-        return std::get<typename BlockType<Block>::type>(m_shadowBlocks);
+        return std::get<BlockType_t<Block>>(m_shadowBlocks);
     }
 
     /**
      * @brief Accesses the CPU-side shadow copy of a UBO block by its enum (const).
      */
     template<SharedVboEnum Block>
-    NODISCARD const typename BlockType<Block>::type &get() const
+    NODISCARD const BlockType_t<Block> &get() const
     {
-        return std::get<typename BlockType<Block>::type>(m_shadowBlocks);
+        return std::get<BlockType_t<Block>>(m_shadowBlocks);
     }
 
     /**
@@ -107,7 +107,10 @@ public:
     /**
      * @brief Checks if a UBO block is currently dirty/invalid.
      */
-    NODISCARD bool isInvalid(SharedVboEnum block) const { return !m_boundBuffers[block].has_value(); }
+    NODISCARD bool isInvalid(SharedVboEnum block) const
+    {
+        return !m_boundBuffers[block].has_value();
+    }
 
     /**
      * @brief Rebuilds the UBO if it's invalid using the registered rebuild function.
@@ -179,7 +182,7 @@ public:
      * Also updates the shadow copy.
      */
     template<SharedVboEnum Block>
-    ALLOW_DISCARD GLuint update(Functions &gl, const typename BlockType<Block>::type &data)
+    ALLOW_DISCARD GLuint update(Functions &gl, const BlockType_t<Block> &data)
     {
         get<Block>() = data;
         return update(gl, Block, data);
@@ -202,7 +205,7 @@ public:
     template<SharedVboEnum Block, typename T, typename... Us>
     void syncFields(Functions &gl, Us T::*...members)
     {
-        using BlockType = typename BlockType<Block>::type;
+        using BlockType = BlockType_t<Block>;
         static_assert(std::is_same_v<T, BlockType>, "Members must belong to the correct block type");
         static_assert(std::is_standard_layout_v<BlockType>,
                       "Block type must have standard layout for offset calculation");

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -17,15 +17,7 @@
 #include <cstdlib>
 
 #include <glm/glm.hpp>
-
-namespace {
-template<typename T>
-T lerp(T a, T b, float t)
-{
-    return a + t * (b - a);
-}
-
-} // namespace
+#include <glm/gtx/compatibility.hpp>
 
 /**
  * Weather transition authority documentation:
@@ -360,7 +352,7 @@ float GLWeather::applyTransition(const float startTime,
     const float t = (m_animationManager.getElapsedTime() - startTime)
                     / WeatherConstants::TRANSITION_DURATION;
     const float factor = std::clamp(t, 0.0f, 1.0f);
-    return lerp(startVal, targetVal, factor);
+    return glm::lerp(startVal, targetVal, factor);
 }
 
 template<typename T>

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -110,7 +110,7 @@ private:
     NODISCARD T applyTransition(float startTime, T startVal, T targetVal) const;
 
     template<typename T>
-    struct TransitionPair
+    struct NODISCARD TransitionPair final
     {
         T &start;
         T target;

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -344,7 +344,7 @@ public:
     NODISCARD bool canRenderQuads() { return virt_canRenderQuads(); }
 
     /// platform-specific (ES vs GL)
-    NODISCARD std::optional<GLenum> toGLenum(DrawModeEnum mode) { return virt_toGLenum(mode); }
+    NODISCARD std::optional<GLenum> toGLenum(const DrawModeEnum mode) { return virt_toGLenum(mode); }
 
 protected:
 private:

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -330,7 +330,7 @@ public:
     /// platform-specific (ES vs GL)
     NODISCARD const char *getShaderVersion() const { return virt_getShaderVersion(); }
 
-protected:
+private:
     NODISCARD virtual bool virt_canRenderQuads() = 0;
     NODISCARD virtual std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) = 0;
     virtual void virt_enableProgramPointSize(bool enable) = 0;

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -344,7 +344,10 @@ public:
     NODISCARD bool canRenderQuads() { return virt_canRenderQuads(); }
 
     /// platform-specific (ES vs GL)
-    NODISCARD std::optional<GLenum> toGLenum(const DrawModeEnum mode) { return virt_toGLenum(mode); }
+    NODISCARD std::optional<GLenum> toGLenum(const DrawModeEnum mode)
+    {
+        return virt_toGLenum(mode);
+    }
 
 protected:
 private:

--- a/src/opengl/legacy/SimpleMesh.h
+++ b/src/opengl/legacy/SimpleMesh.h
@@ -180,7 +180,7 @@ private:
         RenderStateBinder renderStateBinder(m_functions, m_functions.getTexLookup(), renderState);
 
         m_functions.glBindVertexArray(m_vao.get());
-        RAIICallback vaoUnbinder([&]() {
+        RAIICallback vaoUnbinder([this]() {
             m_functions.glBindVertexArray(0);
             m_functions.checkError();
         });

--- a/src/opengl/legacy/TFO.h
+++ b/src/opengl/legacy/TFO.h
@@ -8,6 +8,7 @@
 
 namespace Legacy {
 
+// TFO = Transform Feedback Object
 class NODISCARD TFO final
 {
 private:

--- a/src/parser/AbstractParser-Commands.cpp
+++ b/src/parser/AbstractParser-Commands.cpp
@@ -4,7 +4,6 @@
 
 #include "AbstractParser-Commands.h"
 
-#include "../global/AsyncTasks.h"
 #include "../global/CaseUtils.h"
 #include "../global/Consts.h"
 #include "../global/LineUtils.h"
@@ -17,11 +16,11 @@
 #include "../map/enums.h"
 #include "../map/infomark.h"
 #include "../mapdata/mapdata.h"
+#include "../observer/gameobserver.h"
 #include "../syntax/SyntaxArgs.h"
 #include "../syntax/TreeParser.h"
 #include "../viewers/AnsiViewWindow.h"
 #include "../viewers/LaunchAsyncViewer.h"
-#include "../viewers/TopLevelWindows.h"
 #include "Abbrev.h"
 #include "AbstractParser-Utils.h"
 #include "DoorAction.h"
@@ -37,8 +36,181 @@
 #include <utility>
 #include <vector>
 
-#include <QMessageLogContext>
 #include <QtCore>
+
+namespace { // anonymous
+
+NODISCARD std::string_view safe_substr(const std::string_view sv, const size_t maxlen)
+{
+    if (sv.size() > maxlen) {
+        return sv.substr(0, maxlen);
+    }
+    return sv; // NOLINT (clang-tidy false positive)
+}
+
+NODISCARD bool compareUtf8NoCase(const std::string_view a, const std::string_view b)
+{
+    // this is disgusting
+    return QString::compare(mmqt::toQByteArrayUtf8(a),
+                            mmqt::toQByteArrayUtf8(b),
+                            Qt::CaseInsensitive)
+           == 0;
+}
+
+struct NODISCARD SendToUserHelper final
+{
+private:
+    std::ostringstream m_oss;
+    AnsiOstream m_aos{m_oss};
+    AbstractParser &m_self;
+    SendToUserSourceEnum m_source = SendToUserSourceEnum::FromMMapper;
+
+public:
+    explicit SendToUserHelper(AbstractParser &self,
+                              SendToUserSourceEnum src = SendToUserSourceEnum::FromMMapper)
+        : m_self{self}
+        , m_source{src}
+    {}
+    DELETE_CTORS_AND_ASSIGN_OPS(SendToUserHelper);
+    ~SendToUserHelper()
+    {
+        if (!m_aos.hasNewline()) {
+            m_aos.writeNewline();
+        }
+        m_self.sendToUser(m_source, m_oss.str());
+    }
+    NODISCARD AnsiOstream &getAnsiOstream() { return m_aos; }
+};
+
+template<typename T>
+concept PointerConcept = std::is_pointer_v<T>;
+
+template<typename T>
+concept ContiguousContainer = requires(const T &x) {
+    { x.data() } -> PointerConcept;
+    { x.size() } -> std::integral;
+    { x.empty() } -> std::same_as<bool>;
+};
+
+template<typename E>
+concept EnumConcept = std::is_enum_v<E>;
+
+template<typename T>
+concept StringViewGetter = requires(const T &x) {
+    { x() } -> std::same_as<std::string_view>;
+};
+
+template<typename T>
+concept EnumIndexecContiguousContainer
+    = ContiguousContainer<T> and EnumConcept<typename T::index_type>
+      and ((requires(const T &x, const typename T::index_type e) {
+               // returns const ref
+               { x[e] } -> std::same_as<const typename T::value_type &>;
+           }) or (requires(const T &x, const typename T::index_type e) {
+               // returns by value
+               { x[e] } -> std::same_as<typename T::value_type>;
+           }) or (requires(T &x, const typename T::index_type e) {
+               // returns mutable reference
+               { x[e] } -> std::same_as<typename T::value_type &>;
+           }));
+
+template<typename T>
+concept StringLikeConcept = std::is_same_v<std::string_view, std::remove_cvref_t<T>>
+                            or std::is_same_v<std::string, std::remove_cvref_t<T>>
+                            or std::is_same_v<const char *, std::remove_cvref_t<T>>;
+
+template<typename T>
+concept EnumIndexecContiguousStringContainer = EnumIndexecContiguousContainer<T>
+                                               and requires(const T &x) {
+                                                       { *x.data() } -> StringLikeConcept;
+                                                   };
+
+// test the EnumIndexecContiguousStringContainer concept:
+template<typename T>
+using CommandArray = EnumIndexedArray<T, CommandEnum, NUM_COMMANDS>;
+static_assert(EnumIndexecContiguousStringContainer<CommandArray<std::string>>);
+static_assert(EnumIndexecContiguousStringContainer<CommandArray<std::string_view>>);
+static_assert(EnumIndexecContiguousStringContainer<CommandArray<const char *>>);
+
+template<EnumIndexecContiguousStringContainer Container>
+auto find_abbrev(const Container &container,
+                 const std::string_view input_sv,
+                 const size_t required_len) -> std::optional<typename Container::index_type>
+{
+    using E = typename Container::index_type;
+    if (const auto arglen = input_sv.size(); arglen >= required_len) {
+        for (const std::string_view w : container) {
+            if (compareUtf8NoCase(input_sv, safe_substr(w, arglen))) {
+                if (std::optional<E> opt = container.findIndexOf(w)) {
+                    return opt;
+                }
+            }
+        }
+    }
+    return std::nullopt;
+};
+
+// This might be able to support EnumIndexecContiguousContainer instead of
+// EnumIndexecContiguousStringContainer, but we'd need a concept to check
+// if the contained type can be written to an ansi ostream.
+template<EnumIndexecContiguousStringContainer Container>
+void concat_comma_and_or(AnsiOstream &aos,
+                         const Container &container,
+                         // color each word int he container
+                         const RawAnsi &ansi,
+                         // e.g. "and" or "or"
+                         const std::string_view and_or)
+{
+    using E = typename Container::index_type;
+    if (container.empty()) {
+        return; // This is probably an error, so maybe it should throw or print "(none)" ?
+    }
+    const size_t size = container.size();
+    for (size_t i = 0; i < size; ++i) {
+        if (i != 0) {
+            aos << ", ";
+            if (i + 1 == size && !and_or.empty()) {
+                aos << and_or << " ";
+            }
+        }
+        const auto e = static_cast<E>(i);
+        aos << ColoredValue{ansi, container[e]};
+    }
+}
+
+// one or more question marks
+template<typename T>
+NODISCARD bool is_question_marks(const T word)
+{
+    if constexpr (std::is_same_v<T, std::string_view>) {
+        return !word.empty() && std::all_of(word.begin(), word.end(), [](char c) -> bool {
+            return c == char_consts::C_QUESTION_MARK;
+        });
+    } else if constexpr (std::is_same_v<T, StringView>) {
+        return is_question_marks<std::string_view>(word.getStdStringView());
+    } else {
+        static_assert(std::is_same_v<T, void>, "unsupported word type");
+        std::abort();
+    }
+}
+
+constexpr auto green = getRawAnsi(AnsiColor16Enum::green);
+constexpr auto red = getRawAnsi(AnsiColor16Enum::red);
+constexpr auto yellow = getRawAnsi(AnsiColor16Enum::yellow);
+
+constexpr EnumIndexedArray<std::string_view, PromptFogEnum, NUM_PROMPT_FOG_TYPES> all_fog_names{
+#define X_CASE(_x) std::string_view{#_x},
+    XFOREACH_PROMPT_FOG_ENUM(X_CASE)
+#undef X_CASE
+};
+constexpr EnumIndexedArray<std::string_view, PromptWeatherEnum, NUM_PROMPT_WEATHER_TYPES>
+    all_weather_names{
+#define X_CASE(_x) std::string_view{#_x},
+        XFOREACH_PROMPT_WEATHER_ENUM(X_CASE)
+#undef X_CASE
+    };
+
+} // namespace
 
 const Abbrev cmdBack{"back"};
 const Abbrev cmdConfig{"config", 4};
@@ -514,13 +686,36 @@ bool AbstractParser::parseDoorAction(const DoorActionEnum dat, StringView words)
 
 void AbstractParser::parseSetCommand(StringView view)
 {
+    auto show_set_syntax = [this] {
+        SendToUserHelper helper{*this};
+        AnsiOstream &aos = helper.getAnsiOstream();
+
+        aos << "Syntax:" << AnsiOstream::endl;
+        aos << "  " << getPrefixChar() << "set ..." << AnsiOstream::endl;
+        {
+            aos << "    ... fog [";
+            concat_comma_and_or(aos, all_fog_names, green, "or");
+            aos << "]" << AnsiOstream::endl;
+        }
+        aos << "    ... prefix [punct-char]" << AnsiOstream::endl;
+        {
+            aos << "    ... weather [";
+            concat_comma_and_or(aos, all_weather_names, green, "or");
+            aos << "]" << AnsiOstream::endl;
+        }
+    };
+
     if (view.isEmpty()) {
-        sendToUser(SendToUserSourceEnum::FromMMapper,
-                   QString("Syntax: %1set prefix [punct-char]\n").arg(getPrefixChar()));
+        show_set_syntax();
         return;
     }
 
     auto first = view.takeFirstWord();
+    if (is_question_marks(first)) {
+        show_set_syntax();
+        return;
+    }
+
     if (Abbrev{"prefix", 3}.matches(first)) {
         if (view.isEmpty()) {
             showCommandPrefix();
@@ -549,7 +744,85 @@ void AbstractParser::parseSetCommand(StringView view)
         return;
     }
 
-    sendToUser(SendToUserSourceEnum::FromMMapper, "That variable is not supported.");
+    auto process_set_command = [this,
+                                &view](const std::string_view what,
+                                       const EnumIndexecContiguousStringContainer auto &enum_names,
+                                       const size_t required_len,
+                                       StringViewGetter auto &&get,
+                                       auto &&set) {
+        using E = typename std::remove_cvref_t<decltype(enum_names)>::index_type;
+        static_assert(std::is_invocable_r_v<void, decltype(set), E>,
+                      "constraints not satisfied"); // easier than writing a concept.
+
+        if (view.isEmpty()) {
+            SendToUserHelper helper{*this};
+            AnsiOstream &aos = helper.getAnsiOstream();
+            aos << "The current " << what << " is: " << ColoredValue{green, get()} << ".";
+            return;
+        }
+
+        const auto next = view.takeFirstWord();
+        const auto input_sv = next.getStdStringView();
+
+        auto show_sim = [this, &enum_names, what](const E e) {
+            SendToUserHelper helper{*this};
+            AnsiOstream &aos = helper.getAnsiOstream();
+            aos << "Simulating " << what << ": " << ColoredValue{green, enum_names[e]} << "...";
+        };
+
+        auto choose = [&show_sim, &set](const E e) {
+            show_sim(e);
+            set(e);
+        };
+
+        auto failure = [this, input_sv, &enum_names, what]() {
+            SendToUserHelper helper{*this};
+            AnsiOstream &aos = helper.getAnsiOstream();
+
+            if (!is_question_marks(input_sv)) {
+                aos << "Error: Unrecognized " << what
+                    << " option: " << ColoredQuotedStringView{red, yellow, input_sv} << "."
+                    << AnsiOstream::endl;
+            }
+
+            aos << "Valid " << what << " options: ";
+            concat_comma_and_or(aos, enum_names, green, "or");
+            aos << "." << AnsiOstream::endl;
+        };
+
+        if (auto opt = find_abbrev(enum_names, input_sv, required_len)) {
+            choose(*opt);
+        } else {
+            failure();
+        }
+    };
+
+    if (Abbrev{"fog", 3}.matches(first)) {
+        process_set_command(
+            "fog",
+            all_fog_names,
+            2, // "no" should match "no_fog"
+            [this]() -> std::string_view { return to_string_view(m_gameObserver.getFog()); },
+            [this](const PromptFogEnum e) { m_gameObserver.observeFog(e); });
+        return;
+    } else if (Abbrev{"weather", 3}.matches(first)) {
+        process_set_command(
+            "weather",
+            all_weather_names,
+            3,
+            [this]() -> std::string_view { return to_string_view(m_gameObserver.getWeather()); },
+            [this](const PromptWeatherEnum e) { m_gameObserver.observeWeather(e); });
+
+        return;
+    }
+
+    {
+        SendToUserHelper helper{*this};
+        AnsiOstream &aos = helper.getAnsiOstream();
+        aos << "Error: " << ColoredQuotedStringView{red, yellow, first.getStdStringView()}
+            << " is not a valid variable name." << AnsiOstream::endl;
+    }
+    show_set_syntax();
 }
 
 void AbstractParser::parseSpecialCommand(StringView wholeCommand)

--- a/src/parser/AbstractParser-Commands.cpp
+++ b/src/parser/AbstractParser-Commands.cpp
@@ -82,18 +82,22 @@ public:
     NODISCARD AnsiOstream &getAnsiOstream() { return m_aos; }
 };
 
+namespace concepts {
 template<typename T>
-concept PointerConcept = std::is_pointer_v<T>;
-
-template<typename T>
-concept ContiguousContainer = requires(const T &x) {
-    { x.data() } -> PointerConcept;
+concept ContiguousContainer = requires { typename T::value_type; } and requires(const T &x) {
+    { x.data() } -> std::same_as<const typename T::value_type *>;
     { x.size() } -> std::integral;
     { x.empty() } -> std::same_as<bool>;
+    x.begin();
+    x.end();
+} and requires(T &x) {
+    { x.data() } -> std::same_as<typename T::value_type *>;
+    x.begin();
+    x.end();
 };
 
 template<typename E>
-concept EnumConcept = std::is_enum_v<E>;
+concept IsEnum = std::is_enum_v<E>;
 
 template<typename T>
 concept StringViewGetter = requires(const T &x) {
@@ -101,41 +105,37 @@ concept StringViewGetter = requires(const T &x) {
 };
 
 template<typename T>
-concept EnumIndexecContiguousContainer
-    = ContiguousContainer<T> and EnumConcept<typename T::index_type>
-      and ((requires(const T &x, const typename T::index_type e) {
-               // returns const ref
-               { x[e] } -> std::same_as<const typename T::value_type &>;
-           }) or (requires(const T &x, const typename T::index_type e) {
-               // returns by value
-               { x[e] } -> std::same_as<typename T::value_type>;
-           }) or (requires(T &x, const typename T::index_type e) {
-               // returns mutable reference
-               { x[e] } -> std::same_as<typename T::value_type &>;
-           }));
+concept EnumIndexedContiguousContainer = ContiguousContainer<T> and requires {
+    typename T::index_type;
+} and IsEnum<typename T::index_type> and requires(const T &x, const typename T::index_type e) {
+    { x[e] } -> std::same_as<const typename T::value_type &>;
+} and requires(T &x, const typename T::index_type e) {
+    { x[e] } -> std::same_as<typename T::value_type &>;
+};
 
 template<typename T>
-concept StringLikeConcept = std::is_same_v<std::string_view, std::remove_cvref_t<T>>
-                            or std::is_same_v<std::string, std::remove_cvref_t<T>>
-                            or std::is_same_v<const char *, std::remove_cvref_t<T>>;
-
-template<typename T>
-concept EnumIndexecContiguousStringContainer = EnumIndexecContiguousContainer<T>
-                                               and requires(const T &x) {
-                                                       { *x.data() } -> StringLikeConcept;
-                                                   };
+concept EnumIndexedContiguousStringContainer
+    = EnumIndexedContiguousContainer<T> and requires(const T &x) {
+          { *x.data() } -> std::convertible_to<std::string_view>;
+      } and requires(const T &x, const typename T::index_type e) {
+          { x[e] } -> std::convertible_to<std::string_view>;
+      };
 
 // test the EnumIndexecContiguousStringContainer concept:
 template<typename T>
 using CommandArray = EnumIndexedArray<T, CommandEnum, NUM_COMMANDS>;
-static_assert(EnumIndexecContiguousStringContainer<CommandArray<std::string>>);
-static_assert(EnumIndexecContiguousStringContainer<CommandArray<std::string_view>>);
-static_assert(EnumIndexecContiguousStringContainer<CommandArray<const char *>>);
+static_assert(!EnumIndexedContiguousStringContainer<CommandArray<int>>);
+static_assert(EnumIndexedContiguousStringContainer<CommandArray<std::string>>);
+static_assert(EnumIndexedContiguousStringContainer<CommandArray<std::string_view>>);
+static_assert(EnumIndexedContiguousStringContainer<CommandArray<const char *>>);
 
-template<EnumIndexecContiguousStringContainer Container>
-auto find_abbrev(const Container &container,
-                 const std::string_view input_sv,
-                 const size_t required_len) -> std::optional<typename Container::index_type>
+} // namespace concepts
+
+template<concepts::EnumIndexedContiguousStringContainer Container>
+NODISCARD auto find_abbrev(const Container &container,
+                           const std::string_view input_sv,
+                           const size_t required_len)
+    -> std::optional<typename Container::index_type>
 {
     using E = typename Container::index_type;
     if (const auto arglen = input_sv.size(); arglen >= required_len) {
@@ -153,7 +153,7 @@ auto find_abbrev(const Container &container,
 // This might be able to support EnumIndexecContiguousContainer instead of
 // EnumIndexecContiguousStringContainer, but we'd need a concept to check
 // if the contained type can be written to an ansi ostream.
-template<EnumIndexecContiguousStringContainer Container>
+template<concepts::EnumIndexedContiguousStringContainer Container>
 void concat_comma_and_or(AnsiOstream &aos,
                          const Container &container,
                          // color each word int he container
@@ -209,6 +209,56 @@ constexpr EnumIndexedArray<std::string_view, PromptWeatherEnum, NUM_PROMPT_WEATH
         XFOREACH_PROMPT_WEATHER_ENUM(X_CASE)
 #undef X_CASE
     };
+
+template<concepts::EnumIndexedContiguousStringContainer Container,
+         concepts::StringViewGetter Getter,
+         typename Setter>
+    requires(std::is_invocable_r_v<void, Setter, typename Container::index_type>)
+void trySetEnumValue(AbstractParser &parser,
+                     StringView view,
+                     const std::string_view what,
+                     const Container &enum_names,
+                     const size_t required_len,
+                     Getter &&get,
+                     Setter &&set)
+{
+    using E = typename Container::index_type;
+
+    if (view.isEmpty()) {
+        SendToUserHelper helper{parser};
+        AnsiOstream &aos = helper.getAnsiOstream();
+        aos << "The current " << what << " is: " << ColoredValue{green, get()} << ".";
+        return;
+    }
+
+    const auto next = view.takeFirstWord();
+    const auto input_sv = next.getStdStringView();
+
+    if (const std::optional<E> opt = find_abbrev(enum_names, input_sv, required_len)) {
+        // success
+        const E e = *opt;
+        {
+            SendToUserHelper helper{parser};
+            AnsiOstream &aos = helper.getAnsiOstream();
+            aos << "Setting " << what << " to " << ColoredValue{green, enum_names[e]} << "...";
+        }
+        set(e);
+    } else {
+        // failure
+        SendToUserHelper helper{parser};
+        AnsiOstream &aos = helper.getAnsiOstream();
+
+        if (!is_question_marks(input_sv)) {
+            aos << "Error: Unrecognized " << what
+                << " option: " << ColoredQuotedStringView{red, yellow, input_sv} << "."
+                << AnsiOstream::endl;
+        }
+
+        aos << "Valid " << what << " options: ";
+        concat_comma_and_or(aos, enum_names, green, "or");
+        aos << "." << AnsiOstream::endl;
+    }
+}
 
 } // namespace
 
@@ -744,75 +794,27 @@ void AbstractParser::parseSetCommand(StringView view)
         return;
     }
 
-    auto process_set_command = [this,
-                                &view](const std::string_view what,
-                                       const EnumIndexecContiguousStringContainer auto &enum_names,
-                                       const size_t required_len,
-                                       StringViewGetter auto &&get,
-                                       auto &&set) {
-        using E = typename std::remove_cvref_t<decltype(enum_names)>::index_type;
-        static_assert(std::is_invocable_r_v<void, decltype(set), E>,
-                      "constraints not satisfied"); // easier than writing a concept.
-
-        if (view.isEmpty()) {
-            SendToUserHelper helper{*this};
-            AnsiOstream &aos = helper.getAnsiOstream();
-            aos << "The current " << what << " is: " << ColoredValue{green, get()} << ".";
-            return;
-        }
-
-        const auto next = view.takeFirstWord();
-        const auto input_sv = next.getStdStringView();
-
-        auto show_sim = [this, &enum_names, what](const E e) {
-            SendToUserHelper helper{*this};
-            AnsiOstream &aos = helper.getAnsiOstream();
-            aos << "Simulating " << what << ": " << ColoredValue{green, enum_names[e]} << "...";
-        };
-
-        auto choose = [&show_sim, &set](const E e) {
-            show_sim(e);
-            set(e);
-        };
-
-        auto failure = [this, input_sv, &enum_names, what]() {
-            SendToUserHelper helper{*this};
-            AnsiOstream &aos = helper.getAnsiOstream();
-
-            if (!is_question_marks(input_sv)) {
-                aos << "Error: Unrecognized " << what
-                    << " option: " << ColoredQuotedStringView{red, yellow, input_sv} << "."
-                    << AnsiOstream::endl;
-            }
-
-            aos << "Valid " << what << " options: ";
-            concat_comma_and_or(aos, enum_names, green, "or");
-            aos << "." << AnsiOstream::endl;
-        };
-
-        if (auto opt = find_abbrev(enum_names, input_sv, required_len)) {
-            choose(*opt);
-        } else {
-            failure();
-        }
-    };
-
     if (Abbrev{"fog", 3}.matches(first)) {
-        process_set_command(
+        trySetEnumValue(
+            *this,
+            view,
             "fog",
             all_fog_names,
             2, // "no" should match "no_fog"
             [this]() -> std::string_view { return to_string_view(m_gameObserver.getFog()); },
             [this](const PromptFogEnum e) { m_gameObserver.observeFog(e); });
         return;
-    } else if (Abbrev{"weather", 3}.matches(first)) {
-        process_set_command(
+    }
+
+    if (Abbrev{"weather", 3}.matches(first)) {
+        trySetEnumValue(
+            *this,
+            view,
             "weather",
             all_weather_names,
             3,
             [this]() -> std::string_view { return to_string_view(m_gameObserver.getWeather()); },
             [this](const PromptWeatherEnum e) { m_gameObserver.observeWeather(e); });
-
         return;
     }
 

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -163,9 +163,11 @@ AbstractParser::AbstractParser(MapData &md,
                                HotkeyManager &hm,
                                QObject *const parent,
                                AbstractParserOutputs &outputs,
-                               ParserCommonData &commonData)
+                               ParserCommonData &commonData,
+                               GameObserver &gameObserver)
     : ParserCommon{parent, mc, md, group, hm, proxyUserGmcp, outputs, commonData}
     , m_proxyMudConnection{proxyMudConnection}
+    , m_gameObserver{gameObserver}
 {
     QObject::connect(&m_offlineCommandTimer, &QTimer::timeout, this, [this]() {
         doOfflineCharacterMove();

--- a/src/parser/abstractparser.h
+++ b/src/parser/abstractparser.h
@@ -44,13 +44,14 @@
 #include <QTimer>
 #include <QVariant>
 
+class CTimers;
 class Coordinate;
+class GameObserver;
 class HotkeyManager;
 class MapData;
 class MumeClock;
 class RoomFieldVariant;
 class RoomFilter;
-class CTimers;
 
 namespace syntax {
 class Sublist;
@@ -344,6 +345,7 @@ private:
 
 private:
     QTimer m_offlineCommandTimer;
+    GameObserver &m_gameObserver;
 
 public:
     explicit AbstractParser(MapData &,
@@ -354,7 +356,8 @@ public:
                             HotkeyManager &,
                             QObject *parent,
                             AbstractParserOutputs &outputs,
-                            ParserCommonData &commonData);
+                            ParserCommonData &commonData,
+                            GameObserver &gameObserver);
     ~AbstractParser() override;
 
     void doMove(CommandEnum cmd);

--- a/src/preferences/AdvancedGraphics.cpp
+++ b/src/preferences/AdvancedGraphics.cpp
@@ -24,7 +24,7 @@
 #include <QVector>
 #include <QWidget>
 
-SliderSpinboxButton::~SliderSpinboxButton() {}
+SliderSpinboxButton::~SliderSpinboxButton() = default;
 
 template<int D>
 class NODISCARD FpSlider final : public QSlider

--- a/src/preferences/audiopage.cpp
+++ b/src/preferences/audiopage.cpp
@@ -5,6 +5,7 @@
 
 #include "../configuration/configuration.h"
 #include "../global/SignalBlocker.h"
+#include "../mainwindow/AudioVolumeSlider.h"
 #include "ui_audiopage.h"
 
 #ifndef MMAPPER_NO_AUDIO
@@ -21,14 +22,6 @@ AudioPage::AudioPage(QWidget *const parent)
     slot_updateDevices();
     slot_loadConfig();
 
-    connect(ui->musicVolumeSlider,
-            &QSlider::valueChanged,
-            this,
-            &AudioPage::slot_musicVolumeChanged);
-    connect(ui->soundsVolumeSlider,
-            &QSlider::valueChanged,
-            this,
-            &AudioPage::slot_soundsVolumeChanged);
     connect(ui->outputDeviceComboBox,
             &QComboBox::currentIndexChanged,
             this,
@@ -41,8 +34,6 @@ AudioPage::AudioPage(QWidget *const parent)
 
     if constexpr (NO_AUDIO) {
         ui->outputDeviceComboBox->setEnabled(false);
-        ui->musicVolumeSlider->setEnabled(false);
-        ui->soundsVolumeSlider->setEnabled(false);
     }
 }
 
@@ -58,8 +49,8 @@ void AudioPage::slot_loadConfig()
     SignalBlocker outputBlocker(*ui->outputDeviceComboBox);
 
     const auto &settings = getConfig().audio;
-    ui->musicVolumeSlider->setValue(settings.getMusicVolume());
-    ui->soundsVolumeSlider->setValue(settings.getSoundVolume());
+    ui->musicVolumeSlider->updateFromConfig();
+    ui->soundsVolumeSlider->updateFromConfig();
 
     int index = ui->outputDeviceComboBox->findData(settings.getOutputDeviceId());
     if (index != -1) {
@@ -67,20 +58,6 @@ void AudioPage::slot_loadConfig()
     } else {
         ui->outputDeviceComboBox->setCurrentIndex(0);
     }
-}
-
-void AudioPage::slot_musicVolumeChanged(int value)
-{
-    auto &settings = setConfig().audio;
-    settings.setMusicVolume(value);
-    settings.setUnlocked();
-}
-
-void AudioPage::slot_soundsVolumeChanged(int value)
-{
-    auto &settings = setConfig().audio;
-    settings.setSoundVolume(value);
-    settings.setUnlocked();
 }
 
 void AudioPage::slot_outputDeviceChanged(int index)

--- a/src/preferences/audiopage.h
+++ b/src/preferences/audiopage.h
@@ -23,8 +23,6 @@ public:
 
 public slots:
     void slot_loadConfig();
-    void slot_musicVolumeChanged(int);
-    void slot_soundsVolumeChanged(int);
     void slot_outputDeviceChanged(int);
     void slot_updateDevices();
 };

--- a/src/preferences/audiopage.ui
+++ b/src/preferences/audiopage.ui
@@ -44,12 +44,9 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSlider" name="musicVolumeSlider">
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="AudioVolumeSlider" name="musicVolumeSlider">
+        <property name="audioType">
+         <enum>AudioVolumeSlider::Music</enum>
         </property>
        </widget>
       </item>
@@ -70,12 +67,9 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSlider" name="soundsVolumeSlider">
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="AudioVolumeSlider" name="soundsVolumeSlider">
+        <property name="audioType">
+         <enum>AudioVolumeSlider::Sound</enum>
         </property>
        </widget>
       </item>
@@ -97,6 +91,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AudioVolumeSlider</class>
+   <extends>QSlider</extends>
+   <header>mainwindow/AudioVolumeSlider.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/preferences/audiopage.ui
+++ b/src/preferences/audiopage.ui
@@ -46,7 +46,7 @@
       <item row="1" column="1">
        <widget class="AudioVolumeSlider" name="musicVolumeSlider">
         <property name="audioType">
-         <enum>AudioVolumeSlider::Music</enum>
+         <enum>AudioVolumeSlider::AudioType::Music</enum>
         </property>
        </widget>
       </item>
@@ -69,7 +69,7 @@
       <item row="1" column="1">
        <widget class="AudioVolumeSlider" name="soundsVolumeSlider">
         <property name="audioType">
-         <enum>AudioVolumeSlider::Sound</enum>
+         <enum>AudioVolumeSlider::AudioType::Sound</enum>
         </property>
        </widget>
       </item>

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -116,18 +116,15 @@ void ConfigDialog::createIcons()
 {
     const QSize iconTargetSize = ui->contentsWidget->iconSize();
 
-    auto addItem = [this, iconTargetSize](const QString &iconPath,
-                                    const QString &label) /*-> QListWidgetItem * */ {
+    auto addItem = [this, iconTargetSize](const QString &iconPath, const QString &label) {
         QPixmap pixmap(iconPath);
         QPixmap scaled = pixmap.scaled(iconTargetSize,
                                        Qt::KeepAspectRatio,
                                        Qt::SmoothTransformation);
 
-        // does this leak, or is ownership given to ui->contentsWidget?
         auto *item = new QListWidgetItem(QIcon(scaled), label, ui->contentsWidget);
         item->setTextAlignment(Qt::AlignHCenter);
         item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
-        // return item;
     };
 
     addItem(":/icons/generalcfg.png", tr("General"));

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -116,16 +116,18 @@ void ConfigDialog::createIcons()
 {
     const QSize iconTargetSize = ui->contentsWidget->iconSize();
 
-    auto addItem = [&](const QString &iconPath, const QString &label) {
+    auto addItem = [this, iconTargetSize](const QString &iconPath,
+                                    const QString &label) /*-> QListWidgetItem * */ {
         QPixmap pixmap(iconPath);
         QPixmap scaled = pixmap.scaled(iconTargetSize,
                                        Qt::KeepAspectRatio,
                                        Qt::SmoothTransformation);
 
+        // does this leak, or is ownership given to ui->contentsWidget?
         auto *item = new QListWidgetItem(QIcon(scaled), label, ui->contentsWidget);
         item->setTextAlignment(Qt::AlignHCenter);
         item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
-        return item;
+        // return item;
     };
 
     addItem(":/icons/generalcfg.png", tr("General"));

--- a/src/preferences/graphicspage.cpp
+++ b/src/preferences/graphicspage.cpp
@@ -85,17 +85,17 @@ GraphicsPage::GraphicsPage(QWidget *parent)
             this,
             &GraphicsPage::slot_drawUpperLayersTexturedStateChanged);
 
-    connect(ui->weatherAtmosphereSlider, &QSlider::valueChanged, this, [this](int value) {
+    connect(ui->weatherAtmosphereSlider, &QSlider::valueChanged, this, [this](const int value) {
         setConfig().canvas.weatherAtmosphereIntensity.set(value);
         graphicsSettingsChanged();
     });
 
-    connect(ui->weatherPrecipitationSlider, &QSlider::valueChanged, this, [this](int value) {
+    connect(ui->weatherPrecipitationSlider, &QSlider::valueChanged, this, [this](const int value) {
         setConfig().canvas.weatherPrecipitationIntensity.set(value);
         graphicsSettingsChanged();
     });
 
-    connect(ui->weatherTimeOfDaySlider, &QSlider::valueChanged, this, [this](int value) {
+    connect(ui->weatherTimeOfDaySlider, &QSlider::valueChanged, this, [this](const int value) {
         setConfig().canvas.weatherTimeOfDayIntensity.set(value);
         graphicsSettingsChanged();
     });

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -736,7 +736,8 @@ void Proxy::allocParser()
                                                             m_mainWindow.getHotkeyManager(),
                                                             this,
                                                             deref(out),
-                                                            deref(parserCommon));
+                                                            deref(parserCommon),
+                                                            m_gameObserver);
 
     /* The login credentials are fetched asynchronously because the OS will prompt the user for permission */
     pipe.mud.passwordConfig = std::make_unique<PasswordConfig>(this);

--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -67,14 +67,12 @@ void main()
     float uCloudsIntensity = mix(uIntensities[2], uTargets[2], weatherLerp);
     float uFogIntensity = mix(uIntensities[3], uTargets[3], weatherLerp);
 
-    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
-                                0.0,
-                                1.0);
+    float tTod = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration, 0.0, 1.0);
+    float timeOfDayLerp = smoothstep(0.0, 1.0, tTod);
     float currentTimeOfDayIntensity = mix(uTimeOfDay.z, uTimeOfDay.w, timeOfDayLerp);
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDay.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDay.y)];
-    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
-    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+    float alphaStart = uNamedColors[int(uTimeOfDay.x)].a;
+    float alphaTarget = uNamedColors[int(uTimeOfDay.y)].a;
+    float uTimeOfDayAlpha = mix(alphaStart, alphaTarget, timeOfDayLerp) * currentTimeOfDayIntensity;
 
     // Atmosphere overlay is now transparent by default (TimeOfDay is drawn separately)
     vec4 result = vec4(0.0);
@@ -86,7 +84,7 @@ void main()
         float density = 0.4 + uFogIntensity * 0.4;
         vec4 fog = vec4(0.8, 0.8, 0.85, uFogIntensity * n * localMask * density);
         // Emissive boost at night
-        fog.rgb += uTimeOfDayColor.a * 0.15;
+        fog.rgb += uTimeOfDayAlpha * 0.15;
 
         // Blend fog over result
         float combinedAlpha = 1.0 - (1.0 - result.a) * (1.0 - fog.a);
@@ -106,7 +104,7 @@ void main()
                            1.0 * storminess,
                            uCloudsIntensity * puffy * localMask * 0.5);
         // Emissive boost at night
-        clouds.rgb += uTimeOfDayColor.a * 0.1;
+        clouds.rgb += uTimeOfDayAlpha * 0.1;
 
         // Blend clouds over result
         float combinedAlpha = 1.0 - (1.0 - result.a) * (1.0 - clouds.a);

--- a/src/resources/shaders/legacy/weather/particle/frag.glsl
+++ b/src/resources/shaders/legacy/weather/particle/frag.glsl
@@ -40,14 +40,12 @@ void main()
     float pIntensity = max(pRain, pSnow);
     float pType = pSnow / max(pIntensity, 0.001);
 
-    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
-                                0.0,
-                                1.0);
+    float tTod = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration, 0.0, 1.0);
+    float timeOfDayLerp = smoothstep(0.0, 1.0, tTod);
     float currentTimeOfDayIntensity = mix(uTimeOfDay.z, uTimeOfDay.w, timeOfDayLerp);
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDay.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDay.y)];
-    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
-    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+    float alphaStart = uNamedColors[int(uTimeOfDay.x)].a;
+    float alphaTarget = uNamedColors[int(uTimeOfDay.y)].a;
+    float uTimeOfDayAlpha = mix(alphaStart, alphaTarget, timeOfDayLerp) * currentTimeOfDayIntensity;
 
     float lifeFade = smoothstep(0.0, 0.15, vLife) * smoothstep(1.0, 0.85, vLife);
 
@@ -55,14 +53,14 @@ void main()
     float streak = 1.0 - smoothstep(0.0, 0.15, abs(vLocalCoord.x - 0.5));
     float rainAlpha = mix(0.4, 0.7, clamp(pIntensity, 0.0, 1.0));
     vec4 rainColor = vec4(0.6, 0.6, 1.0, pIntensity * streak * vLocalMask * rainAlpha * lifeFade);
-    rainColor.rgb += uTimeOfDayColor.a * 0.2;
+    rainColor.rgb += uTimeOfDayAlpha * 0.2;
 
     // Snow visuals
     float dist = distance(vLocalCoord, vec2(0.5));
     float flake = 1.0 - smoothstep(0.1, 0.2, dist);
     float snowAlpha = mix(0.6, 0.9, clamp(pIntensity, 0.0, 1.0));
     vec4 snowColor = vec4(1.0, 1.0, 1.1, pIntensity * flake * vLocalMask * snowAlpha * lifeFade);
-    snowColor.rgb += uTimeOfDayColor.a * 0.3;
+    snowColor.rgb += uTimeOfDayAlpha * 0.3;
 
     // Interpolate visuals based on pType
     vec4 pColor = mix(rainColor, snowColor, pType);

--- a/src/resources/shaders/legacy/weather/timeofday/frag.glsl
+++ b/src/resources/shaders/legacy/weather/timeofday/frag.glsl
@@ -23,22 +23,80 @@ layout(std140) uniform WeatherBlock
 
 out vec4 vFragmentColor;
 
+// --- Color Space Conversions (Oklab) ---
+
+vec3 srgbToLinear(vec3 c)
+{
+    vec3 low = c / 12.92;
+    vec3 high = pow((c + 0.055) / 1.055, vec3(2.4));
+    return mix(low, high, step(vec3(0.04045), c));
+}
+
+vec3 linearToSrgb(vec3 c)
+{
+    vec3 low = c * 12.92;
+    vec3 high = 1.055 * pow(c, vec3(1.0 / 2.4)) - 0.055;
+    return mix(low, high, step(vec3(0.0031308), c));
+}
+
+vec3 linearToOklab(vec3 c)
+{
+    float l = 0.4122214708 * c.r + 0.5363325363 * c.g + 0.0514459929 * c.b;
+    float m = 0.2119034982 * c.r + 0.6806995451 * c.g + 0.1073969566 * c.b;
+    float s = 0.0883024619 * c.r + 0.2817188376 * c.g + 0.6299787005 * c.b;
+
+    float l_ = pow(l, 1.0 / 3.0);
+    float m_ = pow(m, 1.0 / 3.0);
+    float s_ = pow(s, 1.0 / 3.0);
+
+    return vec3(0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720403 * s_,
+                1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
+                0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_);
+}
+
+vec3 oklabToLinear(vec3 c)
+{
+    float l_ = c.x + 0.3963377774 * c.y + 0.2158037573 * c.z;
+    float m_ = c.x - 0.1055613458 * c.y - 0.0638541728 * c.z;
+    float s_ = c.x - 0.0894841775 * c.y - 1.2914855480 * c.z;
+
+    float l = l_ * l_ * l_;
+    float m = m_ * m_ * m_;
+    float s = s_ * s_ * s_;
+
+    return vec3(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+                -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+                -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s);
+}
+
 void main()
 {
     float uCurrentTime = uTime.x;
     float uTimeOfDayStartTime = uConfig.y;
     float uTransitionDuration = uConfig.z;
 
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDay.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDay.y)];
+    vec4 timeOfDayStartSrgb = uNamedColors[int(uTimeOfDay.x)];
+    vec4 timeOfDayTargetSrgb = uNamedColors[int(uTimeOfDay.y)];
 
-    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
-                                0.0,
-                                1.0);
+    float t = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration, 0.0, 1.0);
+    float timeOfDayLerp = smoothstep(0.0, 1.0, t);
+
+    // Convert start and target colors to Oklab
+    vec3 startOklab = linearToOklab(srgbToLinear(timeOfDayStartSrgb.rgb));
+    vec3 targetOklab = linearToOklab(srgbToLinear(timeOfDayTargetSrgb.rgb));
+
+    // Interpolate in Oklab space
+    vec3 mixedOklab = mix(startOklab, targetOklab, timeOfDayLerp);
+
+    // Convert back to sRGB
+    vec3 mixedSrgb = linearToSrgb(oklabToLinear(mixedOklab));
+
+    // Mix intensity with smoothstep as well
     float currentTimeOfDayIntensity = mix(uTimeOfDay.z, uTimeOfDay.w, timeOfDayLerp);
 
-    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
-    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+    // Final color with alpha
+    float finalAlpha = mix(timeOfDayStartSrgb.a, timeOfDayTargetSrgb.a, timeOfDayLerp);
+    finalAlpha *= currentTimeOfDayIntensity;
 
-    vFragmentColor = uTimeOfDayColor;
+    vFragmentColor = vec4(mixedSrgb, finalAlpha);
 }

--- a/src/syntax/TreeParser.cpp
+++ b/src/syntax/TreeParser.cpp
@@ -272,7 +272,7 @@ HelpFrame HelpFrame::makeChild()
 {
     flush();
     HelpFrame child = *this; // copy ctor
-    return child; // c++17 spec says NRVO elides the move constructor here, but g++ 7.4 uses move ctor.
+    return child;            // C++ standard says NRVO elides the move constructor here.
 }
 
 class NODISCARD TreeParser::HelpCommon final

--- a/src/syntax/TreeParser.cpp
+++ b/src/syntax/TreeParser.cpp
@@ -271,8 +271,7 @@ void HelpFrame::flush()
 HelpFrame HelpFrame::makeChild()
 {
     flush();
-    HelpFrame child = *this; // copy ctor
-    return child;            // C++ standard says NRVO elides the move constructor here.
+    return HelpFrame{*this}; // note: copy-ctor
 }
 
 class NODISCARD TreeParser::HelpCommon final

--- a/src/syntax/Value.cpp
+++ b/src/syntax/Value.cpp
@@ -137,19 +137,17 @@ Vector::Base::const_iterator Vector::end() const
     return m_vector->end();
 }
 
-bool Vector::empty() const
-{
-    return m_vector->empty();
-}
 size_t Vector::size() const
 {
     return m_vector->size();
 }
-const Value &Vector::at(size_t pos) const
+
+const Value &Vector::at(const size_t pos) const
 {
     return m_vector->at(pos);
 }
-const Value &Vector::operator[](size_t pos) const
+
+const Value &Vector::operator[](const size_t pos) const
 {
     return at(pos);
 }

--- a/src/syntax/Value.cpp
+++ b/src/syntax/Value.cpp
@@ -137,6 +137,11 @@ Vector::Base::const_iterator Vector::end() const
     return m_vector->end();
 }
 
+bool Vector::empty() const
+{
+    return m_vector->empty();
+}
+
 size_t Vector::size() const
 {
     return m_vector->size();

--- a/src/syntax/Value.cpp
+++ b/src/syntax/Value.cpp
@@ -137,6 +137,23 @@ Vector::Base::const_iterator Vector::end() const
     return m_vector->end();
 }
 
+bool Vector::empty() const
+{
+    return m_vector->empty();
+}
+size_t Vector::size() const
+{
+    return m_vector->size();
+}
+const Value &Vector::at(size_t pos) const
+{
+    return m_vector->at(pos);
+}
+const Value &Vector::operator[](size_t pos) const
+{
+    return at(pos);
+}
+
 Vector getAnyVectorReversed(const Pair *const matched)
 {
     size_t len = 0;

--- a/src/syntax/Value.h
+++ b/src/syntax/Value.h
@@ -30,7 +30,7 @@ public:
     explicit Vector(Base &&x);
 
 public:
-    Vector();
+    explicit Vector();
     DEFAULT_RULE_OF_5(Vector);
 
 public:
@@ -38,11 +38,11 @@ public:
     NODISCARD Base::const_iterator end() const;
 
 public:
-    NODISCARD bool empty() const;
+    NODISCARD bool empty() const { return m_vector->empty(); }
     NODISCARD size_t size() const;
     // NOTE: at() throws if out of range.
-    const Value &at(size_t pos) const;
-    const Value &operator[](size_t pos) const;
+    ALLOW_DISCARD const Value &at(size_t pos) const;
+    ALLOW_DISCARD const Value &operator[](size_t pos) const;
 
 public:
     friend std::ostream &operator<<(std::ostream &os, const Vector &v);

--- a/src/syntax/Value.h
+++ b/src/syntax/Value.h
@@ -38,7 +38,7 @@ public:
     NODISCARD Base::const_iterator end() const;
 
 public:
-    NODISCARD bool empty() const { return m_vector->empty(); }
+    NODISCARD bool empty() const;
     NODISCARD size_t size() const;
     // NOTE: at() throws if out of range.
     ALLOW_DISCARD const Value &at(size_t pos) const;

--- a/src/syntax/Value.h
+++ b/src/syntax/Value.h
@@ -38,11 +38,11 @@ public:
     NODISCARD Base::const_iterator end() const;
 
 public:
-    NODISCARD bool empty() const { return m_vector->empty(); }
-    NODISCARD size_t size() const { return m_vector->size(); }
+    NODISCARD bool empty() const;
+    NODISCARD size_t size() const;
     // NOTE: at() throws if out of range.
-    const Value &at(size_t pos) const { return m_vector->at(pos); }
-    const Value &operator[](size_t pos) const { return at(pos); }
+    const Value &at(size_t pos) const;
+    const Value &operator[](size_t pos) const;
 
 public:
     friend std::ostream &operator<<(std::ostream &os, const Vector &v);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,6 +146,8 @@ add_test(NAME TestProxy COMMAND TestProxy)
 # MainWindow
 set(mainwindow_SRCS
     ../src/global/Version.h
+    ../src/mainwindow/AudioVolumeSlider.cpp
+    ../src/mainwindow/AudioVolumeSlider.h
     ../src/mainwindow/UpdateDialog.cpp
     ../src/mainwindow/UpdateDialog.h
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(mm_test STATIC
     ../src/proxy/GmcpMessage.h
 )
 set_target_properties(mm_test PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
     COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -67,7 +67,7 @@ target_link_libraries(TestClock
         coverage_config)
 set_target_properties(
   TestClock PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -92,7 +92,7 @@ target_link_libraries(TestExpandoraCommon
         coverage_config)
 set_target_properties(
   TestExpandoraCommon PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -114,7 +114,7 @@ target_link_libraries(TestParser
         coverage_config)
 set_target_properties(
   TestParser PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -136,7 +136,7 @@ add_dependencies(TestProxy mm_test mm_global)
 target_link_libraries(TestProxy mm_test mm_global Qt6::Test coverage_config)
 set_target_properties(
   TestProxy PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -161,7 +161,7 @@ target_link_libraries(TestMainWindow
         coverage_config)
 set_target_properties(
   TestMainWindow PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -180,7 +180,7 @@ target_link_libraries(TestGlobal
         coverage_config)
 set_target_properties(
   TestGlobal PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -204,7 +204,7 @@ target_link_libraries(TestMap
         coverage_config)
 set_target_properties(
         TestMap PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -226,7 +226,7 @@ add_dependencies(TestAdventure mm_test mm_global)
 target_link_libraries(TestAdventure mm_test mm_global Qt6::Widgets Qt6::Network Qt6::Test coverage_config)
 set_target_properties(
         TestAdventure PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -244,7 +244,7 @@ add_dependencies(TestTimer mm_global)
 target_link_libraries(TestTimer mm_global Qt6::Test coverage_config)
 set_target_properties(
         TestTimer PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -262,7 +262,7 @@ add_dependencies(TestRoomMob mm_global)
 target_link_libraries(TestRoomMob mm_global Qt6::Test Qt6::Gui Qt6::Widgets coverage_config)
 set_target_properties(
         TestRoomMob PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -283,7 +283,7 @@ add_dependencies(TestRoomMobs mm_global)
 target_link_libraries(TestRoomMobs mm_global Qt6::Test Qt6::Gui Qt6::Widgets coverage_config)
 set_target_properties(
         TestRoomMobs PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -305,7 +305,7 @@ add_dependencies(TestRoomManager mm_test mm_global)
 target_link_libraries(TestRoomManager mm_test mm_global Qt6::Test Qt6::Gui Qt6::Widgets coverage_config)
 set_target_properties(
         TestRoomManager PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -325,7 +325,7 @@ add_dependencies(TestHotkeyManager mm_test mm_global mm_map)
 target_link_libraries(TestHotkeyManager mm_map mm_test mm_global Qt6::Test Qt6::Network coverage_config)
 set_target_properties(
         TestHotkeyManager PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"

--- a/tests/TestGlobal.cpp
+++ b/tests/TestGlobal.cpp
@@ -190,17 +190,17 @@ void TestGlobal::flagsTest()
 
 void TestGlobal::hideQDebugTest()
 {
-    static constexpr auto onlyDebug = []() {
+    static constexpr auto onlyDebug = std::invoke([]() consteval -> mmqt::HideQDebugOptions {
         mmqt::HideQDebugOptions tmp;
         tmp.hideInfo = false;
         return tmp;
-    }();
+    });
 
-    static constexpr auto onlyInfo = []() {
+    static constexpr auto onlyInfo = std::invoke([]() consteval -> mmqt::HideQDebugOptions {
         mmqt::HideQDebugOptions tmp;
         tmp.hideDebug = false;
         return tmp;
-    }();
+    });
 
     const QString expected = "1{DIW}\n2{DW}\n3{DIW}\n4{IW}\n5{DIW}\n"
                              "---\n"

--- a/tests/TestMainWindow.cpp
+++ b/tests/TestMainWindow.cpp
@@ -3,10 +3,13 @@
 
 #include "TestMainWindow.h"
 
+#include "../src/configuration/configuration.h"
 #include "../src/global/Version.h"
+#include "../src/mainwindow/AudioVolumeSlider.h"
 #include "../src/mainwindow/UpdateDialog.h"
 
 #include <QDebug>
+#include <QScopeGuard>
 #include <QtTest/QtTest>
 
 const char *getMMapperVersion()
@@ -47,6 +50,41 @@ void TestMainWindow::updaterTest()
     CompareVersion newerPatch{"2.9.0"};
     QVERIFY2(newerPatch > current, "Newer major version is greater than older version");
     QVERIFY2((current > newerPatch) == false, "Older version is not newer than newer patch version");
+}
+
+void TestMainWindow::audioToolbarTest()
+{
+    setEnteredMain();
+
+    const int originalMusic = getConfig().audio.getMusicVolume();
+    const int originalSound = getConfig().audio.getSoundVolume();
+
+    // Ensure we restore configuration
+    auto cleanup = qScopeGuard([=]() {
+        setConfig().audio.setMusicVolume(originalMusic);
+        setConfig().audio.setSoundVolume(originalSound);
+    });
+
+    AudioVolumeSlider musicSlider(AudioVolumeSlider::AudioType::Music);
+    AudioVolumeSlider soundSlider(AudioVolumeSlider::AudioType::Sound);
+
+    // Initial value should match current config defaults
+    QCOMPARE(musicSlider.value(), getConfig().audio.getMusicVolume());
+    QCOMPARE(soundSlider.value(), getConfig().audio.getSoundVolume());
+
+    // Update config -> slider updates
+    setConfig().audio.setMusicVolume(75);
+    QCOMPARE(musicSlider.value(), 75);
+
+    setConfig().audio.setSoundVolume(25);
+    QCOMPARE(soundSlider.value(), 25);
+
+    // Update slider -> config updates
+    musicSlider.setValue(90);
+    QCOMPARE(getConfig().audio.getMusicVolume(), 90);
+
+    soundSlider.setValue(10);
+    QCOMPARE(getConfig().audio.getSoundVolume(), 10);
 }
 
 QTEST_MAIN(TestMainWindow)

--- a/tests/TestMainWindow.h
+++ b/tests/TestMainWindow.h
@@ -17,4 +17,5 @@ public:
 private:
 private Q_SLOTS:
     void updaterTest();
+    void audioToolbarTest();
 };


### PR DESCRIPTION
## Summary by Sourcery

Migrate the codebase to C++20 while modernizing utilities, tightening enum/array abstractions, and improving weather rendering and UI audio controls.

New Features:
- Extend the parser `set` command to support configuring fog and weather prompt options with contextual help output.
- Add an Audio toolbar with dedicated music and sound volume sliders, backed by a reusable `AudioVolumeSlider` widget that syncs with configuration.
- Introduce richer time-of-day color transitions for weather rendering by interpolating in Oklab color space in shaders.

Bug Fixes:
- Harden XML enum name/value conversion and validation in `XmlMapStorage` to avoid mismatches and invalid saves.
- Fix various lambda captures and iterator usages that could lead to dangling references or incorrect behavior in map saving, world stats, diffing, and spatial DB updates.
- Ensure DescriptionWidget and emoji handling use safe captures, type conversions, and non-null image usage to avoid subtle runtime issues.
- Guard Remapping invariants and external ID computations more robustly, only asserting in debug builds.

Enhancements:
- Refine the `set` command UX with syntax help on empty input or `?`, colored error messages, and unified enum option listing.
- Refactor enum-indexed containers via `EnumIndexedArray` (including iteration helpers) and type-safe utilities like `BlockType_t` to simplify enum-based indexing throughout the code.
- Modernize `UboManager`, OpenGL helpers, and weather logic to use common type aliases, `glm::lerp`, and clearer contracts for binding and rebuilding GPU buffers.
- Tidy CRTP mixins, TaggedInt helpers, and small utility templates (hashing, `remove_cvref_t`, `listRemoveIf`, QPointer factory, etc.) to use C++20 concepts, constraints, and standard facilities.
- Improve world and map statistics/printing code by encapsulating statistics in a struct with a dedicated printer and more consistent ANSI coloring.
- Switch charset/UTF-8 and floating-point helpers to constexpr-friendly, implementation-provided intrinsics where available, simplifying older workarounds.
- Streamline emoji lookup structures and logging/encoding behavior for clarity and correctness.
- Clarify OpenGL probing and mesh/connection drawing logic, reducing redundant checks and tightening lambda responsibilities.
- Make various QObject-based managers (music, SFX, group UI, sliders, etc.) explicitly non-copyable and default/destructed where appropriate for safer ownership.

Build:
- Bump the global C++ standard requirement from C++17 to C++20 for the main targets and all test binaries, and adjust compiler flags (including Clang and MSVC options) for the newer language standard.
- Update build documentation to state the C++20 requirement and recommend suitable compiler versions.
- Add AudioVolumeSlider sources to the main and test CMake targets so they are built and linked correctly.

Documentation:
- Revise BUILD documentation to mention C++20 instead of C++17 and update the recommended compiler versions accordingly.

Tests:
- Add a `TestMainWindow::audioToolbarTest` that validates synchronization between the Audio toolbar sliders and the configuration system for music and sound volume.
- Retarget all existing test executables to build as C++20, in line with the main project.