### PR TITLE
Rework password UI to be Wasm-compliant and non-blocking

### DIFF
--- a/src/preferences/ManagePasswordDialog.cpp
+++ b/src/preferences/ManagePasswordDialog.cpp
@@ -29,7 +29,8 @@ ManagePasswordDialog::ManagePasswordDialog(QWidget *parent)
 
         connect(ui->deleteButton, &QPushButton::clicked, this, [this]() {
             emit sig_deleteRequested();
-            reject();
+            ui->accountPassword->clear();
+            ui->deleteButton->setEnabled(false);
         });
     }
 }
@@ -52,6 +53,9 @@ QString ManagePasswordDialog::accountName() const
 void ManagePasswordDialog::setPassword(const QString &password)
 {
     ui->accountPassword->setText(password);
+    if constexpr (CURRENT_PLATFORM != PlatformEnum::Wasm) {
+        ui->deleteButton->setEnabled(!password.isEmpty());
+    }
 }
 
 QString ManagePasswordDialog::password() const

--- a/src/preferences/generalpage.cpp
+++ b/src/preferences/generalpage.cpp
@@ -101,15 +101,19 @@ GeneralPage::GeneralPage(QWidget *parent)
     });
 
     connect(ui->configurationResetButton, &QAbstractButton::clicked, this, [this]() {
-        QMessageBox::StandardButton reply
-            = QMessageBox::question(this,
+        auto *box = new QMessageBox(QMessageBox::Question,
                                     "MMapper Factory Reset",
                                     "Are you sure you want to perform a factory reset?",
-                                    QMessageBox::Yes | QMessageBox::No);
-        if (reply == QMessageBox::Yes) {
-            setConfig().reset();
-            emit sig_reloadConfig();
-        }
+                                    QMessageBox::Yes | QMessageBox::No,
+                                    this);
+        box->setAttribute(Qt::WA_DeleteOnClose);
+        connect(box, &QMessageBox::finished, this, [this](int result) {
+            if (result == QMessageBox::Yes) {
+                setConfig().reset();
+                emit sig_reloadConfig();
+            }
+        });
+        box->open();
     });
 
     connect(ui->configurationExportButton, &QAbstractButton::clicked, this, []() {
@@ -170,87 +174,59 @@ GeneralPage::GeneralPage(QWidget *parent)
         QFileDialog::getOpenFileContent(nameFilter, importFile);
     });
 
-    connect(ui->autoLogin, &QCheckBox::clicked, this, [this](bool checked) {
-        if (checked) {
-            const auto &account = getConfig().account;
-            if (account.accountName.isEmpty()) {
-                slot_setPasswordClicked();
-                if (getConfig().account.accountName.isEmpty()) {
-                    ui->autoLogin->setChecked(false);
-                    return;
-                }
-            }
-            if (!account.accountPassword && CURRENT_PLATFORM != PlatformEnum::Wasm) {
-                QMessageBox::StandardButton reply = QMessageBox::question(
-                    this,
-                    "Login",
-                    "No password stored for this account. Would you like to set one now?",
-                    QMessageBox::Yes | QMessageBox::No);
-                if (reply == QMessageBox::Yes) {
-                    slot_setPasswordClicked();
-                    // Re-check if it was actually set
-                    if (!getConfig().account.accountPassword) {
-                        ui->autoLogin->setChecked(false);
-                    }
-                } else {
-                    ui->autoLogin->setChecked(false);
-                    return;
-                }
-            }
-        } else {
-            if constexpr (CURRENT_PLATFORM != PlatformEnum::Wasm) {
-                if (getConfig().account.accountPassword) {
-                    QMessageBox::StandardButton reply = QMessageBox::question(
-                        this,
-                        "Login",
-                        "Would you like to also delete the stored password for this account?",
-                        QMessageBox::Yes | QMessageBox::No);
-                    if (reply == QMessageBox::Yes) {
-                        passCfg.deletePassword(getConfig().account.accountName);
-                    }
-                }
-            }
-        }
+    connect(ui->autoLogin, &QCheckBox::clicked, this, [this](bool /*checked*/) {
         setConfig().account.rememberLogin = ui->autoLogin->isChecked();
     });
 
     connect(&passCfg, &PasswordConfig::sig_error, this, [this](const QString &msg) {
         qWarning() << msg;
-        QMessageBox::warning(this, "Password Error", msg);
+        auto *box = new QMessageBox(QMessageBox::Warning, "Password Error", msg, QMessageBox::Ok, this);
+        box->setAttribute(Qt::WA_DeleteOnClose);
+        box->open();
     });
 
     connect(&passCfg, &PasswordConfig::sig_incomingPassword, this, [this](const QString &password) {
         if (ui->setPassword->property("requesting").toBool()) {
             ui->setPassword->setProperty("requesting", false);
             const QString accountName = getConfig().account.accountName;
-            ManagePasswordDialog dlg(this);
-            dlg.setAccountName(accountName);
-            dlg.setPassword(password);
-            connect(&dlg, &ManagePasswordDialog::sig_deleteRequested, this, [this, accountName]() {
+            auto *dlg = new ManagePasswordDialog(this);
+            dlg->setAttribute(Qt::WA_DeleteOnClose);
+            dlg->setAccountName(accountName);
+            dlg->setPassword(password);
+            connect(dlg, &ManagePasswordDialog::sig_deleteRequested, this, [this, accountName]() {
                 passCfg.deletePassword(accountName);
             });
 
-            if (dlg.exec() == QDialog::Accepted) {
-                const QString newAccountName = dlg.accountName();
-                const QString newPassword = dlg.password();
+            connect(dlg, &QDialog::accepted, this, [this, dlg]() {
+                const QString newAccountName = dlg->accountName();
+                const QString newPassword = dlg->password();
                 if (!newPassword.isEmpty()) {
                     passCfg.setPassword(newAccountName, newPassword);
                     setConfig().account.accountName = newAccountName;
                 }
-            }
+            });
+            dlg->open();
         }
     });
 
     connect(&passCfg, &PasswordConfig::sig_passwordSaved, this, [this]() {
         setConfig().account.accountPassword = true;
+        updateAutoLoginEnabled();
     });
 
     connect(&passCfg, &PasswordConfig::sig_passwordDeleted, this, [this]() {
-        setConfig().account.accountPassword = false;
-        QMessageBox::information(this, "Password", "Stored password deleted successfully.");
+        auto &account = setConfig().account;
+        account.accountPassword = false;
+        account.rememberLogin = false;
+        ui->autoLogin->setChecked(false);
+        updateAutoLoginEnabled();
     });
 
     connect(ui->setPassword, &QPushButton::clicked, this, &GeneralPage::slot_setPasswordClicked);
+
+    connect(ui->remoteName, &QLineEdit::textChanged, this, [this]() {
+        updateAutoLoginEnabled();
+    });
 
     connect(ui->resourceLineEdit, &QLineEdit::textChanged, this, [](const QString &text) {
         setConfig().canvas.resourcesDirectory = text;
@@ -338,6 +314,7 @@ void GeneralPage::slot_loadConfig()
         ui->setPassword->setEnabled(false);
     } else {
         ui->autoLogin->setChecked(account.rememberLogin);
+        updateAutoLoginEnabled();
     }
 }
 
@@ -417,6 +394,20 @@ void GeneralPage::slot_themeComboBoxChanged(int index)
     setConfig().general.setTheme(static_cast<ThemeEnum>(index));
 }
 
+void GeneralPage::updateAutoLoginEnabled()
+{
+    if constexpr (NO_QTKEYCHAIN) {
+        ui->autoLogin->setEnabled(false);
+        return;
+    }
+
+    const auto &account = getConfig().account;
+    const bool hasAccountName = !account.accountName.isEmpty();
+    const bool hasPassword = account.accountPassword;
+
+    ui->autoLogin->setEnabled(hasAccountName && hasPassword);
+}
+
 void GeneralPage::slot_setPasswordClicked()
 {
     const QString accountName = getConfig().account.accountName;
@@ -432,28 +423,28 @@ void GeneralPage::slot_setPasswordClicked()
                 setConfig().account.accountName = newAccountName;
             }
         });
-        dlg->show();
+        dlg->open();
     } else {
         if (getConfig().account.accountPassword) {
             ui->setPassword->setProperty("requesting", true);
             passCfg.getPassword(accountName);
         } else {
-            ManagePasswordDialog dlg(this);
-            dlg.setAccountName(accountName);
-            connect(&dlg, &ManagePasswordDialog::sig_deleteRequested, this, [this, accountName]() {
+            auto *dlg = new ManagePasswordDialog(this);
+            dlg->setAttribute(Qt::WA_DeleteOnClose);
+            dlg->setAccountName(accountName);
+            connect(dlg, &ManagePasswordDialog::sig_deleteRequested, this, [this, accountName]() {
                 passCfg.deletePassword(accountName);
-                setConfig().account.accountPassword = false;
             });
 
-            if (dlg.exec() == QDialog::Accepted) {
-                const QString newAccountName = dlg.accountName();
-                const QString password = dlg.password();
+            connect(dlg, &QDialog::accepted, this, [this, dlg]() {
+                const QString newAccountName = dlg->accountName();
+                const QString password = dlg->password();
                 if (!password.isEmpty()) {
                     passCfg.setPassword(newAccountName, password);
                     setConfig().account.accountName = newAccountName;
-                    setConfig().account.accountPassword = true;
                 }
-            }
+            });
+            dlg->open();
         }
     }
 }

--- a/src/preferences/generalpage.cpp
+++ b/src/preferences/generalpage.cpp
@@ -180,7 +180,11 @@ GeneralPage::GeneralPage(QWidget *parent)
 
     connect(&passCfg, &PasswordConfig::sig_error, this, [this](const QString &msg) {
         qWarning() << msg;
-        auto *box = new QMessageBox(QMessageBox::Warning, "Password Error", msg, QMessageBox::Ok, this);
+        auto *box = new QMessageBox(QMessageBox::Warning,
+                                    "Password Error",
+                                    msg,
+                                    QMessageBox::Ok,
+                                    this);
         box->setAttribute(Qt::WA_DeleteOnClose);
         box->open();
     });
@@ -224,9 +228,7 @@ GeneralPage::GeneralPage(QWidget *parent)
 
     connect(ui->setPassword, &QPushButton::clicked, this, &GeneralPage::slot_setPasswordClicked);
 
-    connect(ui->remoteName, &QLineEdit::textChanged, this, [this]() {
-        updateAutoLoginEnabled();
-    });
+    connect(ui->remoteName, &QLineEdit::textChanged, this, [this]() { updateAutoLoginEnabled(); });
 
     connect(ui->resourceLineEdit, &QLineEdit::textChanged, this, [](const QString &text) {
         setConfig().canvas.resourcesDirectory = text;

--- a/src/preferences/generalpage.cpp
+++ b/src/preferences/generalpage.cpp
@@ -216,6 +216,23 @@ GeneralPage::GeneralPage(QWidget *parent)
     connect(&passCfg, &PasswordConfig::sig_passwordSaved, this, [this]() {
         setConfig().account.accountPassword = true;
         updateAutoLoginEnabled();
+
+        if (!ui->autoLogin->isChecked()) {
+            auto *box = new QMessageBox(QMessageBox::Question,
+                                        "Login",
+                                        "A password was saved. Would you like to also enable "
+                                        "automatic login for this account?",
+                                        QMessageBox::Yes | QMessageBox::No,
+                                        this);
+            box->setAttribute(Qt::WA_DeleteOnClose);
+            connect(box, &QMessageBox::finished, this, [this](int result) {
+                if (result == QMessageBox::Yes) {
+                    ui->autoLogin->setChecked(true);
+                    setConfig().account.rememberLogin = true;
+                }
+            });
+            box->open();
+        }
     });
 
     connect(&passCfg, &PasswordConfig::sig_passwordDeleted, this, [this]() {

--- a/src/preferences/generalpage.h
+++ b/src/preferences/generalpage.h
@@ -50,4 +50,7 @@ public slots:
     void slot_displayXPStatusStateChanged(int);
     void slot_themeComboBoxChanged(int);
     void slot_setPasswordClicked();
+
+private:
+    void updateAutoLoginEnabled();
 };

--- a/src/preferences/generalpage.ui
+++ b/src/preferences/generalpage.ui
@@ -162,7 +162,7 @@
       <item row="1" column="0">
        <widget class="QPushButton" name="setPassword">
         <property name="text">
-         <string>Manage Password</string>
+         <string>Manage Account</string>
         </property>
        </widget>
       </item>
@@ -182,7 +182,7 @@
       <item row="0" column="0" colspan="2">
        <widget class="QCheckBox" name="autoLogin">
         <property name="text">
-         <string>Remember my login</string>
+         <string>Automatic login</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This change reworks the password-related UI elements in MMapper to ensure they are Wasm-compliant by removing all blocking `.exec()` calls. Key changes include:
- `GeneralPage`: Reworked Factory Reset and Password Error message boxes to use non-blocking `open()`.
- Credential Management: `ManagePasswordDialog` is now opened asynchronously.
- Auto-Login Logic: The "Remember my login" checkbox is now reactive, enabling only when credentials are valid and present in the configuration.
- UX Improvements: Deleting a password now provides immediate visual feedback in the dialog without blocking popups.

---
*PR created automatically by Jules for task [1606406370523669539](https://jules.google.com/task/1606406370523669539) started by @nschimme*