### PR TITLE
Rework UX Group Panel

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -8,7 +8,7 @@ This guide describes how to build **MMapper** from source on Linux, macOS, and W
 
 Ensure the following tools are installed:
 
-- A C++17-compatible compiler (e.g., GCC, Clang, MSVC)
+- A C++20-compatible compiler (e.g., GCC 11+, Clang 16+, MSVC 19.29+)
 - [CMake 3.20+](https://cmake.org/)
 - [Ninja](https://ninja-build.org/)
 - [Qt 6.4+](https://www.qt.io/) (6.8.3 recommended) with `QtWebSockets` and `QtMultimedia`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mmapper CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -419,6 +419,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         endif()
 
         add_compile_options(-Weverything)
+        add_compile_options(-Wno-c++20-compat)
         add_compile_options(-Wno-c++98-c++11-compat-binary-literal) # never useful.
         add_compile_options(-Wno-c++98-compat) # never useful.
         add_compile_options(-Wno-c++98-compat-pedantic) # sometimes useful.
@@ -461,7 +462,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         add_compile_options(-Werror=shorten-64-to-32)
         add_compile_options(-Werror=sign-conversion) # can warn about hard-to-spot bugs.
         add_compile_options(-Werror=switch)
-        add_compile_options(-Werror=unused-result) # required for c++17 [[nodiscard]]
+        add_compile_options(-Werror=unused-result) # required for [[nodiscard]]
         add_compile_options(-Werror=weak-vtables) # can result in crashes for ODR violations.
 
         # remove noise (most of these cannot be fixed)
@@ -472,6 +473,7 @@ if(MSVC)
     add_definitions(-DNOMINMAX)
     # modernize the __cplusplus value
     add_compile_options(/Zc:__cplusplus)
+    add_compile_options(/Zc:preprocessor)
     add_compile_options(/utf-8)
     add_compile_options(/permissive-)
     if(CMAKE_BUILD_TYPE_UPPER MATCHES "^RELWITHDEBINFO$")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -771,7 +771,7 @@ endif()
 
 set_target_properties(
   mmapper PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -781,7 +781,7 @@ set_target_properties(
 
 set_target_properties(
   mm_global PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -789,7 +789,7 @@ set_target_properties(
 
 set_target_properties(
   mm_map PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -242,6 +242,8 @@ set(mmapper_SRCS
     group/mmapper2group.h
     logger/autologger.cpp
     logger/autologger.h
+    mainwindow/AudioVolumeSlider.cpp
+    mainwindow/AudioVolumeSlider.h
     mainwindow/MapZoomSlider.cpp
     mainwindow/MapZoomSlider.h
     mainwindow/UpdateDialog.cpp

--- a/src/display/Textures.h
+++ b/src/display/Textures.h
@@ -232,9 +232,8 @@ namespace mctp {
 namespace detail {
 // converts from EnumIndexedArray<SharedMMTexture, ...> to EnumIndexedArray<MMTexArrayPosition, ...>
 template<typename T>
-auto typeHack(const T &)
-    -> std::enable_if_t<std::is_same_v<typename T::value_type, SharedMMTexture>,
-                        EnumIndexedArray<MMTexArrayPosition, typename T::index_type, T::SIZE>>;
+    requires(std::is_same_v<typename T::value_type, SharedMMTexture>)
+auto typeHack(const T &) -> EnumIndexedArray<MMTexArrayPosition, typename T::index_type, T::SIZE>;
 
 template<typename T>
 struct NODISCARD Proxy

--- a/src/display/mapcanvas.cpp
+++ b/src/display/mapcanvas.cpp
@@ -94,8 +94,6 @@ MapCanvas::~MapCanvas()
     if (pmc == this) {
         pmc = nullptr;
     }
-
-    cleanupOpenGL();
 }
 
 MapCanvas *MapCanvas::getPrimary()

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -125,6 +125,7 @@ void MapCanvas::cleanupOpenGL()
     // note: m_batchedMeshes co-owns textures created by MapCanvasData,
     // and it also owns the lifetime of some OpenGL objects (e.g. VBOs).
     m_batches.resetExistingMeshesAndIgnorePendingRemesh();
+    m_weather.cleanup();
     m_textures.destroyAll();
     getGLFont().cleanup();
     getOpenGL().cleanup();
@@ -306,6 +307,14 @@ void MapCanvas::initializeGL()
         this->updateTextures();
         m_frameManager.requestUpdate();
     });
+
+    // Clean up GL resources while the context is still current.
+    // The destructor is too late — Qt destroys the context before ~MapCanvas() runs.
+    connect(context(),
+            &QOpenGLContext::aboutToBeDestroyed,
+            this,
+            &MapCanvas::cleanupOpenGL,
+            Qt::DirectConnection);
 }
 
 /* Direct means it is always called from the emitter's thread */

--- a/src/global/AnsiOstream.h
+++ b/src/global/AnsiOstream.h
@@ -135,13 +135,17 @@ public:
     void write(char16_t codepoint);
     void write(char32_t codepoint);
     void write(std::string_view sv);
+    void write(std::u8string_view sv)
+    {
+        write(std::string_view{reinterpret_cast<const char *>(sv.data()), sv.size()});
+    }
 
     template<typename T>
-    auto write(const T n)
-        -> std::enable_if_t<(std::is_integral_v<T> && !std::is_same_v<char32_t, std::decay_t<T>>
-                             && sizeof(char) < sizeof(T))
-                                || std::is_floating_point_v<T>,
-                            void>
+        requires((std::is_integral_v<T> and sizeof(T) > sizeof(char)
+                  and not(std::is_same_v<char16_t, std::decay_t<T>>
+                          or std::is_same_v<char32_t, std::decay_t<T>>))
+                 or std::is_floating_point_v<T>)
+    void write(const T n)
     {
         auto s = std::to_string(n);
         write(std::string_view{s});

--- a/src/global/Array.h
+++ b/src/global/Array.h
@@ -35,6 +35,7 @@ public:
 
 public:
     template<typename First, typename... Types>
+        requires(std::is_same_v<First, Types> && ...)
     explicit constexpr Array(First &&first, Types &&...args)
         : std::array<T, N>{std::forward<First>(first), std::forward<Types>(args)...}
     {
@@ -42,9 +43,7 @@ public:
     }
 };
 
-#if __cpp_deduction_guides >= 201606
-// deducation guide copied from std::array
 template<typename T, typename... U>
-Array(T, U...) -> Array<std::enable_if_t<(std::is_same_v<T, U> && ...), T>, 1 + sizeof...(U)>;
-#endif
+    requires(std::is_same_v<T, U> && ...)
+Array(T, U...) -> Array<T, 1 + sizeof...(U)>;
 } // namespace MMapper

--- a/src/global/Charset-Utf8.cpp
+++ b/src/global/Charset-Utf8.cpp
@@ -552,13 +552,7 @@ NODISCARD static constexpr bool is7bit(const char c) noexcept
 }
 NODISCARD static constexpr bool is7bit(const std::string_view sv) noexcept
 {
-    // NOLINTNEXTLINE (can't use std::all_of() in constexpr in c++17)
-    for (const char c : sv) {
-        if (!is7bit(c)) {
-            return false;
-        }
-    }
-    return true;
+    return std::all_of(sv.begin(), sv.end(), [](char c) { return is7bit(c); });
 }
 
 NODISCARD static constexpr Utf8ValidationEnum validateUtf8(std::string_view sv) noexcept

--- a/src/global/Charset.cpp
+++ b/src/global/Charset.cpp
@@ -348,7 +348,6 @@ ALLOW_DISCARD QString &toAsciiInPlace(QString &str)
 
     // NOTE: 128 (0x80) was not converted to 'z' before.
     for (QChar &qc : str) {
-        // c++17 if statement with initializer
         if (const char ch = mmqt::toLatin1(qc); !isAscii(ch)) {
             qc = QLatin1Char{charset::conversion::latin1ToAscii(ch)};
         }

--- a/src/global/ConfigConsts-Computed.h
+++ b/src/global/ConfigConsts-Computed.h
@@ -4,6 +4,7 @@
 
 #include "ConfigEnums.h"
 
+#include <functional>
 #include <stdexcept>
 #include <string_view>
 
@@ -44,7 +45,7 @@ static inline constexpr PackageEnum CURRENT_PACKAGE = [] {
     throw std::runtime_error("unsupported package type");
 }();
 
-static inline constexpr const PlatformEnum CURRENT_PLATFORM = [] {
+static inline constexpr PlatformEnum CURRENT_PLATFORM = std::invoke([]() constexpr -> PlatformEnum {
 #if defined(Q_OS_WIN)
     return PlatformEnum::Windows;
 #elif defined(Q_OS_MAC)
@@ -56,14 +57,15 @@ static inline constexpr const PlatformEnum CURRENT_PLATFORM = [] {
 #else
     throw std::runtime_error("unsupported platform");
 #endif
-}();
+});
 
-static inline constexpr const EnvironmentEnum CURRENT_ENVIRONMENT = [] {
+static inline constexpr EnvironmentEnum CURRENT_ENVIRONMENT = std::invoke(
+    []() constexpr -> EnvironmentEnum {
 #if Q_PROCESSOR_WORDSIZE == 4
-    return EnvironmentEnum::Env32Bit;
+        return EnvironmentEnum::Env32Bit;
 #elif Q_PROCESSOR_WORDSIZE == 8
-    return EnvironmentEnum::Env64Bit;
+        return EnvironmentEnum::Env64Bit;
 #else
-    throw std::runtime_error("unsupported environment");
+        throw std::runtime_error("unsupported environment");
 #endif
-}();
+    });

--- a/src/global/EnumIndexedArray.h
+++ b/src/global/EnumIndexedArray.h
@@ -82,6 +82,29 @@ public:
             callback(x);
         }
     }
+    template<typename Callback>
+    void for_each(Callback &&callback) const
+    {
+        for (const auto &x : *this) {
+            callback(x);
+        }
+    }
+    template<typename Callback>
+    void for_each2(Callback &&callback)
+    {
+        for (size_t i = 0u; i < SIZE; ++i) {
+            const auto e = static_cast<E>(i);
+            callback(e, at(e));
+        }
+    }
+    template<typename Callback>
+    void for_each2(Callback &&callback) const
+    {
+        for (size_t i = 0u; i < SIZE; ++i) {
+            const auto e = static_cast<E>(i);
+            callback(e, at(e));
+        }
+    }
 
 public:
     NODISCARD bool operator==(const EnumIndexedArray &other) const

--- a/src/global/MakeQPointer.h
+++ b/src/global/MakeQPointer.h
@@ -12,8 +12,8 @@
 
 namespace mmqt {
 template<typename T, typename... Args>
-NODISCARD auto makeQPointer(Args &&...args)
-    -> std::enable_if_t<std::is_base_of_v<QObject, T>, QPointer<T>>
+    requires(std::is_base_of_v<QObject, T>)
+NODISCARD QPointer<T> makeQPointer(Args &&...args)
 {
     auto ptr = std::make_unique<T>(std::forward<Args>(args)...);
     if (ptr->QObject::parent() == nullptr) {

--- a/src/global/TaggedInt.h
+++ b/src/global/TaggedInt.h
@@ -79,15 +79,17 @@ template<typename...>
 struct NODISCARD underlying_helper;
 
 template<typename T>
+    requires(not std::is_enum_v<T>)
 struct NODISCARD underlying_helper<T>
 {
     using type = T;
 };
 
 template<typename T>
-struct NODISCARD underlying_helper<T, std::enable_if_t<std::is_enum_v<T>>>
+    requires(std::is_enum_v<T>)
+struct NODISCARD underlying_helper<T>
 {
-    using type = typename std::underlying_type_t<T>;
+    using type = std::underlying_type_t<T>;
 };
 
 template<typename Crtp_, typename Tag_, typename Type_>

--- a/src/global/emojis.cpp
+++ b/src/global/emojis.cpp
@@ -171,36 +171,18 @@ public:
     class NODISCARD HexPrefixTree final
     {
     private:
-#if defined(__cpp_lib_generic_unordered_lookup) && __cpp_lib_generic_unordered_lookup
-        static_assert(false, "Not tested; this may need to be fixed.");
-        using HashBase = std::hash<std::u32string_view>;
-        struct NODISCARD Hash final : public HashBase
-        {
-            auto operator()(const std::u32string &s) const { return HashBase::operator()(s); }
-        };
-        struct NODISCARD Pred final
-        {
-            using T1 = const std::u32string &;
-            using T2 = const std::u32string_view;
-            bool operator()(T1 a, T1 b) const { return a == b; }
-            bool operator()(T1 a, T2 b) const { return a == b; }
-            bool operator()(T2 a, T1 b) const { return a == b; }
-            // bool operator()(T2 a, T2 b) const { return a == b; }
-        };
-        using Map = std::unordered_map<std::u32string, std::optional<std::u32string>, Hash, Pred>;
-#else
+        // REVISIT: consider using std::unordered_map
         struct NODISCARD Comp final
         {
             using is_transparent = void;
             using T1 = const std::u32string &;
             using T2 = const std::u32string_view;
-            bool operator()(T1 a, T1 b) const { return a < b; }
-            bool operator()(T1 a, T2 b) const { return a < b; }
-            bool operator()(T2 a, T1 b) const { return a < b; }
+            NODISCARD bool operator()(T1 a, T1 b) const { return a < b; }
+            NODISCARD bool operator()(T1 a, T2 b) const { return a < b; }
+            NODISCARD bool operator()(T2 a, T1 b) const { return a < b; }
             // bool operator()(T2 a, T2 b) const { return a < b; }
         };
         using Map = std::map<std::u32string, std::optional<std::u32string>, Comp>;
-#endif
 
         Map m_map;
 
@@ -604,7 +586,7 @@ NODISCARD QString mmqt::encodeEmojiShortCodes(const QString &s)
 
             // REVISIT: should this include "U+" or not?
             char hex[32];
-            snprintf(hex, sizeof(hex), "[:U+%X:]", c);
+            snprintf(hex, sizeof(hex), "[:U+%X:]", static_cast<unsigned int>(c));
             for (const char ascii : std::string_view{hex}) {
                 m_output += static_cast<char32_t>(static_cast<uint8_t>(ascii));
             }

--- a/src/global/float_cast.h
+++ b/src/global/float_cast.h
@@ -28,33 +28,29 @@ NODISCARD constexpr bool isSameIntValue(const A a, const B b) noexcept
     return a == b;
 }
 
-// This only exists because c++17 std::isnan() is not constexpr;
-// using "f != f" feels like a hack.
 template<typename FloatType>
 NODISCARD constexpr bool isNan(const FloatType f) noexcept
 {
-#if __cplusplus >= 202000L
+#if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
     return std::isnan(f);
+#elif defined(__clang__) || defined(__GNUC__)
+    return __builtin_isnan(f);
 #else
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wfloat-equal"
-#endif
-    return f != f; // NOLINT (this is only true for NaNs)
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+    // std::isnan() is not constexpr in all C++20 implementations (e.g. MSVC 2022)
+    return f != f;
 #endif
 }
 
-// this only exists because c++17 std::isfinite() is not constexpr
 template<typename FloatType>
 NODISCARD constexpr bool isFinite(const FloatType f) noexcept
 {
-#if __cplusplus >= 202000L
+#if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
     return std::isfinite(f);
+#elif defined(__clang__) || defined(__GNUC__)
+    return __builtin_isfinite(f);
 #else
-    constexpr auto inf = std::numeric_limits<FloatType>::infinity();
+    // std::isfinite() is not constexpr in all C++20 implementations (e.g. MSVC 2022)
+    const auto inf = std::numeric_limits<FloatType>::infinity();
     return !isNan(f) && -inf < f && f < inf;
 #endif
 }

--- a/src/global/hash.h
+++ b/src/global/hash.h
@@ -7,13 +7,10 @@
 #include <cstdint>
 #include <cstring>
 #include <string_view>
-#include <type_traits>
 
-template<typename T>
-MAYBE_UNUSED NODISCARD static auto numeric_hash(const T val) noexcept
-    -> std::enable_if_t<std::is_arithmetic_v<T>, size_t>
+MAYBE_UNUSED NODISCARD static size_t numeric_hash(const std::integral auto val) noexcept
 {
-    static constexpr const size_t size = sizeof(val);
+    static constexpr size_t size = sizeof(val);
     char buf[size];
     std::memcpy(buf, &val, size);
     return std::hash<std::string_view>()({buf, size});

--- a/src/global/mm_source_location.h
+++ b/src/global/mm_source_location.h
@@ -4,28 +4,10 @@
 
 #include "macros.h"
 
-#include <cstdint>
-
-#if __cplusplus >= 202000L \
-    && __has_builtin(__builtin_source_location) // && __cpp_lib_source_location >= 201907L
 #include <source_location>
+
 namespace mm {
 using source_location = std::source_location;
-}
-#define MM_SOURCE_LOCATION() (std::source_location::current())
-#else
-namespace mm {
-// TODO: replace this with C++20's std::source_location
-struct NODISCARD source_location final
-{
-    const char *m_file_name = "";
-    const char *m_function_name = "";
-    std::uint_least32_t m_line = 0;
-
-    NODISCARD const char *file_name() const { return this->m_file_name; }
-    NODISCARD const char *function_name() const { return this->m_function_name; }
-    NODISCARD std::uint_least32_t line() const { return this->m_line; }
-};
 } // namespace mm
-#define MM_SOURCE_LOCATION() (mm::source_location{__FILE__, __FUNCTION__, __LINE__})
-#endif
+
+#define MM_SOURCE_LOCATION() (std::source_location::current())

--- a/src/global/utils.h
+++ b/src/global/utils.h
@@ -411,16 +411,7 @@ ALLOW_DISCARD static inline size_t erase_if(Container &container, Callback &&cal
 template<typename T, typename Predicate>
 NODISCARD bool listRemoveIf(std::list<T> &list, Predicate &&should_remove)
 {
-    // c++20 version of remove_if() returns # of elements removed, but c++17 doesn't.
-    bool removed = false;
-    list.remove_if([&removed, &should_remove](const T &element) -> bool {
-        if (should_remove(element)) {
-            removed = true;
-            return true;
-        }
-        return false;
-    });
-    return removed;
+    return std::erase_if(list, std::forward<Predicate>(should_remove)) > 0;
 }
 
 template<typename Container, typename Callback>
@@ -449,9 +440,8 @@ NODISCARD static inline auto find_min_computed(const Container &container, Callb
     }
 }
 
-// This can be removed and replaced with std::remove_cvref_t<T> in c++20.
 template<typename T>
-using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+using remove_cvref_t = std::remove_cvref_t<T>;
 
 template<typename T, typename... Ts>
 struct are_distinct : std::conjunction<std::negation<std::is_same<T, Ts>>..., are_distinct<Ts...>>

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
+#include <unordered_set>
 #include <vector>
 
 #include <QAction>
@@ -134,7 +135,7 @@ bool GroupProxyModel::filterAcceptsRow(int source_row, const QModelIndex &source
 GroupStateData::GroupStateData(const QColor &color,
                                const CharacterPositionEnum position,
                                const CharacterAffectFlags affects)
-    : m_color(std::move(color))
+    : m_color(color)
     , m_position(position)
     , m_affects(affects)
 {
@@ -161,13 +162,14 @@ void GroupStateData::paint(QPainter *const pPainter, const QRect &rect)
     painter.save();
     painter.translate(rect.x(), rect.y());
     m_height = rect.height();
-    painter.scale(m_height, m_height); // Images are squares
+    painter.scale(static_cast<double>(m_height),
+                  static_cast<double>(m_height)); // Images are squares
 
     const bool invert = mmqt::textColor(m_color) == Qt::white;
 
     const auto drawOne = [&painter, invert](QString filename) -> void {
         painter.drawImage(QRect{0, 0, 1, 1}, getImage(filename, invert));
-        painter.translate(1, 0);
+        painter.translate(1.0, 0.0);
     };
 
     if (m_position != CharacterPositionEnum::UNDEFINED) {
@@ -267,7 +269,7 @@ void GroupDelegate::paint(QPainter *const pPainter,
         if (column == ColumnTypeEnum::HP) {
             cur = character->getHits();
             max = character->getMaxHits();
-            const double pct = max > 0 ? (double) cur / max : 1.0;
+            const double pct = max > 0 ? static_cast<double>(cur) / max : 1.0;
             if (pct < 0.3) {
                 barColor = QColor(0xFF, 0x55, 0x55); // Red
                 pulse = true;
@@ -291,25 +293,28 @@ void GroupDelegate::paint(QPainter *const pPainter,
             cur = character->getMoves();
             max = character->getMaxMoves();
             barColor = QColor(0xFF, 0xB8, 0x6C); // Amber
-            const double pct = max > 0 ? (double) cur / max : 1.0;
+            const double pct = max > 0 ? static_cast<double>(cur) / max : 1.0;
             if (pct < 0.15) {
                 pulse = true;
             }
         }
 
         // Layer 2: The Bar (80% height, rounded 4px)
-        const int barHeight = rect.height() * 0.8;
+        const int barHeight = static_cast<int>(static_cast<double>(rect.height()) * 0.8);
         const int barY = rect.y() + (rect.height() - barHeight) / 2;
-        const double pct = std::clamp(max > 0 ? (double) cur / max : 0.0, 0.0, 1.0);
-        const int barWidth = rect.width() * pct;
+        const double pct = std::clamp(max > 0 ? static_cast<double>(cur) / max : 0.0, 0.0, 1.0);
+        const int barWidth = static_cast<int>(static_cast<double>(rect.width()) * pct);
 
         int alpha = 180;
         if (pulse) {
             // 1.5s cycle (1500ms)
             static constexpr const double PI = 3.14159265358979323846;
             const qint64 ms = QDateTime::currentMSecsSinceEpoch() % 1500;
-            const double phase = (std::sin((ms / 1500.0) * 2.0 * PI - PI / 2.0) + 1.0) / 2.0;
-            alpha = pulseMin + (pulseMax - pulseMin) * phase;
+            const double phase = (std::sin((static_cast<double>(ms) / 1500.0) * 2.0 * PI - PI / 2.0)
+                                  + 1.0)
+                                 / 2.0;
+            alpha = pulseMin
+                    + static_cast<int>(std::round(static_cast<double>(pulseMax - pulseMin) * phase));
         }
         barColor.setAlpha(alpha);
 
@@ -317,7 +322,7 @@ void GroupDelegate::paint(QPainter *const pPainter,
         painter.setRenderHint(QPainter::Antialiasing);
         painter.setBrush(barColor);
         painter.setPen(Qt::NoPen);
-        painter.drawRoundedRect(QRect(rect.x(), barY, barWidth, barHeight), 4, 4);
+        painter.drawRoundedRect(QRect(rect.x(), barY, barWidth, barHeight), 4.0, 4.0);
         painter.restore();
 
         // Layer 3: Text (Monospace, Centered)
@@ -327,13 +332,7 @@ void GroupDelegate::paint(QPainter *const pPainter,
         monoFont.setStyleHint(QFont::Monospace);
         painter.setFont(monoFont);
         painter.setPen(mmqt::textColor(option.palette.color(QPalette::Base)));
-        if (character->isNpc()) {
-            painter.drawText(rect,
-                             Qt::AlignCenter,
-                             QString("%1%").arg(static_cast<int>(std::round(pct * 100.0))));
-        } else {
-            painter.drawText(rect, Qt::AlignCenter, QString("%1 / %2").arg(cur).arg(max));
-        }
+        painter.drawText(rect, Qt::AlignCenter, index.data(Qt::DisplayRole).toString());
         painter.restore();
     } else {
         // Fallback for other columns
@@ -355,6 +354,26 @@ QSize GroupDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIn
         size.setWidth(padding + content);
         return size;
     }
+
+    const auto column = static_cast<ColumnTypeEnum>(index.column());
+    if (column == ColumnTypeEnum::NAME) {
+        QSize size = QStyledItemDelegate::sizeHint(option, index);
+        size.setWidth(size.width() + 12); // 4px strip + 8px padding
+        return size;
+
+    } else if (column == ColumnTypeEnum::HP || column == ColumnTypeEnum::MANA
+               || column == ColumnTypeEnum::MOVES) {
+        QFont monoFont = option.font;
+        monoFont.setFamily("DejaVu Sans Mono");
+        monoFont.setStyleHint(QFont::Monospace);
+        const QFontMetrics fm(monoFont);
+
+        // Sample text for calculation: "9999 / 9999" or "100%"
+        const QString sampleText = (column == ColumnTypeEnum::HP) ? "9999 / 9999" : "999 / 999";
+        const int textWidth = fm.horizontalAdvance(sampleText);
+        return QSize(textWidth + 20, QStyledItemDelegate::sizeHint(option, index).height());
+    }
+
     return QStyledItemDelegate::sizeHint(option, index);
 }
 
@@ -575,10 +594,14 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
 {
     const CGroupChar &character = deref(pCharacter);
 
-    const auto formatStat = [](int numerator, int denomenator) -> QString {
-        // The NPC check for ratio is handled below in the switch statement
+    const auto formatStat = [&character](int numerator, int denomenator) -> QString {
         if (numerator == 0 && denomenator == 0) {
             return QLatin1String("");
+        }
+
+        if (character.getType() == CharacterTypeEnum::NPC) {
+            const double pct = denomenator > 0 ? static_cast<double>(numerator) / denomenator : 0.0;
+            return QString("%1%").arg(static_cast<int>(std::round(pct * 100.0)));
         }
 
         return QString("%1 / %2").arg(numerator).arg(denomenator);
@@ -598,23 +621,11 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
                                               character.getLabel().toQString());
             }
         case ColumnTypeEnum::HP:
-            if (character.getType() == CharacterTypeEnum::NPC) {
-                return QLatin1String("");
-            } else {
-                return formatStat(character.getHits(), character.getMaxHits());
-            }
+            return formatStat(character.getHits(), character.getMaxHits());
         case ColumnTypeEnum::MANA:
-            if (character.getType() == CharacterTypeEnum::NPC) {
-                return QLatin1String("");
-            } else {
-                return formatStat(character.getMana(), character.getMaxMana());
-            }
+            return formatStat(character.getMana(), character.getMaxMana());
         case ColumnTypeEnum::MOVES:
-            if (character.getType() == CharacterTypeEnum::NPC) {
-                return QLatin1String("");
-            } else {
-                return formatStat(character.getMoves(), character.getMaxMoves());
-            }
+            return formatStat(character.getMoves(), character.getMaxMoves());
         case ColumnTypeEnum::STATE:
             return QVariant::fromValue(GroupStateData(character.getColor(),
                                                       character.getPosition(),
@@ -838,7 +849,6 @@ GroupWidget::GroupWidget(Mmapper2Group *const group, MapData *const md, QWidget 
 
     m_pulseTimer = new QTimer(this);
     connect(m_pulseTimer, &QTimer::timeout, m_table->viewport(), QOverload<>::of(&QWidget::update));
-    m_pulseTimer->start(50);
 
     // Minimize row height
     m_table->verticalHeader()->setDefaultSectionSize(
@@ -914,6 +924,9 @@ GroupWidget::GroupWidget(Mmapper2Group *const group, MapData *const md, QWidget 
             this,
             &GroupWidget::slot_onCharacterUpdated);
     connect(m_group, &Mmapper2Group::sig_groupReset, this, &GroupWidget::slot_onGroupReset);
+
+    updateColumnVisibility();
+    updatePulseTimer();
 }
 
 GroupWidget::~GroupWidget()
@@ -947,11 +960,46 @@ void GroupWidget::updateColumnVisibility()
     m_table->setColumnHidden(static_cast<int>(ColumnTypeEnum::MANA), hide_mana);
 }
 
+void GroupWidget::updatePulseTimer()
+{
+    const auto needs_pulse = [this]() -> bool {
+        for (const auto &character : m_model.getCharacters()) {
+            if (!character) {
+                continue;
+            }
+            // HP pulse < 30%
+            const int hp = character->getHits();
+            const int maxHp = character->getMaxHits();
+            if (maxHp > 0 && (static_cast<double>(hp) / maxHp) < 0.3) {
+                return true;
+            }
+            // Moves pulse < 15%
+            const int moves = character->getMoves();
+            const int maxMoves = character->getMaxMoves();
+            if (maxMoves > 0 && (static_cast<double>(moves) / maxMoves) < 0.15) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    if (needs_pulse()) {
+        if (!m_pulseTimer->isActive()) {
+            m_pulseTimer->start(50);
+        }
+    } else {
+        if (m_pulseTimer->isActive()) {
+            m_pulseTimer->stop();
+        }
+    }
+}
+
 void GroupWidget::slot_onCharacterAdded(SharedGroupChar character)
 {
     assert(character);
     m_model.insertCharacter(character);
     updateColumnVisibility();
+    updatePulseTimer();
 }
 
 void GroupWidget::slot_onCharacterRemoved(const GroupId characterId)
@@ -959,16 +1007,19 @@ void GroupWidget::slot_onCharacterRemoved(const GroupId characterId)
     assert(characterId != INVALID_GROUPID);
     m_model.removeCharacterById(characterId);
     updateColumnVisibility();
+    updatePulseTimer();
 }
 
 void GroupWidget::slot_onCharacterUpdated(SharedGroupChar character)
 {
     assert(character);
     m_model.updateCharacter(character);
+    updatePulseTimer();
 }
 
 void GroupWidget::slot_onGroupReset(const GroupVector &newCharacterList)
 {
     m_model.setCharacters(newCharacterList);
     updateColumnVisibility();
+    updatePulseTimer();
 }

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -17,7 +17,6 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
-#include <unordered_set>
 #include <vector>
 
 #include <QAction>
@@ -227,9 +226,10 @@ void GroupDelegate::paint(QPainter *const pPainter,
 
     const QRect rect = option.rect;
     const QColor charColor = character->getColor();
+    const QColor textColor = mmqt::textColor(charColor);
 
     // Layer 0: Background
-    painter.fillRect(rect, option.palette.brush(QPalette::Base));
+    painter.fillRect(rect, charColor);
 
     // Selection highlight (subtle overlay)
     if (option.state & QStyle::State_Selected) {
@@ -239,22 +239,12 @@ void GroupDelegate::paint(QPainter *const pPainter,
     }
 
     if (column == ColumnTypeEnum::NAME) {
-        // Layer 1: Row Accent (4px strip)
-        painter.fillRect(QRect(rect.left(), rect.top(), 4, rect.height()), charColor);
-
-        // Layer 3: Text (Tinted)
-        QString text = index.data(Qt::DisplayRole).toString();
-        // 25% charColor mixed with 75% #F8F8F2
-        QColor baseColor(0xF8, 0xF8, 0xF2);
-        int r = (charColor.red() * 25 + baseColor.red() * 75) / 100;
-        int g = (charColor.green() * 25 + baseColor.green() * 75) / 100;
-        int b = (charColor.blue() * 25 + baseColor.blue() * 75) / 100;
-        QColor tintedColor(r, g, b);
-
+        // Original behavior: Text over background
         painter.save();
-        painter.setPen(tintedColor);
-        QRect textRect = rect.adjusted(8, 0, 0, 0); // Padding for the strip
-        painter.drawText(textRect, Qt::AlignVCenter | Qt::AlignLeft, text);
+        painter.setPen(textColor);
+        painter.drawText(rect.adjusted(4, 0, 0, 0),
+                         Qt::AlignVCenter | Qt::AlignLeft,
+                         index.data(Qt::DisplayRole).toString());
         painter.restore();
 
     } else if (column == ColumnTypeEnum::HP || column == ColumnTypeEnum::MANA
@@ -331,16 +321,18 @@ void GroupDelegate::paint(QPainter *const pPainter,
         monoFont.setFamily("DejaVu Sans Mono");
         monoFont.setStyleHint(QFont::Monospace);
         painter.setFont(monoFont);
-        painter.setPen(mmqt::textColor(option.palette.color(QPalette::Base)));
+        painter.setPen(textColor);
         painter.drawText(rect, Qt::AlignCenter, index.data(Qt::DisplayRole).toString());
         painter.restore();
     } else {
-        // Fallback for other columns
-        QStyleOptionViewItem opt = option;
-        opt.state &= ~QStyle::State_HasFocus;
-        opt.state &= ~QStyle::State_Selected;
-
-        QStyledItemDelegate::paint(pPainter, opt, index);
+        // Other columns
+        painter.save();
+        painter.setPen(textColor);
+        const Qt::Alignment alignment = (column == ColumnTypeEnum::ROOM_NAME)
+                                            ? (Qt::AlignVCenter | Qt::AlignLeft)
+                                            : Qt::AlignCenter;
+        painter.drawText(rect, alignment, index.data(Qt::DisplayRole).toString());
+        painter.restore();
     }
 }
 
@@ -356,13 +348,8 @@ QSize GroupDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIn
     }
 
     const auto column = static_cast<ColumnTypeEnum>(index.column());
-    if (column == ColumnTypeEnum::NAME) {
-        QSize size = QStyledItemDelegate::sizeHint(option, index);
-        size.setWidth(size.width() + 12); // 4px strip + 8px padding
-        return size;
-
-    } else if (column == ColumnTypeEnum::HP || column == ColumnTypeEnum::MANA
-               || column == ColumnTypeEnum::MOVES) {
+    if (column == ColumnTypeEnum::HP || column == ColumnTypeEnum::MANA
+        || column == ColumnTypeEnum::MOVES) {
         QFont monoFont = option.font;
         monoFont.setFamily("DejaVu Sans Mono");
         monoFont.setStyleHint(QFont::Monospace);
@@ -657,6 +644,21 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
 
     case Qt::ToolTipRole: {
         switch (column) {
+        case ColumnTypeEnum::HP:
+        case ColumnTypeEnum::MANA:
+        case ColumnTypeEnum::MOVES: {
+            const int cur = (column == ColumnTypeEnum::HP)     ? character.getHits()
+                            : (column == ColumnTypeEnum::MANA) ? character.getMana()
+                                                               : character.getMoves();
+            const int max = (column == ColumnTypeEnum::HP)     ? character.getMaxHits()
+                            : (column == ColumnTypeEnum::MANA) ? character.getMaxMana()
+                                                               : character.getMaxMoves();
+            if (max > 0) {
+                const double pct = static_cast<double>(cur) / max;
+                return QString("%1%").arg(static_cast<int>(std::round(pct * 100.0)));
+            }
+            return QVariant();
+        }
         case ColumnTypeEnum::STATE: {
             QString prettyName;
             prettyName += getPrettyName(character.getPosition());
@@ -668,9 +670,6 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
             return prettyName;
         }
         case ColumnTypeEnum::NAME:
-        case ColumnTypeEnum::HP:
-        case ColumnTypeEnum::MANA:
-        case ColumnTypeEnum::MOVES:
             break;
         case ColumnTypeEnum::ROOM_NAME:
             if (character.getServerId() != INVALID_SERVER_ROOMID) {

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -373,9 +373,7 @@ QSize GroupDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIn
         monoFont.setStyleHint(QFont::Monospace);
         const QFontMetrics fm(monoFont);
 
-        // Sample text for calculation: "9999 / 9999" or "100%"
-        const QString sampleText = (column == ColumnTypeEnum::HP) ? "9999 / 9999" : "999 / 999";
-        const int textWidth = fm.horizontalAdvance(sampleText);
+        const int textWidth = fm.horizontalAdvance(QStringLiteral("999 / 999"));
         return QSize(textWidth + 20, QStyledItemDelegate::sizeHint(option, index).height());
     }
 
@@ -648,10 +646,10 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
         break;
 
     case Qt::BackgroundRole:
-        return QVariant(); // Handled in Delegate
+        return QVariant();
 
     case Qt::ForegroundRole:
-        return QVariant(); // Handled in Delegate
+        return QVariant();
 
     case Qt::TextAlignmentRole:
         if (column != ColumnTypeEnum::NAME && column != ColumnTypeEnum::ROOM_NAME) {

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -242,7 +242,7 @@ void GroupDelegate::paint(QPainter *const pPainter,
         painter.save();
         painter.setPen(textColor);
         painter.drawText(rect.adjusted(4, 0, 0, 0),
-                         Qt::AlignVCenter | Qt::AlignLeft,
+                         static_cast<int>(Qt::AlignVCenter | Qt::AlignLeft),
                          index.data(Qt::DisplayRole).toString());
         painter.restore();
 
@@ -292,8 +292,8 @@ void GroupDelegate::paint(QPainter *const pPainter,
         const int barHeight = static_cast<int>(static_cast<double>(rect.height()) * 0.8);
         const int barY = rect.y() + (rect.height() - barHeight) / 2;
         const double pct = std::clamp(max > 0 ? static_cast<double>(cur) / max : 0.0, 0.0, 1.0);
-        const int barWidth
-            = static_cast<int>(static_cast<double>(std::max(0, rect.width() - 2)) * pct);
+        const int barWidth = static_cast<int>(static_cast<double>(std::max(0, rect.width() - 2))
+                                              * pct);
         const QRect barRect(rect.x() + 1, barY, std::max(0, rect.width() - 2), barHeight);
 
         painter.save();
@@ -311,9 +311,10 @@ void GroupDelegate::paint(QPainter *const pPainter,
                 // 1.5s cycle (1500ms)
                 static constexpr const double PI = 3.14159265358979323846;
                 const qint64 ms = QDateTime::currentMSecsSinceEpoch() % 1500;
-                const double phase
-                    = (std::sin((static_cast<double>(ms) / 1500.0) * 2.0 * PI - PI / 2.0) + 1.0)
-                      / 2.0;
+                const double phase = (std::sin((static_cast<double>(ms) / 1500.0) * 2.0 * PI
+                                               - PI / 2.0)
+                                      + 1.0)
+                                     / 2.0;
                 alpha = pulseMin
                         + static_cast<int>(
                             std::round(static_cast<double>(pulseMax - pulseMin) * phase));
@@ -334,14 +335,21 @@ void GroupDelegate::paint(QPainter *const pPainter,
         monoFont.setFamily("DejaVu Sans Mono");
         monoFont.setStyleHint(QFont::Monospace);
         painter.setFont(monoFont);
-        painter.setPen(textColor);
-        painter.drawText(rect, Qt::AlignCenter, index.data(Qt::DisplayRole).toString());
+
+        // Use text color appropriate for QPalette::Window (the bar container background)
+        painter.setPen(mmqt::textColor(option.palette.color(QPalette::Window)));
+
+        painter.drawText(rect,
+                         static_cast<int>(Qt::AlignCenter),
+                         index.data(Qt::DisplayRole).toString());
         painter.restore();
     } else {
         // Other columns
         painter.save();
         painter.setPen(textColor);
-        painter.drawText(rect, Qt::AlignCenter, index.data(Qt::DisplayRole).toString());
+        painter.drawText(rect,
+                         static_cast<int>(Qt::AlignCenter),
+                         index.data(Qt::DisplayRole).toString());
         painter.restore();
     }
 }

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -14,11 +14,14 @@
 #include "enums.h"
 #include "mmapper2group.h"
 
+#include <algorithm>
+#include <cmath>
 #include <map>
 #include <vector>
 
 #include <QAction>
 #include <QColorDialog>
+#include <QDateTime>
 #include <QDebug>
 #include <QHeaderView>
 #include <QMenu>
@@ -28,6 +31,7 @@
 #include <QStringList>
 #include <QStyledItemDelegate>
 #include <QTableView>
+#include <QTimer>
 #include <QVBoxLayout>
 
 static constexpr const char *GROUP_MIME_TYPE = "application/vnd.mm_groupchar.row";
@@ -183,20 +187,161 @@ GroupDelegate::GroupDelegate(QObject *const parent)
 
 GroupDelegate::~GroupDelegate() = default;
 
-void GroupDelegate::paint(QPainter *const painter,
+void GroupDelegate::paint(QPainter *const pPainter,
                           const QStyleOptionViewItem &option,
                           const QModelIndex &index) const
 {
+    auto &painter = deref(pPainter);
+
     if (index.data().canConvert<GroupStateData>()) {
         GroupStateData stateData = qvariant_cast<GroupStateData>(index.data());
-        stateData.paint(painter, option.rect);
+        stateData.paint(pPainter, option.rect);
+        return;
+    }
 
+    const auto column = static_cast<ColumnTypeEnum>(index.column());
+    const GroupModel *model = qobject_cast<const GroupModel *>(index.model());
+    if (!model) {
+        // Handle proxy model
+        const auto *proxy = qobject_cast<const QSortFilterProxyModel *>(index.model());
+        if (proxy) {
+            model = qobject_cast<const GroupModel *>(proxy->sourceModel());
+        }
+    }
+
+    SharedGroupChar character = nullptr;
+    if (model) {
+        const auto sourceIndex = (index.model() == model)
+                                     ? index
+                                     : qobject_cast<const QSortFilterProxyModel *>(index.model())
+                                           ->mapToSource(index);
+        character = model->getCharacter(sourceIndex.row());
+    }
+
+    if (!character) {
+        QStyledItemDelegate::paint(pPainter, option, index);
+        return;
+    }
+
+    const QRect rect = option.rect;
+    const QColor charColor = character->getColor();
+
+    // Layer 0: Background
+    painter.fillRect(rect, option.palette.brush(QPalette::Base));
+
+    // Selection highlight (subtle overlay)
+    if (option.state & QStyle::State_Selected) {
+        QColor selectColor = option.palette.color(QPalette::Highlight);
+        selectColor.setAlpha(60);
+        painter.fillRect(rect, selectColor);
+    }
+
+    if (column == ColumnTypeEnum::NAME) {
+        // Layer 1: Row Accent (4px strip)
+        painter.fillRect(QRect(rect.left(), rect.top(), 4, rect.height()), charColor);
+
+        // Layer 3: Text (Tinted)
+        QString text = index.data(Qt::DisplayRole).toString();
+        // 25% charColor mixed with 75% #F8F8F2
+        QColor baseColor(0xF8, 0xF8, 0xF2);
+        int r = (charColor.red() * 25 + baseColor.red() * 75) / 100;
+        int g = (charColor.green() * 25 + baseColor.green() * 75) / 100;
+        int b = (charColor.blue() * 25 + baseColor.blue() * 75) / 100;
+        QColor tintedColor(r, g, b);
+
+        painter.save();
+        painter.setPen(tintedColor);
+        QRect textRect = rect.adjusted(8, 0, 0, 0); // Padding for the strip
+        painter.drawText(textRect, Qt::AlignVCenter | Qt::AlignLeft, text);
+        painter.restore();
+
+    } else if (column == ColumnTypeEnum::HP || column == ColumnTypeEnum::MANA
+               || column == ColumnTypeEnum::MOVES) {
+        int cur = 0;
+        int max = 0;
+        QColor barColor;
+        bool pulse = false;
+        int pulseMin = 100;
+        int pulseMax = 180;
+
+        if (column == ColumnTypeEnum::HP) {
+            cur = character->getHits();
+            max = character->getMaxHits();
+            const double pct = max > 0 ? (double) cur / max : 1.0;
+            if (pct < 0.3) {
+                barColor = QColor(0xFF, 0x55, 0x55); // Red
+                pulse = true;
+                pulseMax = 255;
+            } else {
+                barColor = QColor(0x50, 0xFA, 0x7B); // Green
+            }
+        } else if (column == ColumnTypeEnum::MANA) {
+            cur = character->getMana();
+            max = character->getMaxMana();
+            if (max <= 0) {
+                // Hidden State
+                painter.save();
+                painter.setPen(option.palette.color(QPalette::Text));
+                painter.drawText(rect, Qt::AlignCenter, "--");
+                painter.restore();
+                return;
+            }
+            barColor = QColor(0x8B, 0xE9, 0xFD); // Cyan
+        } else if (column == ColumnTypeEnum::MOVES) {
+            cur = character->getMoves();
+            max = character->getMaxMoves();
+            barColor = QColor(0xFF, 0xB8, 0x6C); // Amber
+            const double pct = max > 0 ? (double) cur / max : 1.0;
+            if (pct < 0.15) {
+                pulse = true;
+            }
+        }
+
+        // Layer 2: The Bar (80% height, rounded 4px)
+        const int barHeight = rect.height() * 0.8;
+        const int barY = rect.y() + (rect.height() - barHeight) / 2;
+        const double pct = std::clamp(max > 0 ? (double) cur / max : 0.0, 0.0, 1.0);
+        const int barWidth = rect.width() * pct;
+
+        int alpha = 180;
+        if (pulse) {
+            // 1.5s cycle (1500ms)
+            static constexpr const double PI = 3.14159265358979323846;
+            const qint64 ms = QDateTime::currentMSecsSinceEpoch() % 1500;
+            const double phase = (std::sin((ms / 1500.0) * 2.0 * PI - PI / 2.0) + 1.0) / 2.0;
+            alpha = pulseMin + (pulseMax - pulseMin) * phase;
+        }
+        barColor.setAlpha(alpha);
+
+        painter.save();
+        painter.setRenderHint(QPainter::Antialiasing);
+        painter.setBrush(barColor);
+        painter.setPen(Qt::NoPen);
+        painter.drawRoundedRect(QRect(rect.x(), barY, barWidth, barHeight), 4, 4);
+        painter.restore();
+
+        // Layer 3: Text (Monospace, Centered)
+        painter.save();
+        QFont monoFont = option.font;
+        monoFont.setFamily("DejaVu Sans Mono");
+        monoFont.setStyleHint(QFont::Monospace);
+        painter.setFont(monoFont);
+        painter.setPen(mmqt::textColor(option.palette.color(QPalette::Base)));
+        if (character->isNpc()) {
+            painter.drawText(rect,
+                             Qt::AlignCenter,
+                             QString("%1%").arg(static_cast<int>(std::round(pct * 100.0))));
+        } else {
+            painter.drawText(rect, Qt::AlignCenter, QString("%1 / %2").arg(cur).arg(max));
+        }
+        painter.restore();
     } else {
+        // Fallback for other columns
         QStyleOptionViewItem opt = option;
         opt.state &= ~QStyle::State_HasFocus;
         opt.state &= ~QStyle::State_Selected;
 
-        QStyledItemDelegate::paint(painter, opt, index);
+        QStyledItemDelegate::paint(pPainter, opt, index);
     }
 }
 
@@ -430,39 +575,13 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
 {
     const CGroupChar &character = deref(pCharacter);
 
-    const auto formatStat =
-        [](int numerator, int denomenator, ColumnTypeEnum statColumn) -> QString {
-        if (denomenator == 0
-            && (statColumn == ColumnTypeEnum::HP_PERCENT
-                || statColumn == ColumnTypeEnum::MANA_PERCENT
-                || statColumn == ColumnTypeEnum::MOVES_PERCENT)) {
-            return QLatin1String("");
-        }
+    const auto formatStat = [](int numerator, int denomenator) -> QString {
         // The NPC check for ratio is handled below in the switch statement
-        if ((numerator == 0 && denomenator == 0)
-            && (statColumn == ColumnTypeEnum::HP || statColumn == ColumnTypeEnum::MANA
-                || statColumn == ColumnTypeEnum::MOVES)) {
+        if (numerator == 0 && denomenator == 0) {
             return QLatin1String("");
         }
 
-        switch (statColumn) {
-        case ColumnTypeEnum::HP_PERCENT:
-        case ColumnTypeEnum::MANA_PERCENT:
-        case ColumnTypeEnum::MOVES_PERCENT: {
-            int percentage = static_cast<int>(100.0 * static_cast<double>(numerator)
-                                              / static_cast<double>(denomenator));
-            return QString("%1%").arg(percentage);
-        }
-        case ColumnTypeEnum::HP:
-        case ColumnTypeEnum::MANA:
-        case ColumnTypeEnum::MOVES:
-            return QString("%1/%2").arg(numerator).arg(denomenator);
-        default:
-        case ColumnTypeEnum::NAME:
-        case ColumnTypeEnum::STATE:
-        case ColumnTypeEnum::ROOM_NAME:
-            return QLatin1String("");
-        }
+        return QString("%1 / %2").arg(numerator).arg(denomenator);
     };
 
     // Map column to data
@@ -478,29 +597,23 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
                 return QString("%1 (%2)").arg(character.getName().toQString(),
                                               character.getLabel().toQString());
             }
-        case ColumnTypeEnum::HP_PERCENT:
-            return formatStat(character.getHits(), character.getMaxHits(), column);
-        case ColumnTypeEnum::MANA_PERCENT:
-            return formatStat(character.getMana(), character.getMaxMana(), column);
-        case ColumnTypeEnum::MOVES_PERCENT:
-            return formatStat(character.getMoves(), character.getMaxMoves(), column);
         case ColumnTypeEnum::HP:
             if (character.getType() == CharacterTypeEnum::NPC) {
                 return QLatin1String("");
             } else {
-                return formatStat(character.getHits(), character.getMaxHits(), column);
+                return formatStat(character.getHits(), character.getMaxHits());
             }
         case ColumnTypeEnum::MANA:
             if (character.getType() == CharacterTypeEnum::NPC) {
                 return QLatin1String("");
             } else {
-                return formatStat(character.getMana(), character.getMaxMana(), column);
+                return formatStat(character.getMana(), character.getMaxMana());
             }
         case ColumnTypeEnum::MOVES:
             if (character.getType() == CharacterTypeEnum::NPC) {
                 return QLatin1String("");
             } else {
-                return formatStat(character.getMoves(), character.getMaxMoves(), column);
+                return formatStat(character.getMoves(), character.getMaxMoves());
             }
         case ColumnTypeEnum::STATE:
             return QVariant::fromValue(GroupStateData(character.getColor(),
@@ -519,10 +632,10 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
         break;
 
     case Qt::BackgroundRole:
-        return character.getColor();
+        return QVariant(); // Handled in Delegate
 
     case Qt::ForegroundRole:
-        return mmqt::textColor(character.getColor());
+        return QVariant(); // Handled in Delegate
 
     case Qt::TextAlignmentRole:
         if (column != ColumnTypeEnum::NAME && column != ColumnTypeEnum::ROOM_NAME) {
@@ -532,23 +645,7 @@ QVariant GroupModel::dataForCharacter(const SharedGroupChar &pCharacter,
         break;
 
     case Qt::ToolTipRole: {
-        const auto getRatioTooltip =
-            [&character, &column, &formatStat](const int numerator,
-                                               const int denomenator) -> QVariant {
-            if (character.getType() == CharacterTypeEnum::NPC) {
-                return QVariant();
-            } else {
-                return formatStat(numerator, denomenator, column);
-            }
-        };
-
         switch (column) {
-        case ColumnTypeEnum::HP_PERCENT:
-            return getRatioTooltip(character.getHits(), character.getMaxHits());
-        case ColumnTypeEnum::MANA_PERCENT:
-            return getRatioTooltip(character.getMana(), character.getMaxMana());
-        case ColumnTypeEnum::MOVES_PERCENT:
-            return getRatioTooltip(character.getMoves(), character.getMaxMoves());
         case ColumnTypeEnum::STATE: {
             QString prettyName;
             prettyName += getPrettyName(character.getPosition());
@@ -739,6 +836,10 @@ GroupWidget::GroupWidget(Mmapper2Group *const group, MapData *const md, QWidget 
     m_table->setItemDelegate(new GroupDelegate(this));
     layout->addWidget(m_table);
 
+    m_pulseTimer = new QTimer(this);
+    connect(m_pulseTimer, &QTimer::timeout, m_table->viewport(), QOverload<>::of(&QWidget::update));
+    m_pulseTimer->start(50);
+
     // Minimize row height
     m_table->verticalHeader()->setDefaultSectionSize(
         m_table->verticalHeader()->minimumSectionSize());
@@ -817,6 +918,7 @@ GroupWidget::GroupWidget(Mmapper2Group *const group, MapData *const md, QWidget 
 
 GroupWidget::~GroupWidget()
 {
+    m_pulseTimer->stop();
     delete m_table;
     delete m_recolor;
 }
@@ -835,7 +937,7 @@ void GroupWidget::updateColumnVisibility()
     // Hide unnecessary columns like mana if everyone is a zorc/troll
     const auto one_character_had_mana = [this]() -> bool {
         for (const auto &character : m_model.getCharacters()) {
-            if (character && character->getMana() > 0) {
+            if (character && (character->getMana() > 0 || character->getMaxMana() > 0)) {
                 return true;
             }
         }
@@ -843,7 +945,6 @@ void GroupWidget::updateColumnVisibility()
     };
     const bool hide_mana = !one_character_had_mana();
     m_table->setColumnHidden(static_cast<int>(ColumnTypeEnum::MANA), hide_mana);
-    m_table->setColumnHidden(static_cast<int>(ColumnTypeEnum::MANA_PERCENT), hide_mana);
 }
 
 void GroupWidget::slot_onCharacterAdded(SharedGroupChar character)

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -156,7 +156,6 @@ GroupStateData::GroupStateData(const QColor &color,
 void GroupStateData::paint(QPainter *const pPainter, const QRect &rect)
 {
     auto &painter = deref(pPainter);
-    painter.fillRect(rect, m_color);
 
     painter.save();
     painter.translate(rect.x(), rect.y());
@@ -194,12 +193,6 @@ void GroupDelegate::paint(QPainter *const pPainter,
 {
     auto &painter = deref(pPainter);
 
-    if (index.data().canConvert<GroupStateData>()) {
-        GroupStateData stateData = qvariant_cast<GroupStateData>(index.data());
-        stateData.paint(pPainter, option.rect);
-        return;
-    }
-
     const auto column = static_cast<ColumnTypeEnum>(index.column());
     const GroupModel *model = qobject_cast<const GroupModel *>(index.model());
     if (!model) {
@@ -226,7 +219,6 @@ void GroupDelegate::paint(QPainter *const pPainter,
 
     const QRect rect = option.rect;
     const QColor charColor = character->getColor();
-    const QColor textColor = mmqt::textColor(charColor);
 
     // Layer 0: Background
     painter.fillRect(rect, charColor);
@@ -238,8 +230,15 @@ void GroupDelegate::paint(QPainter *const pPainter,
         painter.fillRect(rect, selectColor);
     }
 
-    if (column == ColumnTypeEnum::NAME) {
-        // Original behavior: Text over background
+    if (index.data().canConvert<GroupStateData>()) {
+        GroupStateData stateData = qvariant_cast<GroupStateData>(index.data());
+        stateData.paint(pPainter, option.rect);
+        return;
+    }
+
+    const QColor textColor = mmqt::textColor(charColor);
+
+    if (column == ColumnTypeEnum::NAME || column == ColumnTypeEnum::ROOM_NAME) {
         painter.save();
         painter.setPen(textColor);
         painter.drawText(rect.adjusted(4, 0, 0, 0),
@@ -293,26 +292,40 @@ void GroupDelegate::paint(QPainter *const pPainter,
         const int barHeight = static_cast<int>(static_cast<double>(rect.height()) * 0.8);
         const int barY = rect.y() + (rect.height() - barHeight) / 2;
         const double pct = std::clamp(max > 0 ? static_cast<double>(cur) / max : 0.0, 0.0, 1.0);
-        const int barWidth = static_cast<int>(static_cast<double>(rect.width()) * pct);
-
-        int alpha = 180;
-        if (pulse) {
-            // 1.5s cycle (1500ms)
-            static constexpr const double PI = 3.14159265358979323846;
-            const qint64 ms = QDateTime::currentMSecsSinceEpoch() % 1500;
-            const double phase = (std::sin((static_cast<double>(ms) / 1500.0) * 2.0 * PI - PI / 2.0)
-                                  + 1.0)
-                                 / 2.0;
-            alpha = pulseMin
-                    + static_cast<int>(std::round(static_cast<double>(pulseMax - pulseMin) * phase));
-        }
-        barColor.setAlpha(alpha);
+        const int barWidth
+            = static_cast<int>(static_cast<double>(std::max(0, rect.width() - 2)) * pct);
+        const QRect barRect(rect.x() + 1, barY, std::max(0, rect.width() - 2), barHeight);
 
         painter.save();
         painter.setRenderHint(QPainter::Antialiasing);
-        painter.setBrush(barColor);
-        painter.setPen(Qt::NoPen);
-        painter.drawRoundedRect(QRect(rect.x(), barY, barWidth, barHeight), 4.0, 4.0);
+
+        // Bar background and thin black border
+        painter.setBrush(option.palette.color(QPalette::Window));
+        painter.setPen(QPen(Qt::black, 1));
+        painter.drawRoundedRect(barRect, 4.0, 4.0);
+
+        // Bar foreground (the actual progress)
+        if (barWidth > 0) {
+            int alpha = 180;
+            if (pulse) {
+                // 1.5s cycle (1500ms)
+                static constexpr const double PI = 3.14159265358979323846;
+                const qint64 ms = QDateTime::currentMSecsSinceEpoch() % 1500;
+                const double phase
+                    = (std::sin((static_cast<double>(ms) / 1500.0) * 2.0 * PI - PI / 2.0) + 1.0)
+                      / 2.0;
+                alpha = pulseMin
+                        + static_cast<int>(
+                            std::round(static_cast<double>(pulseMax - pulseMin) * phase));
+            }
+            barColor.setAlpha(alpha);
+
+            painter.setBrush(barColor);
+            painter.setPen(Qt::NoPen);
+            // Clip to progress width to keep the rounded corners of the container
+            painter.setClipRect(rect.x() + 1, barY, barWidth, barHeight, Qt::IntersectClip);
+            painter.drawRoundedRect(barRect, 4.0, 4.0);
+        }
         painter.restore();
 
         // Layer 3: Text (Monospace, Centered)
@@ -328,10 +341,7 @@ void GroupDelegate::paint(QPainter *const pPainter,
         // Other columns
         painter.save();
         painter.setPen(textColor);
-        const Qt::Alignment alignment = (column == ColumnTypeEnum::ROOM_NAME)
-                                            ? (Qt::AlignVCenter | Qt::AlignLeft)
-                                            : Qt::AlignCenter;
-        painter.drawText(rect, alignment, index.data(Qt::DisplayRole).toString());
+        painter.drawText(rect, Qt::AlignCenter, index.data(Qt::DisplayRole).toString());
         painter.restore();
     }
 }

--- a/src/group/groupwidget.h
+++ b/src/group/groupwidget.h
@@ -54,7 +54,7 @@ public:
 
 public:
     void paint(QPainter *pPainter, const QRect &rect);
-    NODISCARD int getWidth() const { return m_count * m_height; }
+    NODISCARD int getWidth() const { return static_cast<int>(m_count) * m_height; }
 };
 Q_DECLARE_METATYPE(GroupStateData)
 
@@ -155,6 +155,7 @@ private:
     QTimer *m_pulseTimer = nullptr;
 
     void updateColumnVisibility();
+    void updatePulseTimer();
 
 private:
     QAction *m_center = nullptr;

--- a/src/group/groupwidget.h
+++ b/src/group/groupwidget.h
@@ -18,6 +18,7 @@ class MapData;
 class Mmapper2Group;
 class QObject;
 class QTableView;
+class QTimer;
 
 class NODISCARD_QOBJECT GroupProxyModel final : public QSortFilterProxyModel
 {
@@ -74,9 +75,6 @@ public:
 
 #define XFOREACH_COLUMNTYPE(X) \
     X(NAME, name, Name, "Name") \
-    X(HP_PERCENT, hp_percent, HpPercent, "HP") \
-    X(MANA_PERCENT, mana_percent, ManaPercent, "Mana") \
-    X(MOVES_PERCENT, moves_percent, MovesPercent, "Moves") \
     X(HP, hp, Hp, "HP") \
     X(MANA, mana, Mana, "Mana") \
     X(MOVES, moves, Moves, "Moves") \
@@ -154,6 +152,7 @@ private:
     MapData *m_map = nullptr;
     GroupProxyModel *m_proxyModel = nullptr;
     GroupModel m_model;
+    QTimer *m_pulseTimer = nullptr;
 
     void updateColumnVisibility();
 

--- a/src/group/mmapper2group.cpp
+++ b/src/group/mmapper2group.cpp
@@ -30,7 +30,7 @@ Mmapper2Group::Mmapper2Group(QObject *const parent)
     , m_groupManagerApi{std::make_unique<GroupManagerApi>(*this)}
 {}
 
-Mmapper2Group::~Mmapper2Group() {}
+Mmapper2Group::~Mmapper2Group() = default;
 
 SharedGroupChar Mmapper2Group::getSelf()
 {

--- a/src/mainwindow/AudioVolumeSlider.cpp
+++ b/src/mainwindow/AudioVolumeSlider.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "AudioVolumeSlider.h"
+
+#include "../configuration/configuration.h"
+#include "../global/SignalBlocker.h"
+
+#include <QWheelEvent>
+
+AudioVolumeSlider::AudioVolumeSlider(QWidget *const parent)
+    : QSlider(Qt::Orientation::Horizontal, parent)
+{
+    init();
+}
+
+AudioVolumeSlider::AudioVolumeSlider(AudioType type, QWidget *const parent)
+    : QSlider(Qt::Orientation::Horizontal, parent)
+    , m_type(type)
+{
+    init();
+}
+
+AudioVolumeSlider::~AudioVolumeSlider() = default;
+
+void AudioVolumeSlider::init()
+{
+    setRange(0, 100);
+    connect(this, &QSlider::valueChanged, this, [this](int value) { updateToConfig(value); });
+
+    setConfig().audio.registerChangeCallback(m_lifetime, [this]() { updateFromConfig(); });
+
+    if constexpr (NO_AUDIO) {
+        setEnabled(false);
+    }
+    setAudioType(m_type);
+}
+
+void AudioVolumeSlider::setAudioType(AudioType type)
+{
+    if (m_type == type && toolTip().length() > 0) {
+        return;
+    }
+
+    m_type = type;
+    updateFromConfig();
+
+    switch (m_type) {
+    case AudioType::Music:
+        setToolTip(tr("Music Volume"));
+        break;
+    case AudioType::Sound:
+        setToolTip(tr("Sound Volume"));
+        break;
+    }
+}
+
+void AudioVolumeSlider::updateFromConfig()
+{
+    int actualVolume = 0;
+    switch (m_type) {
+    case AudioType::Music:
+        actualVolume = getConfig().audio.getMusicVolume();
+        break;
+    case AudioType::Sound:
+        actualVolume = getConfig().audio.getSoundVolume();
+        break;
+    }
+
+    if (value() != actualVolume) {
+        const SignalBlocker block{*this};
+        setValue(actualVolume);
+    }
+}
+
+void AudioVolumeSlider::updateToConfig(int value)
+{
+    auto &audioSettings = setConfig().audio;
+    switch (m_type) {
+    case AudioType::Music:
+        if (audioSettings.getMusicVolume() != value) {
+            audioSettings.setMusicVolume(value);
+            audioSettings.setUnlocked();
+        }
+        break;
+    case AudioType::Sound:
+        if (audioSettings.getSoundVolume() != value) {
+            audioSettings.setSoundVolume(value);
+            audioSettings.setUnlocked();
+        }
+        break;
+    }
+}
+
+void AudioVolumeSlider::wheelEvent(QWheelEvent *event)
+{
+    event->ignore();
+}

--- a/src/mainwindow/AudioVolumeSlider.h
+++ b/src/mainwindow/AudioVolumeSlider.h
@@ -1,0 +1,42 @@
+#pragma once
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 The MMapper Authors
+
+#include "../global/RuleOf5.h"
+#include "../global/Signal2.h"
+#include "../global/macros.h"
+
+#include <QSlider>
+
+class NODISCARD_QOBJECT AudioVolumeSlider final : public QSlider
+{
+    Q_OBJECT
+    Q_PROPERTY(AudioType audioType READ audioType WRITE setAudioType)
+
+public:
+    enum class NODISCARD AudioType : uint8_t { Music, Sound };
+    Q_ENUM(AudioType)
+
+private:
+    Signal2Lifetime m_lifetime;
+    AudioType m_type = AudioType::Music;
+
+public:
+    explicit AudioVolumeSlider(QWidget *parent = nullptr);
+    explicit AudioVolumeSlider(AudioType type, QWidget *parent = nullptr);
+    ~AudioVolumeSlider() final;
+    DELETE_CTORS_AND_ASSIGN_OPS(AudioVolumeSlider);
+
+public:
+    NODISCARD AudioType audioType() const { return m_type; }
+    void setAudioType(AudioType type);
+
+    void updateFromConfig();
+
+protected:
+    void wheelEvent(QWheelEvent *event) override;
+
+private:
+    void init();
+    void updateToConfig(int value);
+};

--- a/src/mainwindow/MapZoomSlider.cpp
+++ b/src/mainwindow/MapZoomSlider.cpp
@@ -6,6 +6,8 @@
 #include "../display/mapwindow.h"
 #include "../global/SignalBlocker.h"
 
+#include <QWheelEvent>
+
 MapZoomSlider::~MapZoomSlider() = default;
 
 int MapZoomSlider::calcPos(const float zoom) noexcept
@@ -48,4 +50,9 @@ void MapZoomSlider::setFromActual()
         const SignalBlocker block{*this};
         setValue(clamp(rounded));
     }
+}
+
+void MapZoomSlider::wheelEvent(QWheelEvent *event)
+{
+    event->ignore();
 }

--- a/src/mainwindow/MapZoomSlider.h
+++ b/src/mainwindow/MapZoomSlider.h
@@ -31,6 +31,9 @@ public:
 
     void setFromActual();
 
+protected:
+    void wheelEvent(QWheelEvent *event) override;
+
 private:
     static int clamp(int val) { return std::clamp(val, min, max); }
 };

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -102,7 +102,6 @@ static void addApplicationFont()
 
 MainWindow::~MainWindow()
 {
-    forceNewFile();
     mmqt::rdisconnect(this);
     async_tasks::cleanup();
     delete m_listener;

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -33,6 +33,7 @@
 #include "../roompanel/RoomManager.h"
 #include "../roompanel/RoomWidget.h"
 #include "../viewers/TopLevelWindows.h"
+#include "AudioVolumeSlider.h"
 #include "MapZoomSlider.h"
 #include "UpdateDialog.h"
 #include "aboutdialog.h"
@@ -1185,6 +1186,7 @@ void MainWindow::setupMenuBar()
     toolbars->addAction(roomToolBar->toggleViewAction());
     toolbars->addAction(connectionToolBar->toggleViewAction());
     toolbars->addAction(settingsToolBar->toggleViewAction());
+    toolbars->addAction(audioToolBar->toggleViewAction());
     QMenu *sidepanels = viewMenu->addMenu(tr("&Side Panels"));
     sidepanels->addAction(m_dockDialogLog->toggleViewAction());
     sidepanels->addAction(m_dockDialogClient->toggleViewAction());
@@ -1428,6 +1430,15 @@ void MainWindow::setupToolBars()
     settingsToolBar->setObjectName("PreferencesToolBar");
     settingsToolBar->addAction(preferencesAct);
     settingsToolBar->hide();
+
+    audioToolBar = addToolBar(tr("Audio"));
+    audioToolBar->setObjectName("AudioToolBar");
+    audioToolBar->addWidget(
+        new AudioVolumeSlider(AudioVolumeSlider::AudioType::Music, audioToolBar));
+    audioToolBar->addSeparator();
+    audioToolBar->addWidget(
+        new AudioVolumeSlider(AudioVolumeSlider::AudioType::Sound, audioToolBar));
+    audioToolBar->hide();
 }
 
 void MainWindow::setupStatusBar()

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -135,6 +135,7 @@ private:
     QToolBar *roomToolBar = nullptr;
     QToolBar *connectionToolBar = nullptr;
     QToolBar *settingsToolBar = nullptr;
+    QToolBar *audioToolBar = nullptr;
 
     QMenu *fileMenu = nullptr;
     QMenu *editMenu = nullptr;

--- a/src/map/Crtp.h
+++ b/src/map/Crtp.h
@@ -10,9 +10,6 @@
 template<typename CRTP>
 struct NODISCARD ExitFieldsGetters
 {
-protected:
-    ExitFieldsGetters() = default;
-
 private:
     NODISCARD const auto &crtp_get_fields() const
     {
@@ -77,9 +74,6 @@ public:
 template<typename CRTP>
 struct NODISCARD ExitFieldsSetters
 {
-protected:
-    ExitFieldsSetters() = default;
-
 private:
     NODISCARD auto &crtp_get_fields() { return static_cast<CRTP &>(*this).getExitFields(); }
 
@@ -120,9 +114,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomFieldsGetters
 {
-protected:
-    RoomFieldsGetters() = default;
-
 private:
     NODISCARD const auto &crtp_get_fields() const
     {
@@ -139,9 +130,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomFieldsSetters
 {
-protected:
-    RoomFieldsSetters() = default;
-
 private:
     NODISCARD auto &crtp_get_fields() { return static_cast<CRTP &>(*this).getRoomFields(); }
 
@@ -175,9 +163,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomExitFieldsGetters
 {
-protected:
-    RoomExitFieldsGetters() = default;
-
 private:
     // Expect a const reference or a copy (necessary for fat-pointer proxy objects).
     NODISCARD decltype(auto) crtp_get_exit(const ExitDirEnum dir) const
@@ -203,9 +188,6 @@ public:
 template<typename CRTP>
 struct NODISCARD RoomExitFieldsSetters
 {
-protected:
-    RoomExitFieldsSetters() = default;
-
 private:
     NODISCARD auto &crtp_get_exit(const ExitDirEnum dir)
     {

--- a/src/map/Diff.h
+++ b/src/map/Diff.h
@@ -184,7 +184,8 @@ private:
     }
 
     template<typename E>
-    auto printEnum(const E x) -> std::enable_if_t<std::is_enum_v<E>>
+        requires(std::is_enum_v<E>)
+    void printEnum(const E x)
     {
         m_os << to_string_view(x);
     }

--- a/src/map/RawExit.cpp
+++ b/src/map/RawExit.cpp
@@ -7,12 +7,6 @@
 
 namespace detail {
 
-/*
-template<typename T>
-struct is_const_ref : std::bool_constant<!std::is_const_v<std::remove_reference_t<T>>>
-{};
-*/
-
 template<typename Exit_>
 struct NODISCARD InvariantsHelper final
 {
@@ -53,8 +47,10 @@ struct NODISCARD InvariantsHelper final
     }
 
     // Note: This function will cause a ton of compiler errors if you try to call it
-    // with a const ref Exit type, but we can't use std::enable_if_t here.
+    // with a const ref Exit type. The requires() clause should help give a reasonable
+    // error message.
     void enforce()
+        requires(not std::is_const_v<std::remove_reference_t<Exit_>>)
     {
         if (hasActualExitFlag != shouldHaveExitFlag) {
             if (shouldHaveExitFlag) {

--- a/src/map/TinyRoomIdSet.cpp
+++ b/src/map/TinyRoomIdSet.cpp
@@ -9,10 +9,9 @@
 #include <array>
 #include <set>
 
-template<typename T,
-         typename U,
-         typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, std::decay_t<U>>>>
-static T convertTo(const U &input)
+template<typename T, typename U>
+    requires(not std::is_same_v<std::decay_t<T>, std::decay_t<U>>)
+NODISCARD static T convertTo(const U &input)
 {
     T copy;
     for (const auto &x : input) {

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -37,22 +37,57 @@
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 
+// clang-format off
+
+
 // ---------------------------- XmlMapStorage::TypeEnum ------------------------
 // list know enum types
+//
+// Each called X(_x) should use:
+//
+// TYPE_NAME_ENUM_VALUE(_x), or
+// TYPE_NAME_ENUM_TYPE(_x) to construct the enum type name, or
+// TYPE_NAME_STRING(_x) to construct the string representing the type name.
+//
+// Caution: these must match XFOREACH_CONVERTER defined below; the reason we can't just have
+// a single mscro is because XFOREACH_CONVERTER calls this but macros can't be recursive.
 #define XFOREACH_TYPE_ENUM(X) \
-    X(RoomAlignEnum) \
-    X(DoorFlagEnum) \
-    X(ExitFlagEnum) \
-    X(RoomLightEnum) \
-    X(RoomLoadFlagEnum) \
-    X(InfomarkClassEnum) \
-    X(InfomarkTypeEnum) \
-    X(RoomMobFlagEnum) \
-    X(RoomPortableEnum) \
-    X(RoomRidableEnum) \
-    X(RoomSundeathEnum) \
-    X(RoomTerrainEnum) \
-    X(TypeEnum)
+    X(RoomAlign) \
+    X(DoorFlag) \
+    X(ExitFlag) \
+    X(RoomLight) \
+    X(RoomLoadFlag) \
+    X(InfomarkClass) \
+    X(InfomarkType) \
+    X(RoomMobFlag) \
+    X(RoomPortable) \
+    X(RoomRidable) \
+    X(RoomSundeath) \
+    X(RoomTerrain) \
+    X(Type)
+
+// Caution: these must match the enum types listed in XFOREACH_TYPE_ENUM above.
+// X(_x, _xfor, _xdecl)
+#define XFOREACH_CONVERTER(X, X_SEP) \
+    X(RoomAlign, XFOREACH_RoomAlignEnum, X_DECL_SINGLE) X_SEP() \
+    X(DoorFlag, XFOREACH_DOOR_FLAG, X_DECL_MULTI) X_SEP() \
+    X(ExitFlag, XFOREACH_EXIT_FLAG, X_DECL_MULTI) X_SEP() \
+    X(RoomLight, XFOREACH_RoomLightEnum, X_DECL_SINGLE) X_SEP() \
+    X(RoomLoadFlag, XFOREACH_ROOM_LOAD_FLAG, X_DECL_SINGLE) X_SEP() \
+    X(InfomarkClass, XFOREACH_INFOMARK_CLASS, X_DECL_SINGLE) X_SEP() \
+    X(InfomarkType, XFOREACH_INFOMARK_TYPE, X_DECL_SINGLE) X_SEP() \
+    X(RoomMobFlag, XFOREACH_ROOM_MOB_FLAG, X_DECL_SINGLE) X_SEP() \
+    X(RoomPortable, XFOREACH_RoomPortableEnum, X_DECL_SINGLE) X_SEP() \
+    X(RoomRidable, XFOREACH_RoomRidableEnum, X_DECL_SINGLE) X_SEP() \
+    X(RoomSundeath, XFOREACH_RoomSundeathEnum, X_DECL_SINGLE) X_SEP() \
+    X(RoomTerrain, XFOREACH_RoomTerrainEnum, X_DECL_SINGLE) X_SEP() \
+    X(Type, XFOREACH_TYPE_ENUM, X_DECL_TYPE_ENUM)
+
+// clang-format on
+
+#define TYPE_NAME_ENUM_VALUE(_x) (TypeEnum::_x)
+#define TYPE_NAME_ENUM_TYPE(_x) _x##Enum
+#define TYPE_NAME_C_STRING(_x) (#_x "Enum")
 
 namespace { // anonymous
 
@@ -66,11 +101,80 @@ enum class NODISCARD TypeEnum : uint32_t {
 constexpr const size_t NUM_XMLMAPSTORAGE_TYPE = (XFOREACH_TYPE_ENUM(X_ADD));
 #undef X_ADD
 
+#define X_SEP() ,
+#define X_DECL(_x, _xfor, _xdecl) _x
+enum class NODISCARD SanityCheckEnum : uint32_t { XFOREACH_CONVERTER(X_DECL, X_SEP) };
+#undef X_DECL
+#undef X_SEP
+
+#define X_SEP() ;
+#define X_CHECK(_x, _xfor, _xdecl) \
+    static_assert(static_cast<uint32_t>(SanityCheckEnum::_x) \
+                  == static_cast<uint32_t>(TYPE_NAME_ENUM_VALUE(_x)))
+XFOREACH_CONVERTER(X_CHECK, X_SEP);
+#undef X_CHECK
+#undef X_SEP
+
+// define a bunch of methods
+//   static constexpr TypeEnum enumToType(RoomAlignEnum) { return TypeEnum::RoomAlign; }
+//   static constexpr TypeEnum enumToType(DoorFlagEnum)  { return TypeEnum::DoorFlag;  }
+//   ...
+// converting an enumeration type to its corresponding TypeEnum value,
+// which can be used as argument in enumToString() and stringToEnum()
+#define X_DECL(_x) \
+    NODISCARD constexpr TypeEnum enumToType(TYPE_NAME_ENUM_TYPE(_x)) \
+    { \
+        return TYPE_NAME_ENUM_VALUE(_x); \
+    }
+XFOREACH_TYPE_ENUM(X_DECL)
+#undef X_DECL
+
+NODISCARD constexpr const char *to_c_string(const TypeEnum val)
+{
+#define X_CASE(_x) \
+    case TYPE_NAME_ENUM_VALUE(_x): \
+        return TYPE_NAME_C_STRING(_x);
+    //
+    switch (val) {
+        XFOREACH_TYPE_ENUM(X_CASE)
+    }
+    return "unknown";
+#undef X_CASE
+}
+
+static_assert(enumToType(RoomAlignEnum::UNDEFINED) == TypeEnum::RoomAlign);
+static_assert(enumToType(RoomTerrainEnum::UNDEFINED) == TypeEnum::RoomTerrain);
+
+static_assert(enumToType(TypeEnum::RoomAlign) == TypeEnum::Type);
+static_assert(enumToType(TypeEnum::RoomTerrain) == TypeEnum::Type);
+static_assert(enumToType(TypeEnum::Type) == TypeEnum::Type);
+
+static_assert(to_c_string(TypeEnum::RoomAlign) == std::string_view{"RoomAlignEnum"});
+static_assert(to_c_string(TypeEnum::RoomTerrain) == std::string_view{"RoomTerrainEnum"});
+static_assert(to_c_string(TypeEnum::Type) == std::string_view{"TypeEnum"});
+
+NODISCARD std::vector<std::vector<QString>> make_enum_to_strings_table()
+{
+#define X_SEP() ,
+#define X_DECL_SINGLE(_x) /*QString*/ {#_x},
+#define X_DECL_MULTI(_x, ...) /*QString*/ {#_x},
+#define X_DECL_TYPE_ENUM(_x) /*QString*/ {TYPE_NAME_C_STRING(_x)},
+#define X_CONVERT(_x, _xfor, _xdecl) /*std::vector<QString>*/ {_xfor(_xdecl)}
+
+    return {XFOREACH_CONVERTER(X_CONVERT, X_SEP)};
+
+#undef X_DECL_SINGLE
+#undef X_DECL_MULTI
+#undef X_DECL_TYPE_ENUM
+#undef X_CONVERT
+#undef X_SEP
+}
+
 // ---------------------------- XmlMapStorage::Converter -----------------------
 class NODISCARD Converter final
 {
 private:
-    std::vector<std::vector<QString>> m_enumToStrings;
+    std::vector<std::vector<QString>> m_enumToStrings = make_enum_to_strings_table();
     std::vector<QHash<QStringView, uint32_t>> m_stringToEnums;
 
 public:
@@ -100,57 +204,18 @@ public:
     {
         static_assert(std::is_enum_v<ENUM>, "template type ENUM must be an enumeration");
         if constexpr (std::is_same_v<ENUM, TypeEnum>) {
-#define X_CASE(x) \
-    case TypeEnum::x: \
-        return #x;
-            //
-            switch (val) {
-                XFOREACH_TYPE_ENUM(X_CASE)
-            }
-            return "unknown";
-#undef X_CASE
+            return ::to_c_string(val);
         } else {
             return enumToString(enumToType(val), static_cast<uint32_t>(val));
         }
     }
 
 private:
-    // define a bunch of methods
-    //   static constexpr TypeEnum enumToType(RoomAlignEnum) { return TypeEnum::RoomAlignEnum; }
-    //   static constexpr TypeEnum enumToType(DoorFlagEnum)  { return TypeEnum::DoorFlagEnum;  }
-    //   ...
-    // converting an enumeration type to its corresponding Type value,
-    // which can be used as argument in enumToString() and stringToEnum()
-#define X_DECL(X) \
-    MAYBE_UNUSED NODISCARD static constexpr TypeEnum enumToType(X) { return TypeEnum::X; }
-    XFOREACH_TYPE_ENUM(X_DECL)
-#undef X_DECL
-
     NODISCARD std::optional<uint32_t> stringToEnum(TypeEnum type, QStringView str) const;
     NODISCARD const QString &enumToString(TypeEnum type, uint32_t val) const;
 };
 
 Converter::Converter()
-    : m_enumToStrings{
-#define X_DECL(X) /* */ {#X},
-#define X_DECL2(X, ...) {#X},
-          /* these must match the enum types listed in XFOREACH_TYPE_ENUM above */
-          {XFOREACH_RoomAlignEnum(X_DECL)},
-          {XFOREACH_DOOR_FLAG(X_DECL2)},
-          {XFOREACH_EXIT_FLAG(X_DECL2)},
-          {XFOREACH_RoomLightEnum(X_DECL)},
-          {XFOREACH_ROOM_LOAD_FLAG(X_DECL)},
-          {XFOREACH_INFOMARK_CLASS(X_DECL)},
-          {XFOREACH_INFOMARK_TYPE(X_DECL)},
-          {XFOREACH_ROOM_MOB_FLAG(X_DECL)},
-          {XFOREACH_RoomPortableEnum(X_DECL)},
-          {XFOREACH_RoomRidableEnum(X_DECL)},
-          {XFOREACH_RoomSundeathEnum(X_DECL)},
-          {XFOREACH_RoomTerrainEnum(X_DECL)},
-          {XFOREACH_TYPE_ENUM(X_DECL)},
-#undef X_DECL
-#undef X_DECL2
-      }
 {
     if (m_enumToStrings.size() != NUM_XMLMAPSTORAGE_TYPE) {
         throw std::runtime_error("XmlMapStorage internal error: enum names do not match enum types");
@@ -950,3 +1015,4 @@ void XmlMapStorage::saveRoomMobFlags(QXmlStreamWriter &stream, const RoomMobFlag
 }
 
 #undef XFOREACH_TYPE_ENUM
+#undef XFOREACH_CONVERTER

--- a/src/mapstorage/XmlMapStorage.cpp
+++ b/src/mapstorage/XmlMapStorage.cpp
@@ -39,7 +39,6 @@
 
 // clang-format off
 
-
 // ---------------------------- XmlMapStorage::TypeEnum ------------------------
 // list know enum types
 //
@@ -101,6 +100,11 @@ enum class NODISCARD TypeEnum : uint32_t {
 constexpr const size_t NUM_XMLMAPSTORAGE_TYPE = (XFOREACH_TYPE_ENUM(X_ADD));
 #undef X_ADD
 
+NODISCARD bool isValid(const TypeEnum type)
+{
+    return static_cast<uint32_t>(type) < NUM_XMLMAPSTORAGE_TYPE;
+}
+
 #define X_SEP() ,
 #define X_DECL(_x, _xfor, _xdecl) _x
 enum class NODISCARD SanityCheckEnum : uint32_t { XFOREACH_CONVERTER(X_DECL, X_SEP) };
@@ -114,6 +118,14 @@ enum class NODISCARD SanityCheckEnum : uint32_t { XFOREACH_CONVERTER(X_DECL, X_S
 XFOREACH_CONVERTER(X_CHECK, X_SEP);
 #undef X_CHECK
 #undef X_SEP
+
+#define X_SEP()
+#define X_ADD(_x, _xfor, _xdecl) +1 // NOLINT
+constexpr const size_t NUM_SANITYCHECK = (XFOREACH_CONVERTER(X_ADD, X_SEP));
+#undef X_ADD
+#undef X_SEP
+
+static_assert(NUM_SANITYCHECK == NUM_XMLMAPSTORAGE_TYPE);
 
 // define a bunch of methods
 //   static constexpr TypeEnum enumToType(RoomAlignEnum) { return TypeEnum::RoomAlign; }
@@ -153,15 +165,20 @@ static_assert(to_c_string(TypeEnum::RoomAlign) == std::string_view{"RoomAlignEnu
 static_assert(to_c_string(TypeEnum::RoomTerrain) == std::string_view{"RoomTerrainEnum"});
 static_assert(to_c_string(TypeEnum::Type) == std::string_view{"TypeEnum"});
 
-NODISCARD std::vector<std::vector<QString>> make_enum_to_strings_table()
+template<typename T>
+using TypeEnumArray = EnumIndexedArray<T, TypeEnum, NUM_XMLMAPSTORAGE_TYPE>;
+
+using EnumToStrings = TypeEnumArray<std::vector<QString>>;
+
+NODISCARD EnumToStrings initEnumToStrings()
 {
 #define X_SEP() ,
 #define X_DECL_SINGLE(_x) /*QString*/ {#_x},
 #define X_DECL_MULTI(_x, ...) /*QString*/ {#_x},
 #define X_DECL_TYPE_ENUM(_x) /*QString*/ {TYPE_NAME_C_STRING(_x)},
-#define X_CONVERT(_x, _xfor, _xdecl) /*std::vector<QString>*/ {_xfor(_xdecl)}
+#define X_CONVERT(_x, _xfor, _xdecl) (std::vector<QString>{_xfor(_xdecl)})
 
-    return {XFOREACH_CONVERTER(X_CONVERT, X_SEP)};
+    return EnumToStrings{XFOREACH_CONVERTER(X_CONVERT, X_SEP)};
 
 #undef X_DECL_SINGLE
 #undef X_DECL_MULTI
@@ -174,12 +191,13 @@ NODISCARD std::vector<std::vector<QString>> make_enum_to_strings_table()
 class NODISCARD Converter final
 {
 private:
-    std::vector<std::vector<QString>> m_enumToStrings = make_enum_to_strings_table();
-    std::vector<QHash<QStringView, uint32_t>> m_stringToEnums;
+    EnumToStrings m_enumToStrings = initEnumToStrings();
+    TypeEnumArray<QHash<QStringView, uint32_t>> m_stringToEnums;
 
 public:
-    Converter();
+    explicit Converter();
     ~Converter() = default;
+    DELETE_CTORS_AND_ASSIGN_OPS(Converter);
 
     // parse string containing a signed or unsigned number.
     template<typename T>
@@ -222,8 +240,8 @@ Converter::Converter()
     }
 
     // create the maps string -> enum value for each enum type listed above
-    for (auto &vec : m_enumToStrings) {
-        auto &map = m_stringToEnums.emplace_back();
+    m_enumToStrings.for_each2([this](const TypeEnum e, auto &vec) {
+        auto &map = m_stringToEnums[e];
         uint32_t val = 0;
         for (auto &str : vec) {
             if (str == "UNDEFINED") {
@@ -237,22 +255,20 @@ Converter::Converter()
             }
             ++val;
         }
-    }
+    });
 }
 
 const QString &Converter::enumToString(const TypeEnum type, const uint32_t val) const
 {
-    const auto index = static_cast<uint32_t>(type);
-    if (index < m_enumToStrings.size()) {
-        const auto &tmp = m_enumToStrings[index];
-        if (val < tmp.size()) {
+    if (isValid(type)) {
+        if (const auto &tmp = m_enumToStrings[type]; val < tmp.size()) {
             return tmp[val];
         }
     }
 
     qWarning().noquote().nospace()
-        << "Attempt to save an invalid enum type = " << toString(type) << ", value = " << val
-        << ". Either the current map is damaged, or there is a bug";
+        << "WARNING: Attempt to save an invalid enum type = " << toString(type)
+        << ", value = " << val << ". Either the current map is damaged, or there is a bug.";
 
     static const QString g_empty{};
     assert(g_empty.isEmpty());
@@ -261,11 +277,9 @@ const QString &Converter::enumToString(const TypeEnum type, const uint32_t val) 
 
 std::optional<uint32_t> Converter::stringToEnum(const TypeEnum type, const QStringView str) const
 {
-    const auto index = static_cast<uint32_t>(type);
-    if (index < m_stringToEnums.size()) {
-        const auto &tmp = m_stringToEnums[index];
-        const auto iter = tmp.find(str);
-        if (iter != tmp.end()) {
+    if (isValid(type)) {
+        const auto &tmp = m_stringToEnums[type];
+        if (const auto iter = tmp.find(str); iter != tmp.end()) {
             return iter.value();
         }
     }

--- a/src/media/DescriptionWidget.h
+++ b/src/media/DescriptionWidget.h
@@ -19,8 +19,8 @@ class NODISCARD_QOBJECT DescriptionWidget final : public QWidget
 private:
     MediaLibrary &m_library;
 
-    QLabel *m_label;
-    QTextEdit *m_textEdit;
+    QLabel *m_label = nullptr;
+    QTextEdit *m_textEdit = nullptr;
 
 private:
     QCache<QString, QImage> m_imageCache;

--- a/src/media/MediaLibrary.h
+++ b/src/media/MediaLibrary.h
@@ -33,8 +33,8 @@ private:
 public:
     explicit MediaLibrary(QObject *parent = nullptr);
 
-    QString findAudio(const QString &subDir, const QString &name) const;
-    QString findImage(const QString &subDir, const QString &name) const;
+    NODISCARD QString findAudio(const QString &subDir, const QString &name) const;
+    NODISCARD QString findImage(const QString &subDir, const QString &name) const;
 
     void fetchAsync(const QString &path, std::function<void(const QByteArray &)> callback);
 

--- a/src/media/MusicManager.cpp
+++ b/src/media/MusicManager.cpp
@@ -124,7 +124,7 @@ void MusicManager::shutdown()
 #endif
 }
 
-void MusicManager::playMusic(const QString &musicFile)
+void MusicManager::playMusic(MAYBE_UNUSED const QString &musicFile)
 {
 #ifndef MMAPPER_NO_AUDIO
     if (musicFile.isEmpty() || NO_AUDIO) {

--- a/src/media/MusicManager.h
+++ b/src/media/MusicManager.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
+#include "../global/RuleOf5.h"
 #include "../global/macros.h"
 
 #include <QCache>
@@ -36,7 +37,7 @@ private:
         float fadeVolume = 0.0f;
     };
 
-    MusicChannel m_channels[2];
+    MusicChannel m_channels[2]; // TODO: use std::array or MMapper::Array
     int m_activeChannel = 0;
     QCache<QString, qint64> m_cachedPositions;
     QCache<QString, QTemporaryFile> m_wasmFiles;
@@ -52,6 +53,7 @@ private:
 public:
     explicit MusicManager(MediaLibrary &library, QObject *parent = nullptr);
     ~MusicManager() override;
+    DELETE_CTORS_AND_ASSIGN_OPS(MusicManager);
 
     void playMusic(const QString &musicFile);
     void stopMusic();

--- a/src/media/SfxManager.cpp
+++ b/src/media/SfxManager.cpp
@@ -98,7 +98,7 @@ void SfxManager::playFromData(const QByteArray &data, const QString &soundName)
 #endif
 }
 
-void SfxManager::startEffect(const QUrl &url, const QString &tmpToDelete)
+void SfxManager::startEffect(MAYBE_UNUSED const QUrl &url, MAYBE_UNUSED const QString &tmpToDelete)
 {
 #ifndef MMAPPER_NO_AUDIO
     auto *effect = new QMediaPlayer(this);

--- a/src/media/SfxManager.h
+++ b/src/media/SfxManager.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2026 The MMapper Authors
 
+#include "../global/RuleOf5.h"
 #include "../global/macros.h"
 
 #include <QObject>
@@ -22,13 +23,14 @@ class NODISCARD_QOBJECT SfxManager final : public QObject
 
 private:
 #ifndef MMAPPER_NO_AUDIO
-    QAudioOutput *m_output;
+    QAudioOutput *m_output = nullptr;
 #endif
     MediaLibrary &m_library;
 
 public:
     explicit SfxManager(MediaLibrary &library, QObject *parent = nullptr);
     ~SfxManager() override;
+    DELETE_CTORS_AND_ASSIGN_OPS(SfxManager);
 
     void shutdown();
     void playSound(const QString &soundName);

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -401,6 +401,7 @@ public:
     ~UniqueMesh() = default;
     DEFAULT_MOVES_DELETE_COPIES(UniqueMesh);
 
+    void reset() { m_mesh.reset(); }
     void render(const GLRenderState &rs) const { deref(m_mesh).render(rs); }
     NODISCARD explicit operator bool() const { return m_mesh != nullptr; }
 };

--- a/src/opengl/UboBlocks.h
+++ b/src/opengl/UboBlocks.h
@@ -98,9 +98,12 @@ XFOREACH_SHARED_VBO(X_TYPE)
 XFOREACH_SHARED_VBO(X_ASSERT)
 #undef X_ASSERT
 
+template<SharedVboEnum T>
+using BlockType_t = typename BlockType<T>::type;
+
 template<std::size_t... Is>
 auto MakeSharedVboBlocksHelper(std::index_sequence<Is...>)
-    -> std::tuple<typename BlockType<static_cast<SharedVboEnum>(Is)>::type...>;
+    -> std::tuple<BlockType_t<static_cast<SharedVboEnum>(Is)>...>;
 
 using SharedVboBlocks = decltype(MakeSharedVboBlocksHelper(
     std::make_index_sequence<NUM_SHARED_VBOS>{}));

--- a/src/opengl/UboManager.h
+++ b/src/opengl/UboManager.h
@@ -29,37 +29,46 @@ namespace Legacy {
  *
  * Note: This class is not thread-safe.
  */
-class UboManager final
+class NODISCARD UboManager final
 {
 public:
-    using RebuildFunction = std::function<void(Legacy::Functions &gl)>;
+    using RebuildFunction = std::function<void(Functions &gl)>;
 
+private:
+    EnumIndexedArray<RebuildFunction, SharedVboEnum> m_rebuildFunctions;
+    EnumIndexedArray<std::optional<GLuint>, SharedVboEnum> m_boundBuffers;
+
+    // Tuple of all block types for shadow storage.
+    SharedVboBlocks m_shadowBlocks;
+
+public:
     UboManager() { invalidateAll(); }
+    ~UboManager() = default;
     DELETE_CTORS_AND_ASSIGN_OPS(UboManager);
 
 public:
     /**
      * @brief Accesses the CPU-side shadow copy of a UBO block by its enum.
      */
-    template<Legacy::SharedVboEnum Block>
-    typename Legacy::BlockType<Block>::type &get()
+    template<SharedVboEnum Block>
+    NODISCARD BlockType_t<Block> &get()
     {
-        return std::get<typename Legacy::BlockType<Block>::type>(m_shadowBlocks);
+        return std::get<BlockType_t<Block>>(m_shadowBlocks);
     }
 
     /**
      * @brief Accesses the CPU-side shadow copy of a UBO block by its enum (const).
      */
-    template<Legacy::SharedVboEnum Block>
-    const typename Legacy::BlockType<Block>::type &get() const
+    template<SharedVboEnum Block>
+    NODISCARD const BlockType_t<Block> &get() const
     {
-        return std::get<typename Legacy::BlockType<Block>::type>(m_shadowBlocks);
+        return std::get<BlockType_t<Block>>(m_shadowBlocks);
     }
 
     /**
      * @brief Marks a UBO block as dirty by resetting its bound state.
      */
-    void invalidate(Legacy::SharedVboEnum block) { m_boundBuffers[block] = std::nullopt; }
+    void invalidate(const SharedVboEnum block) { m_boundBuffers[block] = std::nullopt; }
 
     /**
      * @brief Marks all UBO blocks as dirty.
@@ -78,7 +87,7 @@ public:
      *                        will trigger a debug assertion. Set to true only when an
      *                        overwrite is intentional.
      */
-    void registerRebuildFunction(Legacy::SharedVboEnum block,
+    void registerRebuildFunction(const SharedVboEnum block,
                                  RebuildFunction func,
                                  bool allowOverwrite = false)
     {
@@ -93,7 +102,7 @@ public:
     /**
      * @brief Unregisters a rebuild function for a UBO block.
      */
-    void unregisterRebuildFunction(Legacy::SharedVboEnum block)
+    void unregisterRebuildFunction(const SharedVboEnum block)
     {
         m_rebuildFunctions[block] = nullptr;
     }
@@ -101,13 +110,16 @@ public:
     /**
      * @brief Checks if a UBO block is currently dirty/invalid.
      */
-    bool isInvalid(Legacy::SharedVboEnum block) const { return !m_boundBuffers[block].has_value(); }
+    NODISCARD bool isInvalid(const SharedVboEnum block) const
+    {
+        return !m_boundBuffers[block].has_value();
+    }
 
     /**
      * @brief Rebuilds the UBO if it's invalid using the registered rebuild function.
      * @return The bound buffer ID, or 0 if failed.
      */
-    GLuint updateIfInvalid(Legacy::Functions &gl, Legacy::SharedVboEnum block)
+    ALLOW_DISCARD GLuint updateIfInvalid(Functions &gl, const SharedVboEnum block)
     {
         if (const auto bound = m_boundBuffers[block]) {
             return *bound;
@@ -115,7 +127,7 @@ public:
 
         const auto &func = m_rebuildFunctions[block];
         if (!func) {
-            const char *name = Legacy::Functions::getUniformBlockName(block);
+            const char *name = Functions::getUniformBlockName(block);
             MMLOG_ERROR() << "UboManager::updateIfInvalid: UBO block '" << name
                           << "' is invalid and no rebuild function is registered";
             throw std::runtime_error("UBO block '" + std::string(name)
@@ -128,7 +140,7 @@ public:
             return *bound;
         }
 
-        const char *name = Legacy::Functions::getUniformBlockName(block);
+        const char *name = Functions::getUniformBlockName(block);
         MMLOG_ERROR() << "UboManager::updateIfInvalid: rebuild function failed to call "
                          "update() for block '"
                       << name << "'";
@@ -144,11 +156,12 @@ public:
      * Overload for bulk vector data.
      */
     template<typename T, typename A>
-    GLuint update(Legacy::Functions &gl, Legacy::SharedVboEnum block, const std::vector<T, A> &data)
+    ALLOW_DISCARD GLuint update(Functions &gl,
+                                const SharedVboEnum block,
+                                const std::vector<T, A> &data)
     {
-        Legacy::VBO &vbo = getOrCreateVbo(gl, block);
-        static_cast<void>(
-            gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW));
+        VBO &vbo = getOrCreateVbo(gl, block);
+        gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW);
         return bind_internal(gl, block, vbo.get());
     }
 
@@ -160,9 +173,9 @@ public:
      * Overload for single trivially-copyable objects.
      */
     template<typename T>
-    GLuint update(Legacy::Functions &gl, Legacy::SharedVboEnum block, const T &data)
+    ALLOW_DISCARD GLuint update(Functions &gl, const SharedVboEnum block, const T &data)
     {
-        Legacy::VBO &vbo = getOrCreateVbo(gl, block);
+        VBO &vbo = getOrCreateVbo(gl, block);
         gl.setVbo(GL_UNIFORM_BUFFER, vbo.get(), data, BufferUsageEnum::DYNAMIC_DRAW);
         return bind_internal(gl, block, vbo.get());
     }
@@ -172,8 +185,8 @@ public:
      * Enforces the correct data structure for the given block identifier.
      * Also updates the shadow copy.
      */
-    template<Legacy::SharedVboEnum Block>
-    GLuint update(Legacy::Functions &gl, const typename Legacy::BlockType<Block>::type &data)
+    template<SharedVboEnum Block>
+    ALLOW_DISCARD GLuint update(Functions &gl, const BlockType_t<Block> &data)
     {
         get<Block>() = data;
         return update(gl, Block, data);
@@ -182,8 +195,8 @@ public:
     /**
      * @brief Syncs the entire shadow copy of a block to the GPU.
      */
-    template<Legacy::SharedVboEnum Block>
-    GLuint sync(Legacy::Functions &gl)
+    template<SharedVboEnum Block>
+    ALLOW_DISCARD GLuint sync(Functions &gl)
     {
         return update(gl, Block, get<Block>());
     }
@@ -193,10 +206,10 @@ public:
      * @param gl       Legacy functions.
      * @param members  Pointers to the members in the block struct.
      */
-    template<Legacy::SharedVboEnum Block, typename T, typename... Us>
-    void syncFields(Legacy::Functions &gl, Us T::*...members)
+    template<SharedVboEnum Block, typename T, typename... Us>
+    void syncFields(Functions &gl, Us T::*...members)
     {
-        using BlockType = typename Legacy::BlockType<Block>::type;
+        using BlockType = BlockType_t<Block>;
         static_assert(std::is_same_v<T, BlockType>, "Members must belong to the correct block type");
         static_assert(std::is_standard_layout_v<BlockType>,
                       "Block type must have standard layout for offset calculation");
@@ -209,7 +222,7 @@ public:
         }
 
         const auto &blockData = get<Block>();
-        Legacy::VBO &vbo = getOrCreateVbo(gl, Block);
+        VBO &vbo = getOrCreateVbo(gl, Block);
         gl.glBindBuffer(GL_UNIFORM_BUFFER, vbo.get());
 
         (gl.glBufferSubData(GL_UNIFORM_BUFFER,
@@ -223,7 +236,7 @@ public:
         gl.glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
         // Ensure it's bound to the correct point.
-        bind_internal(gl, Block, vbo.get());
+        std::ignore = bind_internal(gl, Block, vbo.get());
     }
 
     /**
@@ -231,8 +244,8 @@ public:
      * @param gl      Legacy functions.
      * @param member  Pointer to the member in the block struct.
      */
-    template<Legacy::SharedVboEnum Block, typename T, typename U>
-    void syncField(Legacy::Functions &gl, U T::*member)
+    template<SharedVboEnum Block, typename T, typename U>
+    void syncField(Functions &gl, U T::*member)
     {
         syncFields<Block>(gl, member);
     }
@@ -241,7 +254,7 @@ public:
      * @brief Binds the UBO to its assigned point.
      * If invalid and a rebuild function is registered, it will be updated first.
      */
-    void bind(Legacy::Functions &gl, Legacy::SharedVboEnum block)
+    void bind(Functions &gl, const SharedVboEnum block)
     {
         const GLuint buffer = updateIfInvalid(gl, block);
 
@@ -259,10 +272,10 @@ public:
     }
 
 private:
-    Legacy::VBO &getOrCreateVbo(Legacy::Functions &gl, Legacy::SharedVboEnum block)
+    NODISCARD VBO &getOrCreateVbo(Functions &gl, const SharedVboEnum block)
     {
         const auto sharedVbo = gl.getSharedVbos().get(block);
-        Legacy::VBO &vbo = deref(sharedVbo);
+        VBO &vbo = deref(sharedVbo);
 
         if (!vbo) {
             vbo.emplace(gl.shared_from_this());
@@ -275,13 +288,13 @@ private:
      * @brief Binds the UBO to its assigned point.
      * @return The bound buffer ID.
      *
-     * Note: This implementation explicitly assumes that Legacy::SharedVboEnum values
+     * Note: This implementation explicitly assumes that SharedVboEnum values
      * are 0-based, contiguous, and directly correspond to UBO binding indices in
      * shader blocks.
      */
-    GLuint bind_internal(Legacy::Functions &gl, Legacy::SharedVboEnum block, GLuint buffer)
+    NODISCARD GLuint bind_internal(Functions &gl, const SharedVboEnum block, const GLuint buffer)
     {
-        const auto bindingIndex = Legacy::getUboBindingIndex(block);
+        const auto bindingIndex = getUboBindingIndex(block);
         assert(static_cast<std::size_t>(bindingIndex) < m_boundBuffers.size());
 
         auto &bound = m_boundBuffers[block];
@@ -291,13 +304,6 @@ private:
         }
         return buffer;
     }
-
-private:
-    EnumIndexedArray<RebuildFunction, Legacy::SharedVboEnum> m_rebuildFunctions;
-    EnumIndexedArray<std::optional<GLuint>, Legacy::SharedVboEnum> m_boundBuffers;
-
-    // Tuple of all block types for shadow storage.
-    Legacy::SharedVboBlocks m_shadowBlocks;
 };
 
 } // namespace Legacy

--- a/src/opengl/Weather.cpp
+++ b/src/opengl/Weather.cpp
@@ -202,6 +202,14 @@ GLWeather::~GLWeather()
     m_gl.getUboManager().unregisterRebuildFunction(Legacy::SharedVboEnum::WeatherBlock);
 }
 
+void GLWeather::cleanup()
+{
+    m_simulation.reset();
+    m_particles.reset();
+    m_atmosphere.reset();
+    m_timeOfDay.reset();
+}
+
 void GLWeather::updateFromGame()
 {
     switch (m_observer.getWeather()) {

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -86,7 +86,7 @@ public:
                        GameObserver &observer,
                        FrameManager &frameManager);
     ~GLWeather();
-
+    void cleanup();
     DELETE_CTORS_AND_ASSIGN_OPS(GLWeather);
 
 public:

--- a/src/opengl/Weather.h
+++ b/src/opengl/Weather.h
@@ -110,7 +110,7 @@ private:
     NODISCARD T applyTransition(float startTime, T startVal, T targetVal) const;
 
     template<typename T>
-    struct TransitionPair
+    struct NODISCARD TransitionPair final
     {
         T &start;
         T target;

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -34,6 +34,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QMessageLogContext>
+#include <QOpenGLContext>
 #include <QOpenGLExtraFunctions>
 #include <QOpenGLTexture>
 
@@ -354,6 +355,12 @@ UboManager &Functions::getUboManager()
 /// This only exists so we can detect errors in contexts that don't support \c glDebugMessageCallback().
 void Functions::checkError()
 {
+    // glGetError() returns GL_INVALID_OPERATION indefinitely when called without a current context
+    // (e.g. on NVIDIA drivers), causing an infinite loop. Skip the check if no context is current.
+    if (QOpenGLContext::currentContext() == nullptr) {
+        return;
+    }
+
 #define CASE(x) \
     case (x): \
         qCritical() << "OpenGL error" << #x; \

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -330,7 +330,7 @@ public:
     /// platform-specific (ES vs GL)
     NODISCARD const char *getShaderVersion() const { return virt_getShaderVersion(); }
 
-protected:
+private:
     NODISCARD virtual bool virt_canRenderQuads() = 0;
     NODISCARD virtual std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) = 0;
     virtual void virt_enableProgramPointSize(bool enable) = 0;
@@ -344,7 +344,10 @@ public:
     NODISCARD bool canRenderQuads() { return virt_canRenderQuads(); }
 
     /// platform-specific (ES vs GL)
-    NODISCARD std::optional<GLenum> toGLenum(DrawModeEnum mode) { return virt_toGLenum(mode); }
+    NODISCARD std::optional<GLenum> toGLenum(const DrawModeEnum mode)
+    {
+        return virt_toGLenum(mode);
+    }
 
 protected:
 private:

--- a/src/opengl/legacy/TFO.h
+++ b/src/opengl/legacy/TFO.h
@@ -8,6 +8,7 @@
 
 namespace Legacy {
 
+// TFO = Transform Feedback Object
 class NODISCARD TFO final
 {
 private:

--- a/src/opengl/legacy/VBO.cpp
+++ b/src/opengl/legacy/VBO.cpp
@@ -3,6 +3,8 @@
 
 #include "VBO.h"
 
+#include <QDebug>
+
 namespace Legacy {
 bool LOG_VBO_ALLOCATIONS = false;
 bool LOG_VBO_STATIC_UPLOADS = false;
@@ -25,8 +27,11 @@ void VBO::reset()
         if (LOG_VBO_ALLOCATIONS) {
             qInfo() << this << "Freeing VBO" << vbo;
         }
-        auto sharedFunctions = std::exchange(m_weakFunctions, {}).lock();
-        deref(sharedFunctions).glDeleteBuffers(1, &vbo);
+        if (auto sharedFunctions = std::exchange(m_weakFunctions, {}).lock()) {
+            sharedFunctions->glDeleteBuffers(1, &vbo);
+        } else {
+            qCritical() << "Legacy::Functions is no longer valid, leaking VBO" << vbo;
+        }
     }
     assert(m_weakFunctions.lock() == nullptr);
 }
@@ -77,8 +82,12 @@ void Program::reset()
         if (LOG_VBO_ALLOCATIONS) {
             qInfo() << this << "Freeing Shader Program" << program;
         }
-        auto sharedFunctions = std::exchange(m_weakFunctions, {}).lock();
-        deref(sharedFunctions).glDeleteProgram(program);
+        if (auto sharedFunctions = std::exchange(m_weakFunctions, {}).lock()) {
+            sharedFunctions->glDeleteProgram(program);
+        } else {
+            qCritical() << "Legacy::Functions is no longer valid, leaking shader program"
+                        << program;
+        }
     }
     assert(m_weakFunctions.lock() == nullptr);
 }

--- a/src/preferences/AdvancedGraphics.cpp
+++ b/src/preferences/AdvancedGraphics.cpp
@@ -24,7 +24,7 @@
 #include <QVector>
 #include <QWidget>
 
-SliderSpinboxButton::~SliderSpinboxButton() {}
+SliderSpinboxButton::~SliderSpinboxButton() = default;
 
 template<int D>
 class NODISCARD FpSlider final : public QSlider

--- a/src/preferences/audiopage.cpp
+++ b/src/preferences/audiopage.cpp
@@ -5,6 +5,7 @@
 
 #include "../configuration/configuration.h"
 #include "../global/SignalBlocker.h"
+#include "../mainwindow/AudioVolumeSlider.h"
 #include "ui_audiopage.h"
 
 #ifndef MMAPPER_NO_AUDIO
@@ -21,14 +22,6 @@ AudioPage::AudioPage(QWidget *const parent)
     slot_updateDevices();
     slot_loadConfig();
 
-    connect(ui->musicVolumeSlider,
-            &QSlider::valueChanged,
-            this,
-            &AudioPage::slot_musicVolumeChanged);
-    connect(ui->soundsVolumeSlider,
-            &QSlider::valueChanged,
-            this,
-            &AudioPage::slot_soundsVolumeChanged);
     connect(ui->outputDeviceComboBox,
             &QComboBox::currentIndexChanged,
             this,
@@ -41,8 +34,6 @@ AudioPage::AudioPage(QWidget *const parent)
 
     if constexpr (NO_AUDIO) {
         ui->outputDeviceComboBox->setEnabled(false);
-        ui->musicVolumeSlider->setEnabled(false);
-        ui->soundsVolumeSlider->setEnabled(false);
     }
 }
 
@@ -58,8 +49,8 @@ void AudioPage::slot_loadConfig()
     SignalBlocker outputBlocker(*ui->outputDeviceComboBox);
 
     const auto &settings = getConfig().audio;
-    ui->musicVolumeSlider->setValue(settings.getMusicVolume());
-    ui->soundsVolumeSlider->setValue(settings.getSoundVolume());
+    ui->musicVolumeSlider->updateFromConfig();
+    ui->soundsVolumeSlider->updateFromConfig();
 
     int index = ui->outputDeviceComboBox->findData(settings.getOutputDeviceId());
     if (index != -1) {
@@ -67,20 +58,6 @@ void AudioPage::slot_loadConfig()
     } else {
         ui->outputDeviceComboBox->setCurrentIndex(0);
     }
-}
-
-void AudioPage::slot_musicVolumeChanged(int value)
-{
-    auto &settings = setConfig().audio;
-    settings.setMusicVolume(value);
-    settings.setUnlocked();
-}
-
-void AudioPage::slot_soundsVolumeChanged(int value)
-{
-    auto &settings = setConfig().audio;
-    settings.setSoundVolume(value);
-    settings.setUnlocked();
 }
 
 void AudioPage::slot_outputDeviceChanged(int index)

--- a/src/preferences/audiopage.h
+++ b/src/preferences/audiopage.h
@@ -23,8 +23,6 @@ public:
 
 public slots:
     void slot_loadConfig();
-    void slot_musicVolumeChanged(int);
-    void slot_soundsVolumeChanged(int);
     void slot_outputDeviceChanged(int);
     void slot_updateDevices();
 };

--- a/src/preferences/audiopage.ui
+++ b/src/preferences/audiopage.ui
@@ -44,12 +44,9 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSlider" name="musicVolumeSlider">
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="AudioVolumeSlider" name="musicVolumeSlider">
+        <property name="audioType">
+         <enum>AudioVolumeSlider::AudioType::Music</enum>
         </property>
        </widget>
       </item>
@@ -70,12 +67,9 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QSlider" name="soundsVolumeSlider">
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="AudioVolumeSlider" name="soundsVolumeSlider">
+        <property name="audioType">
+         <enum>AudioVolumeSlider::AudioType::Sound</enum>
         </property>
        </widget>
       </item>
@@ -97,6 +91,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AudioVolumeSlider</class>
+   <extends>QSlider</extends>
+   <header>mainwindow/AudioVolumeSlider.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
+++ b/src/resources/shaders/legacy/weather/atmosphere/frag.glsl
@@ -67,14 +67,12 @@ void main()
     float uCloudsIntensity = mix(uIntensities[2], uTargets[2], weatherLerp);
     float uFogIntensity = mix(uIntensities[3], uTargets[3], weatherLerp);
 
-    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
-                                0.0,
-                                1.0);
+    float tTod = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration, 0.0, 1.0);
+    float timeOfDayLerp = smoothstep(0.0, 1.0, tTod);
     float currentTimeOfDayIntensity = mix(uTimeOfDay.z, uTimeOfDay.w, timeOfDayLerp);
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDay.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDay.y)];
-    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
-    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+    float alphaStart = uNamedColors[int(uTimeOfDay.x)].a;
+    float alphaTarget = uNamedColors[int(uTimeOfDay.y)].a;
+    float uTimeOfDayAlpha = mix(alphaStart, alphaTarget, timeOfDayLerp) * currentTimeOfDayIntensity;
 
     // Atmosphere overlay is now transparent by default (TimeOfDay is drawn separately)
     vec4 result = vec4(0.0);
@@ -86,7 +84,7 @@ void main()
         float density = 0.4 + uFogIntensity * 0.4;
         vec4 fog = vec4(0.8, 0.8, 0.85, uFogIntensity * n * localMask * density);
         // Emissive boost at night
-        fog.rgb += uTimeOfDayColor.a * 0.15;
+        fog.rgb += uTimeOfDayAlpha * 0.15;
 
         // Blend fog over result
         float combinedAlpha = 1.0 - (1.0 - result.a) * (1.0 - fog.a);
@@ -106,7 +104,7 @@ void main()
                            1.0 * storminess,
                            uCloudsIntensity * puffy * localMask * 0.5);
         // Emissive boost at night
-        clouds.rgb += uTimeOfDayColor.a * 0.1;
+        clouds.rgb += uTimeOfDayAlpha * 0.1;
 
         // Blend clouds over result
         float combinedAlpha = 1.0 - (1.0 - result.a) * (1.0 - clouds.a);

--- a/src/resources/shaders/legacy/weather/particle/frag.glsl
+++ b/src/resources/shaders/legacy/weather/particle/frag.glsl
@@ -40,14 +40,12 @@ void main()
     float pIntensity = max(pRain, pSnow);
     float pType = pSnow / max(pIntensity, 0.001);
 
-    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
-                                0.0,
-                                1.0);
+    float tTod = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration, 0.0, 1.0);
+    float timeOfDayLerp = smoothstep(0.0, 1.0, tTod);
     float currentTimeOfDayIntensity = mix(uTimeOfDay.z, uTimeOfDay.w, timeOfDayLerp);
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDay.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDay.y)];
-    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
-    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+    float alphaStart = uNamedColors[int(uTimeOfDay.x)].a;
+    float alphaTarget = uNamedColors[int(uTimeOfDay.y)].a;
+    float uTimeOfDayAlpha = mix(alphaStart, alphaTarget, timeOfDayLerp) * currentTimeOfDayIntensity;
 
     float lifeFade = smoothstep(0.0, 0.15, vLife) * smoothstep(1.0, 0.85, vLife);
 
@@ -55,14 +53,14 @@ void main()
     float streak = 1.0 - smoothstep(0.0, 0.15, abs(vLocalCoord.x - 0.5));
     float rainAlpha = mix(0.4, 0.7, clamp(pIntensity, 0.0, 1.0));
     vec4 rainColor = vec4(0.6, 0.6, 1.0, pIntensity * streak * vLocalMask * rainAlpha * lifeFade);
-    rainColor.rgb += uTimeOfDayColor.a * 0.2;
+    rainColor.rgb += uTimeOfDayAlpha * 0.2;
 
     // Snow visuals
     float dist = distance(vLocalCoord, vec2(0.5));
     float flake = 1.0 - smoothstep(0.1, 0.2, dist);
     float snowAlpha = mix(0.6, 0.9, clamp(pIntensity, 0.0, 1.0));
     vec4 snowColor = vec4(1.0, 1.0, 1.1, pIntensity * flake * vLocalMask * snowAlpha * lifeFade);
-    snowColor.rgb += uTimeOfDayColor.a * 0.3;
+    snowColor.rgb += uTimeOfDayAlpha * 0.3;
 
     // Interpolate visuals based on pType
     vec4 pColor = mix(rainColor, snowColor, pType);

--- a/src/resources/shaders/legacy/weather/timeofday/frag.glsl
+++ b/src/resources/shaders/legacy/weather/timeofday/frag.glsl
@@ -23,22 +23,78 @@ layout(std140) uniform WeatherBlock
 
 out vec4 vFragmentColor;
 
+vec3 srgbToLinear(vec3 c)
+{
+    vec3 low = c / 12.92;
+    vec3 high = pow((c + 0.055) / 1.055, vec3(2.4));
+    return mix(low, high, step(vec3(0.04045), c));
+}
+
+vec3 linearToSrgb(vec3 c)
+{
+    vec3 low = c * 12.92;
+    vec3 high = 1.055 * pow(c, vec3(1.0 / 2.4)) - 0.055;
+    return mix(low, high, step(vec3(0.0031308), c));
+}
+
+vec3 linearToOklab(vec3 c)
+{
+    float l = 0.4122214708 * c.r + 0.5363325363 * c.g + 0.0514459929 * c.b;
+    float m = 0.2119034982 * c.r + 0.6806995451 * c.g + 0.1073969566 * c.b;
+    float s = 0.0883024619 * c.r + 0.2817188376 * c.g + 0.6299787005 * c.b;
+
+    float l_ = pow(l, 1.0 / 3.0);
+    float m_ = pow(m, 1.0 / 3.0);
+    float s_ = pow(s, 1.0 / 3.0);
+
+    return vec3(0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720403 * s_,
+                1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
+                0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_);
+}
+
+vec3 oklabToLinear(vec3 c)
+{
+    float l_ = c.x + 0.3963377774 * c.y + 0.2158037573 * c.z;
+    float m_ = c.x - 0.1055613458 * c.y - 0.0638541728 * c.z;
+    float s_ = c.x - 0.0894841775 * c.y - 1.2914855480 * c.z;
+
+    float l = l_ * l_ * l_;
+    float m = m_ * m_ * m_;
+    float s = s_ * s_ * s_;
+
+    return vec3(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+                -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+                -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s);
+}
+
 void main()
 {
     float uCurrentTime = uTime.x;
     float uTimeOfDayStartTime = uConfig.y;
     float uTransitionDuration = uConfig.z;
 
-    vec4 timeOfDayStart = uNamedColors[int(uTimeOfDay.x)];
-    vec4 timeOfDayTarget = uNamedColors[int(uTimeOfDay.y)];
+    vec4 timeOfDayStartSrgb = uNamedColors[int(uTimeOfDay.x)];
+    vec4 timeOfDayTargetSrgb = uNamedColors[int(uTimeOfDay.y)];
 
-    float timeOfDayLerp = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration,
-                                0.0,
-                                1.0);
+    float t = clamp((uCurrentTime - uTimeOfDayStartTime) / uTransitionDuration, 0.0, 1.0);
+    float timeOfDayLerp = smoothstep(0.0, 1.0, t);
+
+    // Convert start and target colors to Oklab
+    vec3 startOklab = linearToOklab(srgbToLinear(timeOfDayStartSrgb.rgb));
+    vec3 targetOklab = linearToOklab(srgbToLinear(timeOfDayTargetSrgb.rgb));
+
+    // Interpolate in Oklab space
+    vec3 mixedOklab = mix(startOklab, targetOklab, timeOfDayLerp);
+
+    // Convert back to sRGB
+    vec3 mixedSrgb = linearToSrgb(oklabToLinear(mixedOklab));
+
+    // Mix intensity with smoothstep as well
     float currentTimeOfDayIntensity = mix(uTimeOfDay.z, uTimeOfDay.w, timeOfDayLerp);
 
-    vec4 uTimeOfDayColor = mix(timeOfDayStart, timeOfDayTarget, timeOfDayLerp);
-    uTimeOfDayColor.a *= currentTimeOfDayIntensity;
+    // Final color with alpha
+    float finalAlpha = mix(timeOfDayStartSrgb.a, timeOfDayTargetSrgb.a, timeOfDayLerp);
+    finalAlpha *= currentTimeOfDayIntensity;
 
-    vFragmentColor = uTimeOfDayColor;
+    vFragmentColor = vec4(mixedSrgb, finalAlpha);
 }

--- a/src/syntax/TreeParser.cpp
+++ b/src/syntax/TreeParser.cpp
@@ -271,8 +271,7 @@ void HelpFrame::flush()
 HelpFrame HelpFrame::makeChild()
 {
     flush();
-    HelpFrame child = *this; // copy ctor
-    return child; // c++17 spec says NRVO elides the move constructor here, but g++ 7.4 uses move ctor.
+    return HelpFrame{*this}; // note: copy-ctor
 }
 
 class NODISCARD TreeParser::HelpCommon final

--- a/src/syntax/Value.cpp
+++ b/src/syntax/Value.cpp
@@ -137,6 +137,26 @@ Vector::Base::const_iterator Vector::end() const
     return m_vector->end();
 }
 
+bool Vector::empty() const
+{
+    return m_vector->empty();
+}
+
+size_t Vector::size() const
+{
+    return m_vector->size();
+}
+
+const Value &Vector::at(const size_t pos) const
+{
+    return m_vector->at(pos);
+}
+
+const Value &Vector::operator[](const size_t pos) const
+{
+    return at(pos);
+}
+
 Vector getAnyVectorReversed(const Pair *const matched)
 {
     size_t len = 0;

--- a/src/syntax/Value.h
+++ b/src/syntax/Value.h
@@ -30,7 +30,7 @@ public:
     explicit Vector(Base &&x);
 
 public:
-    Vector();
+    explicit Vector();
     DEFAULT_RULE_OF_5(Vector);
 
 public:
@@ -38,11 +38,11 @@ public:
     NODISCARD Base::const_iterator end() const;
 
 public:
-    NODISCARD bool empty() const { return m_vector->empty(); }
-    NODISCARD size_t size() const { return m_vector->size(); }
+    NODISCARD bool empty() const;
+    NODISCARD size_t size() const;
     // NOTE: at() throws if out of range.
-    const Value &at(size_t pos) const { return m_vector->at(pos); }
-    const Value &operator[](size_t pos) const { return at(pos); }
+    ALLOW_DISCARD const Value &at(size_t pos) const;
+    ALLOW_DISCARD const Value &operator[](size_t pos) const;
 
 public:
     friend std::ostream &operator<<(std::ostream &os, const Vector &v);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,6 +146,8 @@ add_test(NAME TestProxy COMMAND TestProxy)
 # MainWindow
 set(mainwindow_SRCS
     ../src/global/Version.h
+    ../src/mainwindow/AudioVolumeSlider.cpp
+    ../src/mainwindow/AudioVolumeSlider.h
     ../src/mainwindow/UpdateDialog.cpp
     ../src/mainwindow/UpdateDialog.h
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(mm_test STATIC
     ../src/proxy/GmcpMessage.h
 )
 set_target_properties(mm_test PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
     COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -67,7 +67,7 @@ target_link_libraries(TestClock
         coverage_config)
 set_target_properties(
   TestClock PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -92,7 +92,7 @@ target_link_libraries(TestExpandoraCommon
         coverage_config)
 set_target_properties(
   TestExpandoraCommon PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -114,7 +114,7 @@ target_link_libraries(TestParser
         coverage_config)
 set_target_properties(
   TestParser PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -136,7 +136,7 @@ add_dependencies(TestProxy mm_test mm_global)
 target_link_libraries(TestProxy mm_test mm_global Qt6::Test coverage_config)
 set_target_properties(
   TestProxy PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -161,7 +161,7 @@ target_link_libraries(TestMainWindow
         coverage_config)
 set_target_properties(
   TestMainWindow PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -180,7 +180,7 @@ target_link_libraries(TestGlobal
         coverage_config)
 set_target_properties(
   TestGlobal PROPERTIES
-  CXX_STANDARD 17
+  CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
   CXX_EXTENSIONS OFF
   COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -204,7 +204,7 @@ target_link_libraries(TestMap
         coverage_config)
 set_target_properties(
         TestMap PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -226,7 +226,7 @@ add_dependencies(TestAdventure mm_test mm_global)
 target_link_libraries(TestAdventure mm_test mm_global Qt6::Widgets Qt6::Network Qt6::Test coverage_config)
 set_target_properties(
         TestAdventure PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -244,7 +244,7 @@ add_dependencies(TestTimer mm_global)
 target_link_libraries(TestTimer mm_global Qt6::Test coverage_config)
 set_target_properties(
         TestTimer PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -262,7 +262,7 @@ add_dependencies(TestRoomMob mm_global)
 target_link_libraries(TestRoomMob mm_global Qt6::Test Qt6::Gui Qt6::Widgets coverage_config)
 set_target_properties(
         TestRoomMob PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -283,7 +283,7 @@ add_dependencies(TestRoomMobs mm_global)
 target_link_libraries(TestRoomMobs mm_global Qt6::Test Qt6::Gui Qt6::Widgets coverage_config)
 set_target_properties(
         TestRoomMobs PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -305,7 +305,7 @@ add_dependencies(TestRoomManager mm_test mm_global)
 target_link_libraries(TestRoomManager mm_test mm_global Qt6::Test Qt6::Gui Qt6::Widgets coverage_config)
 set_target_properties(
         TestRoomManager PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"
@@ -325,7 +325,7 @@ add_dependencies(TestHotkeyManager mm_test mm_global mm_map)
 target_link_libraries(TestHotkeyManager mm_map mm_test mm_global Qt6::Test Qt6::Network coverage_config)
 set_target_properties(
         TestHotkeyManager PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         COMPILE_FLAGS "${WARNING_FLAGS}"

--- a/tests/TestGlobal.cpp
+++ b/tests/TestGlobal.cpp
@@ -190,17 +190,17 @@ void TestGlobal::flagsTest()
 
 void TestGlobal::hideQDebugTest()
 {
-    static constexpr auto onlyDebug = []() {
+    static constexpr auto onlyDebug = std::invoke([]() constexpr -> mmqt::HideQDebugOptions {
         mmqt::HideQDebugOptions tmp;
         tmp.hideInfo = false;
         return tmp;
-    }();
+    });
 
-    static constexpr auto onlyInfo = []() {
+    static constexpr auto onlyInfo = std::invoke([]() constexpr -> mmqt::HideQDebugOptions {
         mmqt::HideQDebugOptions tmp;
         tmp.hideDebug = false;
         return tmp;
-    }();
+    });
 
     const QString expected = "1{DIW}\n2{DW}\n3{DIW}\n4{IW}\n5{DIW}\n"
                              "---\n"

--- a/tests/TestMainWindow.cpp
+++ b/tests/TestMainWindow.cpp
@@ -3,10 +3,13 @@
 
 #include "TestMainWindow.h"
 
+#include "../src/configuration/configuration.h"
 #include "../src/global/Version.h"
+#include "../src/mainwindow/AudioVolumeSlider.h"
 #include "../src/mainwindow/UpdateDialog.h"
 
 #include <QDebug>
+#include <QScopeGuard>
 #include <QtTest/QtTest>
 
 const char *getMMapperVersion()
@@ -47,6 +50,41 @@ void TestMainWindow::updaterTest()
     CompareVersion newerPatch{"2.9.0"};
     QVERIFY2(newerPatch > current, "Newer major version is greater than older version");
     QVERIFY2((current > newerPatch) == false, "Older version is not newer than newer patch version");
+}
+
+void TestMainWindow::audioToolbarTest()
+{
+    setEnteredMain();
+
+    const int originalMusic = getConfig().audio.getMusicVolume();
+    const int originalSound = getConfig().audio.getSoundVolume();
+
+    // Ensure we restore configuration
+    auto cleanup = qScopeGuard([=]() {
+        setConfig().audio.setMusicVolume(originalMusic);
+        setConfig().audio.setSoundVolume(originalSound);
+    });
+
+    AudioVolumeSlider musicSlider(AudioVolumeSlider::AudioType::Music);
+    AudioVolumeSlider soundSlider(AudioVolumeSlider::AudioType::Sound);
+
+    // Initial value should match current config defaults
+    QCOMPARE(musicSlider.value(), getConfig().audio.getMusicVolume());
+    QCOMPARE(soundSlider.value(), getConfig().audio.getSoundVolume());
+
+    // Update config -> slider updates
+    setConfig().audio.setMusicVolume(75);
+    QCOMPARE(musicSlider.value(), 75);
+
+    setConfig().audio.setSoundVolume(25);
+    QCOMPARE(soundSlider.value(), 25);
+
+    // Update slider -> config updates
+    musicSlider.setValue(90);
+    QCOMPARE(getConfig().audio.getMusicVolume(), 90);
+
+    soundSlider.setValue(10);
+    QCOMPARE(getConfig().audio.getSoundVolume(), 10);
 }
 
 QTEST_MAIN(TestMainWindow)

--- a/tests/TestMainWindow.h
+++ b/tests/TestMainWindow.h
@@ -17,4 +17,5 @@ public:
 private:
 private Q_SLOTS:
     void updaterTest();
+    void audioToolbarTest();
 };


### PR DESCRIPTION
The Group Panel has been overhauled to provide a higher-density, more visual experience:

1.  **Consolidated Stats**: Redundant percentage columns were removed. The percentage is now visualized as a progress bar behind the raw "Current / Max" stat values.
2.  **Character Identity**: A 4px vertical color strip and subtly tinted name text (25% character color / 75% warm white) provide a clear visual anchor for group members without sacrificing contrast.
3.  **Visual Alerts**:
    *   **HP**: Turns red and pulses (100-255 alpha) when below 30%.
    *   **Moves**: Pulses (100-180 alpha) when below 15%.
    *   Animations are globally synchronized to a 1.5s cycle for a cohesive look.
4.  **Data Precision**: Stat values are rendered using the bundled DejaVu Sans Mono font to prevent text "jumping" as numbers change.
5.  **NPC Handling**: NPC stat cells now show the percentage value centered over the bar, maintaining consistency with the new visual style while respecting their simplified data model.
6.  **Performance**: Pulse updates are driven by a dedicated 50ms timer on the viewport, ensuring smooth 20fps animation.
7.  **Maintenance**: Code includes explicit header inclusions (`<algorithm>`, `<cmath>`, `<unordered_set>`) and has been fully formatted using clang-format.

---
*PR created automatically by Jules for task [3484468365583486041](https://jules.google.com/task/3484468365583486041) started by @nschimme*