### PR TITLE
Refactor account management and restore platform-specific storage keys

### DIFF
--- a/src/configuration/PasswordConfig.cpp
+++ b/src/configuration/PasswordConfig.cpp
@@ -3,10 +3,13 @@
 
 #include "PasswordConfig.h"
 
+#include "../global/ConfigConsts-Computed.h"
+#include "../global/ConfigEnums.h"
 #include "../global/macros.h"
 
 #ifndef MMAPPER_NO_QTKEYCHAIN
 static const QLatin1String APP_NAME("org.mume.mmapper");
+static const QLatin1String PASSWORD_KEY("password");
 #endif
 
 PasswordConfig::PasswordConfig(QObject *const parent)
@@ -20,25 +23,35 @@ PasswordConfig::PasswordConfig(QObject *const parent)
     m_writeJob.setAutoDelete(false);
     m_deleteJob.setAutoDelete(false);
 
-    connect(&m_readJob, &QKeychain::ReadPasswordJob::finished, [this]() {
+    auto handleError = [this](const QKeychain::Job &job) {
+        if constexpr (CURRENT_PLATFORM == PlatformEnum::Wasm) {
+            if (job.error() == QKeychain::AccessDeniedByUser) {
+                return true;
+            }
+        }
+        emit sig_error(job.errorString());
+        return false;
+    };
+
+    connect(&m_readJob, &QKeychain::ReadPasswordJob::finished, [this, handleError]() {
         if (m_readJob.error()) {
-            emit sig_error(m_readJob.errorString());
+            handleError(m_readJob);
         } else {
             emit sig_incomingPassword(m_readJob.textData());
         }
     });
 
-    connect(&m_writeJob, &QKeychain::WritePasswordJob::finished, [this]() {
+    connect(&m_writeJob, &QKeychain::WritePasswordJob::finished, [this, handleError]() {
         if (m_writeJob.error()) {
-            emit sig_error(m_writeJob.errorString());
+            handleError(m_writeJob);
         } else {
             emit sig_passwordSaved();
         }
     });
 
-    connect(&m_deleteJob, &QKeychain::DeletePasswordJob::finished, [this]() {
+    connect(&m_deleteJob, &QKeychain::DeletePasswordJob::finished, [this, handleError]() {
         if (m_deleteJob.error()) {
-            emit sig_error(m_deleteJob.errorString());
+            handleError(m_deleteJob);
         } else {
             emit sig_passwordDeleted();
         }
@@ -52,7 +65,11 @@ PasswordConfig::PasswordConfig(QObject *const parent)
 void PasswordConfig::setPassword(const QString &accountName, const QString &password)
 {
 #ifndef MMAPPER_NO_QTKEYCHAIN
-    m_writeJob.setKey(accountName);
+    if constexpr (CURRENT_PLATFORM == PlatformEnum::Wasm) {
+        m_writeJob.setKey(accountName);
+    } else {
+        m_writeJob.setKey(PASSWORD_KEY);
+    }
     m_writeJob.setTextData(password);
     m_writeJob.start();
 #else
@@ -65,7 +82,11 @@ void PasswordConfig::setPassword(const QString &accountName, const QString &pass
 void PasswordConfig::getPassword(const QString &accountName)
 {
 #ifndef MMAPPER_NO_QTKEYCHAIN
-    m_readJob.setKey(accountName);
+    if constexpr (CURRENT_PLATFORM == PlatformEnum::Wasm) {
+        m_readJob.setKey(accountName);
+    } else {
+        m_readJob.setKey(PASSWORD_KEY);
+    }
     m_readJob.start();
 #else
     std::ignore = accountName;
@@ -76,7 +97,11 @@ void PasswordConfig::getPassword(const QString &accountName)
 void PasswordConfig::deletePassword(const QString &accountName)
 {
 #ifndef MMAPPER_NO_QTKEYCHAIN
-    m_deleteJob.setKey(accountName);
+    if constexpr (CURRENT_PLATFORM == PlatformEnum::Wasm) {
+        m_deleteJob.setKey(accountName);
+    } else {
+        m_deleteJob.setKey(PASSWORD_KEY);
+    }
     m_deleteJob.start();
 #else
     std::ignore = accountName;

--- a/src/preferences/ManagePasswordDialog.cpp
+++ b/src/preferences/ManagePasswordDialog.cpp
@@ -3,6 +3,8 @@
 
 #include "ManagePasswordDialog.h"
 
+#include "../global/ConfigConsts-Computed.h"
+#include "../global/ConfigEnums.h"
 #include "ui_ManagePasswordDialog.h"
 
 #include <QLineEdit>
@@ -14,14 +16,22 @@ ManagePasswordDialog::ManagePasswordDialog(QWidget *parent)
 {
     ui->setupUi(this);
 
-    connect(ui->showPassword, &QToolButton::toggled, this, [this](bool checked) {
-        ui->accountPassword->setEchoMode(checked ? QLineEdit::Normal : QLineEdit::Password);
-    });
+    if constexpr (CURRENT_PLATFORM == PlatformEnum::Wasm) {
+        setWindowTitle("Manage Account");
+        ui->label_2->hide();
+        ui->accountPassword->hide();
+        ui->showPassword->hide();
+        ui->deleteButton->hide();
+    } else {
+        connect(ui->showPassword, &QToolButton::toggled, this, [this](bool checked) {
+            ui->accountPassword->setEchoMode(checked ? QLineEdit::Normal : QLineEdit::Password);
+        });
 
-    connect(ui->deleteButton, &QPushButton::clicked, this, [this]() {
-        emit sig_deleteRequested();
-        reject();
-    });
+        connect(ui->deleteButton, &QPushButton::clicked, this, [this]() {
+            emit sig_deleteRequested();
+            reject();
+        });
+    }
 }
 
 ManagePasswordDialog::~ManagePasswordDialog()

--- a/src/preferences/generalpage.cpp
+++ b/src/preferences/generalpage.cpp
@@ -174,12 +174,13 @@ GeneralPage::GeneralPage(QWidget *parent)
         if (checked) {
             const auto &account = getConfig().account;
             if (account.accountName.isEmpty()) {
-                QMessageBox::information(this, "Login", "Please enter your account name first.");
-                ui->autoLogin->setChecked(false);
-                ui->accountName->setFocus();
-                return;
+                slot_setPasswordClicked();
+                if (getConfig().account.accountName.isEmpty()) {
+                    ui->autoLogin->setChecked(false);
+                    return;
+                }
             }
-            if (!account.accountPassword) {
+            if (!account.accountPassword && CURRENT_PLATFORM != PlatformEnum::Wasm) {
                 QMessageBox::StandardButton reply = QMessageBox::question(
                     this,
                     "Login",
@@ -213,10 +214,6 @@ GeneralPage::GeneralPage(QWidget *parent)
         setConfig().account.rememberLogin = ui->autoLogin->isChecked();
     });
 
-    connect(ui->accountName, &QLineEdit::textChanged, this, [this](const QString &account) {
-        setConfig().account.accountName = account;
-    });
-
     connect(&passCfg, &PasswordConfig::sig_error, this, [this](const QString &msg) {
         qWarning() << msg;
         QMessageBox::warning(this, "Password Error", msg);
@@ -239,7 +236,6 @@ GeneralPage::GeneralPage(QWidget *parent)
                 if (!newPassword.isEmpty()) {
                     passCfg.setPassword(newAccountName, newPassword);
                     setConfig().account.accountName = newAccountName;
-                    ui->accountName->setText(newAccountName);
                 }
             }
         }
@@ -339,11 +335,9 @@ void GeneralPage::slot_loadConfig()
 
     if constexpr (NO_QTKEYCHAIN) {
         ui->autoLogin->setEnabled(false);
-        ui->accountName->setEnabled(false);
         ui->setPassword->setEnabled(false);
     } else {
         ui->autoLogin->setChecked(account.rememberLogin);
-        ui->accountName->setText(account.accountName);
     }
 }
 
@@ -425,15 +419,20 @@ void GeneralPage::slot_themeComboBoxChanged(int index)
 
 void GeneralPage::slot_setPasswordClicked()
 {
-    const QString accountName = ui->accountName->text();
-    if (accountName.isEmpty()) {
-        QMessageBox::information(this, "Manage Password", "Please enter your account name first.");
-        ui->accountName->setFocus();
-        return;
-    }
+    const QString accountName = getConfig().account.accountName;
 
     if constexpr (CURRENT_PLATFORM == PlatformEnum::Wasm) {
-        passCfg.setPassword(accountName, "");
+        auto *dlg = new ManagePasswordDialog(this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        dlg->setAccountName(accountName);
+        connect(dlg, &QDialog::accepted, this, [this, dlg]() {
+            const QString newAccountName = dlg->accountName();
+            if (!newAccountName.isEmpty()) {
+                passCfg.setPassword(newAccountName, "");
+                setConfig().account.accountName = newAccountName;
+            }
+        });
+        dlg->show();
     } else {
         if (getConfig().account.accountPassword) {
             ui->setPassword->setProperty("requesting", true);
@@ -452,7 +451,6 @@ void GeneralPage::slot_setPasswordClicked()
                 if (!password.isEmpty()) {
                     passCfg.setPassword(newAccountName, password);
                     setConfig().account.accountName = newAccountName;
-                    ui->accountName->setText(newAccountName);
                     setConfig().account.accountPassword = true;
                 }
             }

--- a/src/preferences/generalpage.ui
+++ b/src/preferences/generalpage.ui
@@ -160,30 +160,13 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_7">
       <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
+       <widget class="QPushButton" name="setPassword">
         <property name="text">
-         <string>Account:</string>
-        </property>
-        <property name="buddy">
-         <cstring>accountName</cstring>
+         <string>Manage Password</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_account">
-        <item>
-         <widget class="QLineEdit" name="accountName"/>
-        </item>
-        <item>
-         <widget class="QPushButton" name="setPassword">
-          <property name="text">
-           <string>Manage Password</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="2">
        <spacer name="horizontalSpacer_account">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -196,7 +179,7 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="0" colspan="3">
+      <item row="0" column="0" colspan="2">
        <widget class="QCheckBox" name="autoLogin">
         <property name="text">
          <string>Remember my login</string>
@@ -496,7 +479,6 @@
   <tabstop>localPort</tabstop>
   <tabstop>charsetComboBox</tabstop>
   <tabstop>autoLogin</tabstop>
-  <tabstop>accountName</tabstop>
   <tabstop>setPassword</tabstop>
   <tabstop>checkForUpdateCheckBox</tabstop>
   <tabstop>autoLoadCheck</tabstop>


### PR DESCRIPTION
This change refactors how account credentials are managed and stored. It removes the redundant account name field from the main preferences and moves it into a platform-aware management dialog. It also restores the original storage key behavior for desktop platforms while maintaining modern account-based keys for Wasm. Finally, it addresses Wasm-specific freezing issues by handling credential prompt cancellations gracefully and avoiding blocking dialog calls.

---
*PR created automatically by Jules for task [1190091658125455007](https://jules.google.com/task/1190091658125455007) started by @nschimme*