### PR TITLE
Fix ConfigDialog search focus and add empty state message

### DIFF
--- a/src/preferences/audiopage.ui
+++ b/src/preferences/audiopage.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>AudioPage</class>
  <widget class="QWidget" name="AudioPage">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>300</height>
-   </rect>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="outputGroupBox">
@@ -19,13 +11,26 @@
      <layout class="QGridLayout" name="gridLayoutOutput">
       <item row="0" column="0">
        <widget class="QLabel" name="outputDeviceLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Device:</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="outputDeviceComboBox"/>
+       <widget class="QComboBox" name="outputDeviceComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -38,6 +43,12 @@
      <layout class="QGridLayout" name="gridLayoutMusic">
       <item row="1" column="0">
        <widget class="QLabel" name="musicVolumeLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Volume:</string>
         </property>
@@ -45,8 +56,26 @@
       </item>
       <item row="1" column="1">
        <widget class="AudioVolumeSlider" name="musicVolumeSlider">
-        <property name="audioType">
-         <enum>AudioVolumeSlider::AudioType::Music</enum>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="mouseTracking">
+         <bool>true</bool>
+        </property>
+        <property name="tracking">
+         <bool>false</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TickPosition::TicksBelow</enum>
+        </property>
+        <property name="tickInterval">
+         <number>10</number>
         </property>
        </widget>
       </item>
@@ -61,6 +90,12 @@
      <layout class="QGridLayout" name="gridLayoutSounds">
       <item row="1" column="0">
        <widget class="QLabel" name="soundsVolumeLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Volume:</string>
         </property>
@@ -68,8 +103,26 @@
       </item>
       <item row="1" column="1">
        <widget class="AudioVolumeSlider" name="soundsVolumeSlider">
-        <property name="audioType">
-         <enum>AudioVolumeSlider::AudioType::Sound</enum>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="mouseTracking">
+         <bool>true</bool>
+        </property>
+        <property name="tracking">
+         <bool>false</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TickPosition::TicksBelow</enum>
+        </property>
+        <property name="tickInterval">
+         <number>10</number>
         </property>
        </widget>
       </item>
@@ -79,7 +132,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/preferences/autologpage.ui
+++ b/src/preferences/autologpage.ui
@@ -196,7 +196,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -292,7 +292,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>

--- a/src/preferences/autologpage.ui
+++ b/src/preferences/autologpage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>326</width>
-    <height>384</height>
+    <width>345</width>
+    <height>404</height>
    </rect>
   </property>
   <layout class="QVBoxLayout">
@@ -36,10 +36,10 @@
       <item row="6" column="0" colspan="6">
        <widget class="QFrame" name="autoLogFrame">
         <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
+         <enum>QFrame::Shape::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
+         <enum>QFrame::Shadow::Plain</enum>
         </property>
         <property name="lineWidth">
          <number>0</number>
@@ -129,6 +129,9 @@
       </item>
       <item row="2" column="1">
        <widget class="QSpinBox" name="spinBoxDays">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="maximum">
          <number>9999999</number>
         </property>
@@ -150,6 +153,9 @@
           <width>0</width>
           <height>0</height>
          </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -192,7 +198,7 @@
       <item row="3" column="3">
        <spacer name="advancedSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -268,6 +274,9 @@
           <height>0</height>
          </size>
         </property>
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="toolTip">
          <string>Rotate logs to keep files small for editors</string>
         </property>
@@ -288,7 +297,7 @@
       <item row="0" column="3">
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -304,7 +313,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/preferences/clientpage.ui
+++ b/src/preferences/clientpage.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>ClientPage</class>
  <widget class="QWidget" name="ClientPage">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>331</width>
-    <height>687</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
@@ -77,7 +69,7 @@
       <item row="2" column="3">
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -90,10 +82,10 @@
       <item row="0" column="0" colspan="4">
        <widget class="QLabel" name="exampleLabel">
         <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
+         <enum>QFrame::Shape::StyledPanel</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
         <property name="text">
          <string>Arglebargle, glop-glyf!?!</string>
@@ -117,6 +109,9 @@
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="4" column="1">
        <widget class="QSpinBox" name="scrollbackSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="showGroupSeparator" stdset="0">
          <bool>true</bool>
         </property>
@@ -130,6 +125,9 @@
       </item>
       <item row="0" column="1">
        <widget class="QSpinBox" name="columnsSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="showGroupSeparator" stdset="0">
          <bool>true</bool>
         </property>
@@ -170,6 +168,9 @@
       </item>
       <item row="1" column="1">
        <widget class="QSpinBox" name="rowsSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="showGroupSeparator" stdset="0">
          <bool>true</bool>
         </property>
@@ -205,7 +206,11 @@
        </widget>
       </item>
       <item row="5" column="1">
-       <widget class="QSpinBox" name="previewSpinBox"/>
+       <widget class="QSpinBox" name="previewSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+       </widget>
       </item>
       <item row="7" column="0" colspan="2">
        <widget class="QCheckBox" name="audibleBellCheckBox">
@@ -238,6 +243,9 @@
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="2" column="1">
        <widget class="QSpinBox" name="tabDictionarySpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="showGroupSeparator" stdset="0">
          <bool>true</bool>
         </property>
@@ -254,6 +262,9 @@
       </item>
       <item row="1" column="1">
        <widget class="QSpinBox" name="inputHistorySpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="showGroupSeparator" stdset="0">
          <bool>true</bool>
         </property>
@@ -291,7 +302,7 @@
       <item row="4" column="1">
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -344,7 +355,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/preferences/clientpage.ui
+++ b/src/preferences/clientpage.ui
@@ -81,7 +81,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -295,7 +295,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -38,14 +38,6 @@ bool matches(const QWidget *widget, const QString &text)
     return false;
 }
 
-void showWithBuddy(QWidget *widget)
-{
-    widget->show();
-    if (auto *lbl = qobject_cast<QLabel *>(widget)) {
-        if (lbl->buddy())
-            lbl->buddy()->show();
-    }
-}
 } // namespace
 
 ConfigDialog::ConfigDialog(QWidget *const parent)
@@ -130,6 +122,14 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ConfigDialog::slot_ok);
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ConfigDialog::slot_cancel);
     connect(ui->searchBar, &QLineEdit::textChanged, this, &ConfigDialog::slot_search);
+    connect(ui->searchResultsList,
+            &QListWidget::itemActivated,
+            this,
+            &ConfigDialog::slot_onResultSelected);
+    connect(ui->searchResultsList,
+            &QListWidget::itemClicked,
+            this,
+            &ConfigDialog::slot_onResultSelected);
 
     connect(generalPage, &GeneralPage::sig_reloadConfig, this, [this]() { emit sig_loadConfig(); });
 
@@ -204,10 +204,8 @@ void ConfigDialog::slot_onScroll(int value)
 
     QListWidgetItem *activeItem = nullptr;
     for (const auto &page : m_pages) {
-        if (!page.item->isHidden() && page.container->isVisible()) {
-            if (page.container->y() <= value + 8) {
-                activeItem = page.item;
-            }
+        if (page.container->y() <= value + 8) {
+            activeItem = page.item;
         }
     }
 
@@ -232,122 +230,77 @@ void ConfigDialog::slot_cancel()
 
 void ConfigDialog::slot_search(const QString &text)
 {
-    const QSignalBlocker blocker{ui->contentsWidget};
-
-    bool anyResult = false;
+    ui->searchResultsList->clear();
 
     if (text.isEmpty()) {
-        for (auto &page : m_pages) {
-            if (page.container->isHidden()) {
-                page.container->show();
-            }
-            if (page.item->isHidden()) {
-                page.item->setHidden(false);
-            }
+        ui->rightStack->setCurrentIndex(0);
+        ui->contentsWidget->setEnabled(true);
+        ui->searchBar->setFocus();
+        return;
+    }
 
-            const auto children = page.widget->findChildren<QWidget *>();
-            for (auto *child : children) {
-                if (child->isHidden()) {
-                    child->show();
+    ui->contentsWidget->setEnabled(false);
+
+    for (const auto &page : m_pages) {
+        const auto children = page.widget->findChildren<QWidget *>();
+        for (auto *child : children) {
+            if (matches(child, text)) {
+                QString matchText;
+                if (auto *cb = qobject_cast<QCheckBox *>(child)) {
+                    matchText = cb->text();
+                } else if (auto *rb = qobject_cast<QRadioButton *>(child)) {
+                    matchText = rb->text();
+                } else if (auto *lbl = qobject_cast<QLabel *>(child)) {
+                    matchText = lbl->text();
+                } else if (auto *pb = qobject_cast<QPushButton *>(child)) {
+                    matchText = pb->text();
+                } else if (auto *gb = qobject_cast<QGroupBox *>(child)) {
+                    matchText = gb->title();
                 }
-            }
-        }
-        anyResult = true;
-    } else {
-        for (auto &page : m_pages) {
-            bool pageMatches = page.name.contains(text, Qt::CaseInsensitive);
-            bool anyChildMatches = false;
 
-            const auto groupBoxes = page.widget->findChildren<QGroupBox *>();
-            for (auto *gb : groupBoxes) {
-                if (matches(gb, text)) {
-                    if (gb->isHidden()) {
-                        gb->show();
-                    }
-                    const auto children = gb->findChildren<QWidget *>();
-                    for (auto *child : children) {
-                        if (child->isHidden()) {
-                            child->show();
-                        }
-                    }
-                    anyChildMatches = true;
-                } else {
-                    bool anyGbChildMatches = false;
-                    const auto children = gb->findChildren<QWidget *>();
-                    for (auto *child : children) {
-                        if (matches(child, text)) {
-                            showWithBuddy(child);
-                            anyGbChildMatches = true;
-                        } else if (qobject_cast<QLabel *>(child) || qobject_cast<QCheckBox *>(child)
-                                   || qobject_cast<QRadioButton *>(child)
-                                   || qobject_cast<QPushButton *>(child)) {
-                            if (!child->isHidden()) {
-                                child->hide();
-                            }
-                        }
-                    }
-
-                    if (anyGbChildMatches) {
-                        if (gb->isHidden()) {
-                            gb->show();
-                        }
-                        anyChildMatches = true;
-                    } else {
-                        if (!gb->isHidden()) {
-                            gb->hide();
-                        }
-                    }
-                }
-            }
-
-            const auto directChildren
-                = page.widget->findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly);
-            for (auto *child : directChildren) {
-                if (qobject_cast<QGroupBox *>(child))
+                if (matchText.isEmpty()) {
                     continue;
+                }
 
-                if (matches(child, text)) {
-                    showWithBuddy(child);
-                    anyChildMatches = true;
-                } else if (qobject_cast<QLabel *>(child) || qobject_cast<QCheckBox *>(child)
-                           || qobject_cast<QRadioButton *>(child)
-                           || qobject_cast<QPushButton *>(child)) {
-                    if (!child->isHidden()) {
-                        child->hide();
-                    }
-                }
-            }
-
-            if (pageMatches || anyChildMatches) {
-                if (page.container->isHidden()) {
-                    page.container->show();
-                }
-                if (page.item->isHidden()) {
-                    page.item->setHidden(false);
-                }
-                anyResult = true;
-                if (pageMatches && !anyChildMatches) {
-                    const auto children = page.widget->findChildren<QWidget *>();
-                    for (auto *child : children) {
-                        if (child->isHidden()) {
-                            child->show();
-                        }
-                    }
-                }
-            } else {
-                if (!page.container->isHidden()) {
-                    page.container->hide();
-                }
-                if (!page.item->isHidden()) {
-                    page.item->setHidden(true);
-                }
+                matchText.remove('&');
+                auto *item = new QListWidgetItem(QString("%1 > %2").arg(page.name, matchText),
+                                                 ui->searchResultsList);
+                item->setData(Qt::UserRole, QVariant::fromValue(child));
             }
         }
     }
 
-    if (ui->noResultsContainer->isVisible() != !anyResult) {
-        ui->noResultsContainer->setVisible(!anyResult);
+    if (ui->searchResultsList->count() > 0) {
+        ui->rightStack->setCurrentIndex(1);
+    } else {
+        ui->rightStack->setCurrentIndex(2);
     }
 
     ui->searchBar->setFocus();
+}
+
+void ConfigDialog::slot_onResultSelected(QListWidgetItem *item)
+{
+    if (item == nullptr) {
+        return;
+    }
+
+    auto *widget = item->data(Qt::UserRole).value<QWidget *>();
+    if (widget == nullptr) {
+        return;
+    }
+
+    ui->searchBar->clear();
+    ui->rightStack->setCurrentIndex(0);
+
+    // Find which page this widget belongs to
+    for (const auto &page : m_pages) {
+        if (page.widget->isAncestorOf(widget)) {
+            ui->contentsWidget->setCurrentItem(page.item);
+            break;
+        }
+    }
+
+    ui->pagesScrollArea->ensureWidgetVisible(widget);
+    widget->setFocus();
 }

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -117,7 +117,15 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     ui->noResultsLabel->setText(tr("No matches found!\nMaybe try searching for something else? ")
                                 + QString::fromUcs4(&magnifyingGlassEmoji, 1));
 
-    ui->scrollLayout->addStretch();
+    m_topStretch = new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
+    m_bottomStretch = new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
+    ui->scrollLayout->insertItem(0, m_topStretch);
+    ui->scrollLayout->addSpacerItem(m_bottomStretch);
+
+    ui->contentsWidget->setFocusPolicy(Qt::NoFocus);
+    ui->pagesScrollArea->setFocusPolicy(Qt::NoFocus);
+    ui->pagesScrollArea->verticalScrollBar()->setFocusPolicy(Qt::NoFocus);
+    ui->scrollAreaWidgetContents->setFocusPolicy(Qt::NoFocus);
 
     connect(ui->contentsWidget,
             &QListWidget::currentItemChanged,
@@ -212,13 +220,8 @@ void ConfigDialog::slot_onScroll(int value)
     }
 
     if (activeItem && ui->contentsWidget->currentItem() != activeItem) {
-        m_suppressScrollSync = true;
-        auto *const focusedWidget = focusWidget();
+        const QSignalBlocker blocker{ui->contentsWidget};
         ui->contentsWidget->setCurrentItem(activeItem);
-        if (focusedWidget != nullptr) {
-            focusedWidget->setFocus();
-        }
-        m_suppressScrollSync = false;
     }
 }
 
@@ -238,8 +241,9 @@ void ConfigDialog::slot_cancel()
 void ConfigDialog::slot_search(const QString &text)
 {
     m_suppressScrollSync = true;
-    ui->pagesScrollArea->setUpdatesEnabled(false);
-    const QSignalBlocker blocker{ui->contentsWidget};
+    setUpdatesEnabled(false);
+    const QSignalBlocker contentBlocker{ui->contentsWidget};
+    const QSignalBlocker scrollBlocker{ui->pagesScrollArea->verticalScrollBar()};
 
     bool anyResult = false;
 
@@ -354,12 +358,25 @@ void ConfigDialog::slot_search(const QString &text)
 
     if (ui->noResultsLabel->isVisible() != !anyResult) {
         ui->noResultsLabel->setVisible(!anyResult);
+        if (anyResult) {
+            m_topStretch->changeSize(0, 0, QSizePolicy::Fixed, QSizePolicy::Fixed);
+            m_bottomStretch->changeSize(0, 0, QSizePolicy::Fixed, QSizePolicy::Fixed);
+        } else {
+            m_topStretch->changeSize(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
+            m_bottomStretch->changeSize(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
+        }
+        ui->scrollLayout->invalidate();
     }
 
-    ui->pagesScrollArea->setUpdatesEnabled(true);
+    setUpdatesEnabled(true);
 
     // Keep scroll synchronization suppressed until layout updates are finished.
-    // Explicitly restore focus to the search bar.
+    // Explicitly restore focus to the search bar via multiple deferred calls to
+    // ensure it's the last focus-related action across all event loop cycles.
     ui->searchBar->setFocus();
-    QTimer::singleShot(0, this, [this]() { m_suppressScrollSync = false; });
+    QTimer::singleShot(0, ui->searchBar, qOverload<>(&QWidget::setFocus));
+    QTimer::singleShot(50, this, [this]() {
+        ui->searchBar->setFocus();
+        m_suppressScrollSync = false;
+    });
 }

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -113,6 +113,14 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     addPage(mumeProtocolPage, tr("Mume Protocol"), ":/icons/mumeprotocolcfg.png");
     addPage(pathmachinePage, tr("Path Machine"), ":/icons/pathmachinecfg.png");
 
+    m_noResultsLabel = new QLabel(tr("<b>No matches found!</b><br>Maybe try searching for something else? \xF0\x9F\x94\x8D"), this);
+    m_noResultsLabel->setAlignment(Qt::AlignCenter);
+    m_noResultsLabel->setWordWrap(true);
+    m_noResultsLabel->setMargin(20);
+    m_noResultsLabel->setStyleSheet("font-size: 14pt; color: gray;");
+    m_noResultsLabel->hide();
+    ui->scrollLayout->addWidget(m_noResultsLabel);
+
     ui->scrollLayout->addStretch();
 
     connect(ui->contentsWidget,
@@ -231,6 +239,11 @@ void ConfigDialog::slot_cancel()
 
 void ConfigDialog::slot_search(const QString &text)
 {
+    m_suppressScrollSync = true;
+    setUpdatesEnabled(false);
+
+    bool anyResult = false;
+
     if (text.isEmpty()) {
         for (auto &page : m_pages) {
             page.container->show();
@@ -241,71 +254,80 @@ void ConfigDialog::slot_search(const QString &text)
                 child->show();
             }
         }
-        return;
-    }
+        anyResult = true;
+    } else {
+        for (auto &page : m_pages) {
+            bool pageMatches = page.name.contains(text, Qt::CaseInsensitive);
+            bool anyChildMatches = false;
 
-    for (auto &page : m_pages) {
-        bool pageMatches = page.name.contains(text, Qt::CaseInsensitive);
-        bool anyChildMatches = false;
-
-        const auto groupBoxes = page.widget->findChildren<QGroupBox *>();
-        for (auto *gb : groupBoxes) {
-            if (matches(gb, text)) {
-                gb->show();
-                const auto children = gb->findChildren<QWidget *>();
-                for (auto *child : children)
-                    child->show();
-                anyChildMatches = true;
-            } else {
-                bool anyGbChildMatches = false;
-                const auto children = gb->findChildren<QWidget *>();
-                for (auto *child : children) {
-                    if (matches(child, text)) {
-                        showWithBuddy(child);
-                        anyGbChildMatches = true;
-                    } else if (qobject_cast<QLabel *>(child) || qobject_cast<QCheckBox *>(child)
-                               || qobject_cast<QRadioButton *>(child)
-                               || qobject_cast<QPushButton *>(child)) {
-                        child->hide();
-                    }
-                }
-
-                if (anyGbChildMatches) {
+            const auto groupBoxes = page.widget->findChildren<QGroupBox *>();
+            for (auto *gb : groupBoxes) {
+                if (matches(gb, text)) {
                     gb->show();
+                    const auto children = gb->findChildren<QWidget *>();
+                    for (auto *child : children)
+                        child->show();
                     anyChildMatches = true;
                 } else {
-                    gb->hide();
+                    bool anyGbChildMatches = false;
+                    const auto children = gb->findChildren<QWidget *>();
+                    for (auto *child : children) {
+                        if (matches(child, text)) {
+                            showWithBuddy(child);
+                            anyGbChildMatches = true;
+                        } else if (qobject_cast<QLabel *>(child) || qobject_cast<QCheckBox *>(child)
+                                   || qobject_cast<QRadioButton *>(child)
+                                   || qobject_cast<QPushButton *>(child)) {
+                            child->hide();
+                        }
+                    }
+
+                    if (anyGbChildMatches) {
+                        gb->show();
+                        anyChildMatches = true;
+                    } else {
+                        gb->hide();
+                    }
                 }
             }
-        }
 
-        const auto directChildren = page.widget->findChildren<QWidget *>(QString(),
-                                                                         Qt::FindDirectChildrenOnly);
-        for (auto *child : directChildren) {
-            if (qobject_cast<QGroupBox *>(child))
-                continue;
+            const auto directChildren = page.widget->findChildren<QWidget *>(
+                QString(), Qt::FindDirectChildrenOnly);
+            for (auto *child : directChildren) {
+                if (qobject_cast<QGroupBox *>(child))
+                    continue;
 
-            if (matches(child, text)) {
-                showWithBuddy(child);
-                anyChildMatches = true;
-            } else if (qobject_cast<QLabel *>(child) || qobject_cast<QCheckBox *>(child)
-                       || qobject_cast<QRadioButton *>(child)
-                       || qobject_cast<QPushButton *>(child)) {
-                child->hide();
+                if (matches(child, text)) {
+                    showWithBuddy(child);
+                    anyChildMatches = true;
+                } else if (qobject_cast<QLabel *>(child) || qobject_cast<QCheckBox *>(child)
+                           || qobject_cast<QRadioButton *>(child)
+                           || qobject_cast<QPushButton *>(child)) {
+                    child->hide();
+                }
             }
-        }
 
-        if (pageMatches || anyChildMatches) {
-            page.container->show();
-            page.item->setHidden(false);
-            if (pageMatches && !anyChildMatches) {
-                const auto children = page.widget->findChildren<QWidget *>();
-                for (auto *child : children)
-                    child->show();
+            if (pageMatches || anyChildMatches) {
+                page.container->show();
+                page.item->setHidden(false);
+                anyResult = true;
+                if (pageMatches && !anyChildMatches) {
+                    const auto children = page.widget->findChildren<QWidget *>();
+                    for (auto *child : children)
+                        child->show();
+                }
+            } else {
+                page.container->hide();
+                page.item->setHidden(true);
             }
-        } else {
-            page.container->hide();
-            page.item->setHidden(true);
         }
     }
+
+    m_noResultsLabel->setVisible(!anyResult);
+
+    setUpdatesEnabled(true);
+    m_suppressScrollSync = false;
+
+    // Ensure search bar keeps focus after layout changes
+    ui->searchBar->setFocus();
 }

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -213,7 +213,11 @@ void ConfigDialog::slot_onScroll(int value)
 
     if (activeItem && ui->contentsWidget->currentItem() != activeItem) {
         m_suppressScrollSync = true;
+        auto *const focusedWidget = focusWidget();
         ui->contentsWidget->setCurrentItem(activeItem);
+        if (focusedWidget != nullptr) {
+            focusedWidget->setFocus();
+        }
         m_suppressScrollSync = false;
     }
 }
@@ -235,17 +239,24 @@ void ConfigDialog::slot_search(const QString &text)
 {
     m_suppressScrollSync = true;
     ui->pagesScrollArea->setUpdatesEnabled(false);
+    const QSignalBlocker blocker{ui->contentsWidget};
 
     bool anyResult = false;
 
     if (text.isEmpty()) {
         for (auto &page : m_pages) {
-            page.container->show();
-            page.item->setHidden(false);
+            if (page.container->isHidden()) {
+                page.container->show();
+            }
+            if (page.item->isHidden()) {
+                page.item->setHidden(false);
+            }
 
             const auto children = page.widget->findChildren<QWidget *>();
             for (auto *child : children) {
-                child->show();
+                if (child->isHidden()) {
+                    child->show();
+                }
             }
         }
         anyResult = true;
@@ -257,10 +268,15 @@ void ConfigDialog::slot_search(const QString &text)
             const auto groupBoxes = page.widget->findChildren<QGroupBox *>();
             for (auto *gb : groupBoxes) {
                 if (matches(gb, text)) {
-                    gb->show();
+                    if (gb->isHidden()) {
+                        gb->show();
+                    }
                     const auto children = gb->findChildren<QWidget *>();
-                    for (auto *child : children)
-                        child->show();
+                    for (auto *child : children) {
+                        if (child->isHidden()) {
+                            child->show();
+                        }
+                    }
                     anyChildMatches = true;
                 } else {
                     bool anyGbChildMatches = false;
@@ -272,15 +288,21 @@ void ConfigDialog::slot_search(const QString &text)
                         } else if (qobject_cast<QLabel *>(child) || qobject_cast<QCheckBox *>(child)
                                    || qobject_cast<QRadioButton *>(child)
                                    || qobject_cast<QPushButton *>(child)) {
-                            child->hide();
+                            if (!child->isHidden()) {
+                                child->hide();
+                            }
                         }
                     }
 
                     if (anyGbChildMatches) {
-                        gb->show();
+                        if (gb->isHidden()) {
+                            gb->show();
+                        }
                         anyChildMatches = true;
                     } else {
-                        gb->hide();
+                        if (!gb->isHidden()) {
+                            gb->hide();
+                        }
                     }
                 }
             }
@@ -297,34 +319,47 @@ void ConfigDialog::slot_search(const QString &text)
                 } else if (qobject_cast<QLabel *>(child) || qobject_cast<QCheckBox *>(child)
                            || qobject_cast<QRadioButton *>(child)
                            || qobject_cast<QPushButton *>(child)) {
-                    child->hide();
+                    if (!child->isHidden()) {
+                        child->hide();
+                    }
                 }
             }
 
             if (pageMatches || anyChildMatches) {
-                page.container->show();
-                page.item->setHidden(false);
+                if (page.container->isHidden()) {
+                    page.container->show();
+                }
+                if (page.item->isHidden()) {
+                    page.item->setHidden(false);
+                }
                 anyResult = true;
                 if (pageMatches && !anyChildMatches) {
                     const auto children = page.widget->findChildren<QWidget *>();
-                    for (auto *child : children)
-                        child->show();
+                    for (auto *child : children) {
+                        if (child->isHidden()) {
+                            child->show();
+                        }
+                    }
                 }
             } else {
-                page.container->hide();
-                page.item->setHidden(true);
+                if (!page.container->isHidden()) {
+                    page.container->hide();
+                }
+                if (!page.item->isHidden()) {
+                    page.item->setHidden(true);
+                }
             }
         }
     }
 
-    ui->noResultsLabel->setVisible(!anyResult);
+    if (ui->noResultsLabel->isVisible() != !anyResult) {
+        ui->noResultsLabel->setVisible(!anyResult);
+    }
 
     ui->pagesScrollArea->setUpdatesEnabled(true);
 
-    // Ensure search bar keeps focus after layout changes. On some platforms (like Linux),
-    // layout updates can trigger focus changes, so we use a timer to ensure focus
-    // is restored after all pending events are processed.
-    QTimer::singleShot(0, ui->searchBar, qOverload<>(&QWidget::setFocus));
-
-    m_suppressScrollSync = false;
+    // Keep scroll synchronization suppressed until layout updates are finished.
+    // Explicitly restore focus to the search bar.
+    ui->searchBar->setFocus();
+    QTimer::singleShot(0, this, [this]() { m_suppressScrollSync = false; });
 }

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -290,7 +290,7 @@ void ConfigDialog::slot_search(const QString &text)
             page.item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
             auto *const headerItem = new QListWidgetItem(page.item->icon(), page.name);
-            headerItem->setFlags(Qt::ItemIsEnabled);
+            headerItem->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
             headerItem->setData(Qt::UserRole, QVariant::fromValue(page.widget));
             QFont font = headerItem->font();
             font.setBold(true);

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -18,8 +18,6 @@
 #include "pathmachinepage.h"
 #include "ui_configdialog.h"
 
-#include <array>
-
 #include <QIcon>
 #include <QListWidget>
 #include <QtWidgets>
@@ -39,7 +37,6 @@ bool matches(const QWidget *widget, const QString &text)
         return gb->title().contains(text, Qt::CaseInsensitive);
     return false;
 }
-
 } // namespace
 
 ConfigDialog::ConfigDialog(QWidget *const parent)
@@ -65,7 +62,6 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
         auto *container = new QWidget(headerParent);
         auto *layout = new QHBoxLayout(container);
         layout->setContentsMargins(0, 0, 0, 4);
-        layout->setSpacing(8);
 
         auto *label = new QLabel(name, container);
         QFont font = label->font();
@@ -89,7 +85,6 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
             auto *container = new QWidget(this);
             auto *containerLayout = new QVBoxLayout(container);
             containerLayout->setContentsMargins(0, 0, 0, 0);
-            containerLayout->setSpacing(8);
             containerLayout->addWidget(makeSectionHeader(name, container));
             containerLayout->addWidget(widget);
 
@@ -100,22 +95,17 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     addPage(generalPage, tr("General"), ":/icons/generalcfg.png");
     addPage(graphicsPage, tr("Graphics"), ":/icons/graphicscfg.png");
     addPage(parserPage, tr("Parser"), ":/icons/parsercfg.png");
-    addPage(clientPage, tr("Integrated Mud Client"), ":/icons/terminal.png");
+    addPage(clientPage, tr("Integrated Client"), ":/icons/terminal.png");
     addPage(groupPage, tr("Group Panel"), ":/icons/group-recolor.png");
     addPage(autoLogPage, tr("Auto Logger"), ":/icons/autologgercfg.png");
     addPage(audioPage, tr("Audio"), ":/icons/audiocfg.png");
     addPage(mumeProtocolPage, tr("Mume Protocol"), ":/icons/mumeprotocolcfg.png");
     addPage(pathmachinePage, tr("Path Machine"), ":/icons/pathmachinecfg.png");
 
-    const char32_t magnifyingGlassEmoji = 0x1F50D;
-    ui->noResultsLabel->setText(tr("No matches found!\nMaybe try searching for something else? ")
-                                + QString::fromUcs4(&magnifyingGlassEmoji, 1));
-
     ui->scrollLayout->addStretch();
 
     ui->mainSplitter->setStretchFactor(0, 0);
     ui->mainSplitter->setStretchFactor(1, 1);
-    ui->mainSplitter->setSizes({200, 600});
 
     connect(ui->contentsWidget,
             &QListWidget::currentItemChanged,
@@ -176,13 +166,6 @@ void ConfigDialog::showEvent(QShowEvent *const event)
 {
     // Populate the preference pages from config each time the widget is shown
     emit sig_loadConfig();
-
-    if (parentWidget()) {
-        auto pos = parentWidget()->pos();
-        pos.setX(pos.x() + (parentWidget()->width() / 2) - (width() / 2));
-        move(pos);
-    }
-
     event->accept();
 }
 

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -117,15 +117,7 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     ui->noResultsLabel->setText(tr("No matches found!\nMaybe try searching for something else? ")
                                 + QString::fromUcs4(&magnifyingGlassEmoji, 1));
 
-    m_topStretch = new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
-    m_bottomStretch = new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
-    ui->scrollLayout->insertItem(0, m_topStretch);
-    ui->scrollLayout->addSpacerItem(m_bottomStretch);
-
-    ui->contentsWidget->setFocusPolicy(Qt::NoFocus);
-    ui->pagesScrollArea->setFocusPolicy(Qt::NoFocus);
-    ui->pagesScrollArea->verticalScrollBar()->setFocusPolicy(Qt::NoFocus);
-    ui->scrollAreaWidgetContents->setFocusPolicy(Qt::NoFocus);
+    ui->scrollLayout->addStretch();
 
     connect(ui->contentsWidget,
             &QListWidget::currentItemChanged,
@@ -206,7 +198,7 @@ void ConfigDialog::slot_changePage(QListWidgetItem *current, QListWidgetItem *co
 
 void ConfigDialog::slot_onScroll(int value)
 {
-    if (m_suppressScrollSync) {
+    if (m_suppressScrollSync || !ui->searchBar->text().isEmpty()) {
         return;
     }
 
@@ -240,10 +232,7 @@ void ConfigDialog::slot_cancel()
 
 void ConfigDialog::slot_search(const QString &text)
 {
-    m_suppressScrollSync = true;
-    setUpdatesEnabled(false);
-    const QSignalBlocker contentBlocker{ui->contentsWidget};
-    const QSignalBlocker scrollBlocker{ui->pagesScrollArea->verticalScrollBar()};
+    const QSignalBlocker blocker{ui->contentsWidget};
 
     bool anyResult = false;
 
@@ -356,27 +345,9 @@ void ConfigDialog::slot_search(const QString &text)
         }
     }
 
-    if (ui->noResultsLabel->isVisible() != !anyResult) {
-        ui->noResultsLabel->setVisible(!anyResult);
-        if (anyResult) {
-            m_topStretch->changeSize(0, 0, QSizePolicy::Fixed, QSizePolicy::Fixed);
-            m_bottomStretch->changeSize(0, 0, QSizePolicy::Fixed, QSizePolicy::Fixed);
-        } else {
-            m_topStretch->changeSize(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
-            m_bottomStretch->changeSize(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
-        }
-        ui->scrollLayout->invalidate();
+    if (ui->noResultsContainer->isVisible() != !anyResult) {
+        ui->noResultsContainer->setVisible(!anyResult);
     }
 
-    setUpdatesEnabled(true);
-
-    // Keep scroll synchronization suppressed until layout updates are finished.
-    // Explicitly restore focus to the search bar via multiple deferred calls to
-    // ensure it's the last focus-related action across all event loop cycles.
     ui->searchBar->setFocus();
-    QTimer::singleShot(0, ui->searchBar, qOverload<>(&QWidget::setFocus));
-    QTimer::singleShot(50, this, [this]() {
-        ui->searchBar->setFocus();
-        m_suppressScrollSync = false;
-    });
 }

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -108,10 +108,8 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     addPage(pathmachinePage, tr("Path Machine"), ":/icons/pathmachinecfg.png");
 
     const char32_t magnifyingGlassEmoji = 0x1F50D;
-    ui->noResultsLabel->setText(
-        tr("No matches found!\nMaybe try searching for something else? ")
-        + QString::fromUcs4(&magnifyingGlassEmoji, 1) + "\n\n"
-        + QString::fromUcs4(std::array<char32_t, 1>{0x1F632}.data(), 1)); // 😲
+    ui->noResultsLabel->setText(tr("No matches found!\nMaybe try searching for something else? ")
+                                + QString::fromUcs4(&magnifyingGlassEmoji, 1));
 
     ui->scrollLayout->addStretch();
 
@@ -190,6 +188,11 @@ void ConfigDialog::slot_changePage(QListWidgetItem *current, QListWidgetItem *co
         return;
     }
 
+    if (!ui->searchBar->text().isEmpty()) {
+        ui->searchBar->clear();
+        // search bar clear will restore Stack index 0
+    }
+
     for (const auto &page : m_pages) {
         if (page.item == current) {
             m_suppressScrollSync = true;
@@ -238,41 +241,32 @@ void ConfigDialog::slot_search(const QString &text)
 
     if (text.isEmpty()) {
         ui->rightStack->setCurrentIndex(0);
+        for (const auto &page : m_pages) {
+            page.item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+        }
         ui->searchBar->setFocus();
         return;
     }
 
     for (const auto &page : m_pages) {
-        if (page.name.contains(text, Qt::CaseInsensitive)) {
-            auto *const item = new QListWidgetItem(page.item->icon(),
-                                                   tr("Go to %1").arg(page.name),
-                                                   ui->searchResultsList);
-            item->setData(Qt::UserRole, QVariant::fromValue(page.widget));
-            QFont font = item->font();
-            font.setBold(true);
-            item->setFont(font);
-        }
-
+        bool anyChildMatches = false;
         const auto children = page.widget->findChildren<QWidget *>();
+
+        QList<QListWidgetItem *> pageResults;
+
         for (auto *const child : children) {
             if (matches(child, text)) {
                 QString matchText;
-                QString emoji;
                 if (auto *const cb = qobject_cast<QCheckBox *>(child)) {
                     matchText = cb->text();
-                    emoji = QString::fromUcs4(std::array<char32_t, 1>{0x2611}.data(), 1); // ☑
                 } else if (auto *const rb = qobject_cast<QRadioButton *>(child)) {
                     matchText = rb->text();
-                    emoji = QString::fromUcs4(std::array<char32_t, 1>{0x1F518}.data(), 1); // 🔘
                 } else if (auto *const lbl = qobject_cast<QLabel *>(child)) {
                     matchText = lbl->text();
-                    emoji = QString::fromUcs4(std::array<char32_t, 1>{0x1F4DD}.data(), 1); // 📝
                 } else if (auto *const pb = qobject_cast<QPushButton *>(child)) {
                     matchText = pb->text();
-                    emoji = QString::fromUcs4(std::array<char32_t, 1>{0x1F192}.data(), 1); // 🆒
                 } else if (auto *const gb = qobject_cast<QGroupBox *>(child)) {
                     matchText = gb->title();
-                    emoji = QString::fromUcs4(std::array<char32_t, 1>{0x1F4E6}.data(), 1); // 📦
                 }
 
                 if (matchText.isEmpty()) {
@@ -280,12 +274,30 @@ void ConfigDialog::slot_search(const QString &text)
                 }
 
                 matchText.remove('&');
-                auto *const item
-                    = new QListWidgetItem(page.item->icon(),
-                                          QString("%1 %2 > %3").arg(emoji, page.name, matchText),
-                                          ui->searchResultsList);
+                auto *const item = new QListWidgetItem(QString("  %1").arg(matchText));
                 item->setData(Qt::UserRole, QVariant::fromValue(child));
+                pageResults.append(item);
+                anyChildMatches = true;
             }
+        }
+
+        const bool pageMatches = page.name.contains(text, Qt::CaseInsensitive);
+        if (pageMatches || anyChildMatches) {
+            page.item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+
+            auto *const headerItem = new QListWidgetItem(page.item->icon(), page.name);
+            headerItem->setFlags(Qt::ItemIsEnabled);
+            headerItem->setData(Qt::UserRole, QVariant::fromValue(page.widget));
+            QFont font = headerItem->font();
+            font.setBold(true);
+            headerItem->setFont(font);
+            ui->searchResultsList->addItem(headerItem);
+
+            for (auto *res : pageResults) {
+                ui->searchResultsList->addItem(res);
+            }
+        } else {
+            page.item->setFlags(Qt::NoItemFlags);
         }
     }
 

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -66,7 +66,8 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     auto mumeProtocolPage = new MumeProtocolPage(this);
     auto pathmachinePage = new PathmachinePage(this);
 
-    const auto makeSectionHeader = [](const QString &name, QWidget *const headerParent) -> QWidget * {
+    const auto makeSectionHeader = [](const QString &name,
+                                      QWidget *const headerParent) -> QWidget * {
         auto *container = new QWidget(headerParent);
         auto *layout = new QHBoxLayout(container);
         layout->setContentsMargins(0, 0, 0, 4);
@@ -87,21 +88,20 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
         return container;
     };
 
-    auto addPage = [this, &makeSectionHeader](QWidget *widget,
-                                              const QString &name,
-                                              const QString &iconPath) {
-        auto *item = new QListWidgetItem(QIcon(iconPath), name, ui->contentsWidget);
+    auto addPage =
+        [this, &makeSectionHeader](QWidget *widget, const QString &name, const QString &iconPath) {
+            auto *item = new QListWidgetItem(QIcon(iconPath), name, ui->contentsWidget);
 
-        auto *container = new QWidget(this);
-        auto *containerLayout = new QVBoxLayout(container);
-        containerLayout->setContentsMargins(0, 0, 0, 0);
-        containerLayout->setSpacing(8);
-        containerLayout->addWidget(makeSectionHeader(name, container));
-        containerLayout->addWidget(widget);
+            auto *container = new QWidget(this);
+            auto *containerLayout = new QVBoxLayout(container);
+            containerLayout->setContentsMargins(0, 0, 0, 0);
+            containerLayout->setSpacing(8);
+            containerLayout->addWidget(makeSectionHeader(name, container));
+            containerLayout->addWidget(widget);
 
-        ui->scrollLayout->addWidget(container);
-        m_pages.append({name, widget, item, container});
-    };
+            ui->scrollLayout->addWidget(container);
+            m_pages.append({name, widget, item, container});
+        };
 
     addPage(generalPage, tr("General"), ":/icons/generalcfg.png");
     addPage(graphicsPage, tr("Graphics"), ":/icons/graphicscfg.png");
@@ -113,7 +113,9 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     addPage(mumeProtocolPage, tr("Mume Protocol"), ":/icons/mumeprotocolcfg.png");
     addPage(pathmachinePage, tr("Path Machine"), ":/icons/pathmachinecfg.png");
 
-    m_noResultsLabel = new QLabel(tr("<b>No matches found!</b><br>Maybe try searching for something else? \xF0\x9F\x94\x8D"), this);
+    m_noResultsLabel = new QLabel(
+        tr("<b>No matches found!</b><br>Maybe try searching for something else? \xF0\x9F\x94\x8D"),
+        this);
     m_noResultsLabel->setAlignment(Qt::AlignCenter);
     m_noResultsLabel->setWordWrap(true);
     m_noResultsLabel->setMargin(20);
@@ -135,9 +137,7 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ConfigDialog::slot_cancel);
     connect(ui->searchBar, &QLineEdit::textChanged, this, &ConfigDialog::slot_search);
 
-    connect(generalPage, &GeneralPage::sig_reloadConfig, this, [this]() {
-        emit sig_loadConfig();
-    });
+    connect(generalPage, &GeneralPage::sig_reloadConfig, this, [this]() { emit sig_loadConfig(); });
 
     connect(this, &ConfigDialog::sig_loadConfig, generalPage, &GeneralPage::slot_loadConfig);
     connect(this, &ConfigDialog::sig_loadConfig, graphicsPage, &GraphicsPage::slot_loadConfig);
@@ -291,8 +291,8 @@ void ConfigDialog::slot_search(const QString &text)
                 }
             }
 
-            const auto directChildren = page.widget->findChildren<QWidget *>(
-                QString(), Qt::FindDirectChildrenOnly);
+            const auto directChildren
+                = page.widget->findChildren<QWidget *>(QString(), Qt::FindDirectChildrenOnly);
             for (auto *child : directChildren) {
                 if (qobject_cast<QGroupBox *>(child))
                     continue;

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -113,6 +113,10 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
 
     ui->scrollLayout->addStretch();
 
+    ui->mainSplitter->setStretchFactor(0, 0);
+    ui->mainSplitter->setStretchFactor(1, 1);
+    ui->mainSplitter->setSizes({200, 600});
+
     connect(ui->contentsWidget,
             &QListWidget::currentItemChanged,
             this,
@@ -274,7 +278,7 @@ void ConfigDialog::slot_search(const QString &text)
                 }
 
                 matchText.remove('&');
-                auto *const item = new QListWidgetItem(QString("  %1").arg(matchText));
+                auto *const item = new QListWidgetItem(QString("  \xE2\x80\xA2 %1").arg(matchText));
                 item->setData(Qt::UserRole, QVariant::fromValue(child));
                 pageResults.append(item);
                 anyChildMatches = true;

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -113,13 +113,14 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     addPage(mumeProtocolPage, tr("Mume Protocol"), ":/icons/mumeprotocolcfg.png");
     addPage(pathmachinePage, tr("Path Machine"), ":/icons/pathmachinecfg.png");
 
-    m_noResultsLabel = new QLabel(
-        tr("<b>No matches found!</b><br>Maybe try searching for something else? \xF0\x9F\x94\x8D"),
-        this);
+    const char32_t magnifyingGlassEmoji = 0x1F50D;
+    m_noResultsLabel = new QLabel(tr("No matches found!\nMaybe try searching for something else? ")
+                                      + QString::fromUcs4(&magnifyingGlassEmoji, 1),
+                                  this);
     m_noResultsLabel->setAlignment(Qt::AlignCenter);
     m_noResultsLabel->setWordWrap(true);
     m_noResultsLabel->setMargin(20);
-    m_noResultsLabel->setStyleSheet("font-size: 14pt; color: gray;");
+    m_noResultsLabel->setStyleSheet("font-size: 14pt; color: gray; font-weight: bold;");
     m_noResultsLabel->hide();
     ui->scrollLayout->addWidget(m_noResultsLabel);
 
@@ -240,7 +241,7 @@ void ConfigDialog::slot_cancel()
 void ConfigDialog::slot_search(const QString &text)
 {
     m_suppressScrollSync = true;
-    setUpdatesEnabled(false);
+    ui->pagesScrollArea->setUpdatesEnabled(false);
 
     bool anyResult = false;
 
@@ -325,7 +326,7 @@ void ConfigDialog::slot_search(const QString &text)
 
     m_noResultsLabel->setVisible(!anyResult);
 
-    setUpdatesEnabled(true);
+    ui->pagesScrollArea->setUpdatesEnabled(true);
     m_suppressScrollSync = false;
 
     // Ensure search bar keeps focus after layout changes

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -114,15 +114,8 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     addPage(pathmachinePage, tr("Path Machine"), ":/icons/pathmachinecfg.png");
 
     const char32_t magnifyingGlassEmoji = 0x1F50D;
-    m_noResultsLabel = new QLabel(tr("No matches found!\nMaybe try searching for something else? ")
-                                      + QString::fromUcs4(&magnifyingGlassEmoji, 1),
-                                  this);
-    m_noResultsLabel->setAlignment(Qt::AlignCenter);
-    m_noResultsLabel->setWordWrap(true);
-    m_noResultsLabel->setMargin(20);
-    m_noResultsLabel->setStyleSheet("font-size: 14pt; color: gray; font-weight: bold;");
-    m_noResultsLabel->hide();
-    ui->scrollLayout->addWidget(m_noResultsLabel);
+    ui->noResultsLabel->setText(tr("No matches found!\nMaybe try searching for something else? ")
+                                + QString::fromUcs4(&magnifyingGlassEmoji, 1));
 
     ui->scrollLayout->addStretch();
 
@@ -324,11 +317,14 @@ void ConfigDialog::slot_search(const QString &text)
         }
     }
 
-    m_noResultsLabel->setVisible(!anyResult);
+    ui->noResultsLabel->setVisible(!anyResult);
 
     ui->pagesScrollArea->setUpdatesEnabled(true);
-    m_suppressScrollSync = false;
 
-    // Ensure search bar keeps focus after layout changes
-    ui->searchBar->setFocus();
+    // Ensure search bar keeps focus after layout changes. On some platforms (like Linux),
+    // layout updates can trigger focus changes, so we use a timer to ensure focus
+    // is restored after all pending events are processed.
+    QTimer::singleShot(0, ui->searchBar, qOverload<>(&QWidget::setFocus));
+
+    m_suppressScrollSync = false;
 }

--- a/src/preferences/configdialog.cpp
+++ b/src/preferences/configdialog.cpp
@@ -18,6 +18,8 @@
 #include "pathmachinepage.h"
 #include "ui_configdialog.h"
 
+#include <array>
+
 #include <QIcon>
 #include <QListWidget>
 #include <QtWidgets>
@@ -106,8 +108,10 @@ ConfigDialog::ConfigDialog(QWidget *const parent)
     addPage(pathmachinePage, tr("Path Machine"), ":/icons/pathmachinecfg.png");
 
     const char32_t magnifyingGlassEmoji = 0x1F50D;
-    ui->noResultsLabel->setText(tr("No matches found!\nMaybe try searching for something else? ")
-                                + QString::fromUcs4(&magnifyingGlassEmoji, 1));
+    ui->noResultsLabel->setText(
+        tr("No matches found!\nMaybe try searching for something else? ")
+        + QString::fromUcs4(&magnifyingGlassEmoji, 1) + "\n\n"
+        + QString::fromUcs4(std::array<char32_t, 1>{0x1F632}.data(), 1)); // 😲
 
     ui->scrollLayout->addStretch();
 
@@ -234,28 +238,41 @@ void ConfigDialog::slot_search(const QString &text)
 
     if (text.isEmpty()) {
         ui->rightStack->setCurrentIndex(0);
-        ui->contentsWidget->setEnabled(true);
         ui->searchBar->setFocus();
         return;
     }
 
-    ui->contentsWidget->setEnabled(false);
-
     for (const auto &page : m_pages) {
+        if (page.name.contains(text, Qt::CaseInsensitive)) {
+            auto *const item = new QListWidgetItem(page.item->icon(),
+                                                   tr("Go to %1").arg(page.name),
+                                                   ui->searchResultsList);
+            item->setData(Qt::UserRole, QVariant::fromValue(page.widget));
+            QFont font = item->font();
+            font.setBold(true);
+            item->setFont(font);
+        }
+
         const auto children = page.widget->findChildren<QWidget *>();
-        for (auto *child : children) {
+        for (auto *const child : children) {
             if (matches(child, text)) {
                 QString matchText;
-                if (auto *cb = qobject_cast<QCheckBox *>(child)) {
+                QString emoji;
+                if (auto *const cb = qobject_cast<QCheckBox *>(child)) {
                     matchText = cb->text();
-                } else if (auto *rb = qobject_cast<QRadioButton *>(child)) {
+                    emoji = QString::fromUcs4(std::array<char32_t, 1>{0x2611}.data(), 1); // ☑
+                } else if (auto *const rb = qobject_cast<QRadioButton *>(child)) {
                     matchText = rb->text();
-                } else if (auto *lbl = qobject_cast<QLabel *>(child)) {
+                    emoji = QString::fromUcs4(std::array<char32_t, 1>{0x1F518}.data(), 1); // 🔘
+                } else if (auto *const lbl = qobject_cast<QLabel *>(child)) {
                     matchText = lbl->text();
-                } else if (auto *pb = qobject_cast<QPushButton *>(child)) {
+                    emoji = QString::fromUcs4(std::array<char32_t, 1>{0x1F4DD}.data(), 1); // 📝
+                } else if (auto *const pb = qobject_cast<QPushButton *>(child)) {
                     matchText = pb->text();
-                } else if (auto *gb = qobject_cast<QGroupBox *>(child)) {
+                    emoji = QString::fromUcs4(std::array<char32_t, 1>{0x1F192}.data(), 1); // 🆒
+                } else if (auto *const gb = qobject_cast<QGroupBox *>(child)) {
                     matchText = gb->title();
+                    emoji = QString::fromUcs4(std::array<char32_t, 1>{0x1F4E6}.data(), 1); // 📦
                 }
 
                 if (matchText.isEmpty()) {
@@ -263,8 +280,10 @@ void ConfigDialog::slot_search(const QString &text)
                 }
 
                 matchText.remove('&');
-                auto *item = new QListWidgetItem(QString("%1 > %2").arg(page.name, matchText),
-                                                 ui->searchResultsList);
+                auto *const item
+                    = new QListWidgetItem(page.item->icon(),
+                                          QString("%1 %2 > %3").arg(emoji, page.name, matchText),
+                                          ui->searchResultsList);
                 item->setData(Qt::UserRole, QVariant::fromValue(child));
             }
         }
@@ -279,13 +298,13 @@ void ConfigDialog::slot_search(const QString &text)
     ui->searchBar->setFocus();
 }
 
-void ConfigDialog::slot_onResultSelected(QListWidgetItem *item)
+void ConfigDialog::slot_onResultSelected(QListWidgetItem *const item)
 {
     if (item == nullptr) {
         return;
     }
 
-    auto *widget = item->data(Qt::UserRole).value<QWidget *>();
+    auto *const widget = item->data(Qt::UserRole).value<QWidget *>();
     if (widget == nullptr) {
         return;
     }
@@ -295,7 +314,7 @@ void ConfigDialog::slot_onResultSelected(QListWidgetItem *item)
 
     // Find which page this widget belongs to
     for (const auto &page : m_pages) {
-        if (page.widget->isAncestorOf(widget)) {
+        if (page.widget == widget || page.widget->isAncestorOf(widget)) {
             ui->contentsWidget->setCurrentItem(page.item);
             break;
         }

--- a/src/preferences/configdialog.h
+++ b/src/preferences/configdialog.h
@@ -50,6 +50,7 @@ private slots:
     void slot_ok();
     void slot_cancel();
     void slot_search(const QString &text);
+    void slot_onResultSelected(QListWidgetItem *item);
 
 signals:
     void sig_graphicsSettingsChanged();

--- a/src/preferences/configdialog.h
+++ b/src/preferences/configdialog.h
@@ -33,7 +33,6 @@ private:
 
     Ui::ConfigDialog *ui;
     QList<PageInfo> m_pages;
-    QLabel *m_noResultsLabel = nullptr;
     bool m_suppressScrollSync = false;
 
 public:

--- a/src/preferences/configdialog.h
+++ b/src/preferences/configdialog.h
@@ -9,6 +9,8 @@
 
 #include <QDialog>
 
+class QLabel;
+
 namespace Ui {
 class ConfigDialog;
 }
@@ -31,6 +33,7 @@ private:
 
     Ui::ConfigDialog *ui;
     QList<PageInfo> m_pages;
+    QLabel *m_noResultsLabel = nullptr;
     bool m_suppressScrollSync = false;
 
 public:
@@ -53,7 +56,4 @@ signals:
     void sig_groupSettingsChanged();
     void sig_loadConfig();
 
-private:
-    void createIcons();
-    void updateSearch();
 };

--- a/src/preferences/configdialog.h
+++ b/src/preferences/configdialog.h
@@ -10,6 +10,7 @@
 #include <QDialog>
 
 class QLabel;
+class QSpacerItem;
 
 namespace Ui {
 class ConfigDialog;
@@ -34,6 +35,9 @@ private:
     Ui::ConfigDialog *ui;
     QList<PageInfo> m_pages;
     bool m_suppressScrollSync = false;
+
+    QSpacerItem *m_topStretch = nullptr;
+    QSpacerItem *m_bottomStretch = nullptr;
 
 public:
     explicit ConfigDialog(QWidget *parent = nullptr);

--- a/src/preferences/configdialog.h
+++ b/src/preferences/configdialog.h
@@ -36,9 +36,6 @@ private:
     QList<PageInfo> m_pages;
     bool m_suppressScrollSync = false;
 
-    QSpacerItem *m_topStretch = nullptr;
-    QSpacerItem *m_bottomStretch = nullptr;
-
 public:
     explicit ConfigDialog(QWidget *parent = nullptr);
     ~ConfigDialog() override;

--- a/src/preferences/configdialog.h
+++ b/src/preferences/configdialog.h
@@ -45,7 +45,7 @@ protected:
     void showEvent(QShowEvent *event) override;
 
 private slots:
-    void slot_changePage(QListWidgetItem *current, QListWidgetItem */*previous*/);
+    void slot_changePage(QListWidgetItem *current, QListWidgetItem * /*previous*/);
     void slot_onScroll(int value);
     void slot_ok();
     void slot_cancel();
@@ -55,5 +55,4 @@ signals:
     void sig_graphicsSettingsChanged();
     void sig_groupSettingsChanged();
     void sig_loadConfig();
-
 };

--- a/src/preferences/configdialog.ui
+++ b/src/preferences/configdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>700</height>
+    <width>900</width>
+    <height>761</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="mainLayout">
@@ -27,15 +27,24 @@
    </item>
    <item>
     <widget class="QSplitter" name="mainSplitter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <widget class="QListWidget" name="contentsWidget">
-      <property name="minimumSize">
-       <size>
-        <width>150</width>
-        <height>0</height>
-       </size>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="sizeAdjustPolicy">
+       <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
       </property>
      </widget>
      <widget class="QStackedWidget" name="rightStack">
@@ -43,8 +52,14 @@
        <number>0</number>
       </property>
       <widget class="QScrollArea" name="pagesScrollArea">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAsNeeded</enum>
+        <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
        </property>
        <property name="widgetResizable">
         <bool>true</bool>
@@ -59,11 +74,17 @@
       </widget>
       <widget class="QListWidget" name="searchResultsList"/>
       <widget class="QWidget" name="noResultsPage">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <layout class="QVBoxLayout" name="noResultsLayout">
         <item>
          <spacer name="verticalSpacer_3">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -79,10 +100,11 @@
            <string notr="true">font-size: 14pt; color: gray; font-weight: bold;</string>
           </property>
           <property name="text">
-           <string/>
+           <string>No matches found!
+Maybe try searching for something else? 🔎</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
@@ -95,7 +117,7 @@
         <item>
          <spacer name="verticalSpacer_4">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -113,7 +135,7 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/preferences/configdialog.ui
+++ b/src/preferences/configdialog.ui
@@ -44,68 +44,69 @@
       </widget>
      </item>
      <item>
-      <widget class="QScrollArea" name="pagesScrollArea">
-       <property name="widgetResizable">
-        <bool>true</bool>
+      <widget class="QStackedWidget" name="rightStack">
+       <property name="currentIndex">
+        <number>0</number>
        </property>
-       <widget class="QWidget" name="scrollAreaWidgetContents">
-        <layout class="QVBoxLayout" name="scrollLayout">
-         <property name="spacing">
-          <number>20</number>
-         </property>
+       <widget class="QScrollArea" name="pagesScrollArea">
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaWidgetContents">
+         <layout class="QVBoxLayout" name="scrollLayout">
+          <property name="spacing">
+           <number>20</number>
+          </property>
+         </layout>
+        </widget>
+       </widget>
+       <widget class="QListWidget" name="searchResultsList"/>
+       <widget class="QWidget" name="noResultsPage">
+        <layout class="QVBoxLayout" name="noResultsLayout">
          <item>
-          <widget class="QWidget" name="noResultsContainer" native="true">
-           <property name="visible">
-            <bool>false</bool>
+          <spacer name="verticalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
            </property>
-           <layout class="QVBoxLayout" name="noResultsLayout">
-            <item>
-             <spacer name="verticalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QLabel" name="noResultsLabel">
-              <property name="styleSheet">
-               <string notr="true">font-size: 14pt; color: gray; font-weight: bold;</string>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-              <property name="margin">
-               <number>20</number>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="noResultsLabel">
+           <property name="styleSheet">
+            <string notr="true">font-size: 14pt; color: gray; font-weight: bold;</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="margin">
+            <number>20</number>
+           </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </widget>

--- a/src/preferences/configdialog.ui
+++ b/src/preferences/configdialog.ui
@@ -54,25 +54,57 @@
           <number>20</number>
          </property>
          <item>
-          <widget class="QLabel" name="noResultsLabel">
+          <widget class="QWidget" name="noResultsContainer" native="true">
            <property name="visible">
             <bool>false</bool>
            </property>
-           <property name="styleSheet">
-            <string notr="true">font-size: 14pt; color: gray; font-weight: bold;</string>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-           <property name="margin">
-            <number>20</number>
-           </property>
+           <layout class="QVBoxLayout" name="noResultsLayout">
+            <item>
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="noResultsLabel">
+              <property name="styleSheet">
+               <string notr="true">font-size: 14pt; color: gray; font-weight: bold;</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+              <property name="margin">
+               <number>20</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </widget>
          </item>
         </layout>

--- a/src/preferences/configdialog.ui
+++ b/src/preferences/configdialog.ui
@@ -44,7 +44,7 @@
       </property>
       <widget class="QScrollArea" name="pagesScrollArea">
        <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
+        <enum>Qt::ScrollBarAsNeeded</enum>
        </property>
        <property name="widgetResizable">
         <bool>true</bool>

--- a/src/preferences/configdialog.ui
+++ b/src/preferences/configdialog.ui
@@ -26,93 +26,89 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="contentLayout">
-     <item>
-      <widget class="QListWidget" name="contentsWidget">
-       <property name="minimumSize">
-        <size>
-         <width>150</width>
-         <height>0</height>
-        </size>
+    <widget class="QSplitter" name="mainSplitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QListWidget" name="contentsWidget">
+      <property name="minimumSize">
+       <size>
+        <width>150</width>
+        <height>0</height>
+       </size>
+      </property>
+     </widget>
+     <widget class="QStackedWidget" name="rightStack">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QScrollArea" name="pagesScrollArea">
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
        </property>
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>16777215</height>
-        </size>
+       <property name="widgetResizable">
+        <bool>true</bool>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QStackedWidget" name="rightStack">
-       <property name="currentIndex">
-        <number>0</number>
-       </property>
-       <widget class="QScrollArea" name="pagesScrollArea">
-        <property name="widgetResizable">
-         <bool>true</bool>
-        </property>
-        <widget class="QWidget" name="scrollAreaWidgetContents">
-         <layout class="QVBoxLayout" name="scrollLayout">
-          <property name="spacing">
-           <number>20</number>
-          </property>
-         </layout>
-        </widget>
-       </widget>
-       <widget class="QListWidget" name="searchResultsList"/>
-       <widget class="QWidget" name="noResultsPage">
-        <layout class="QVBoxLayout" name="noResultsLayout">
-         <item>
-          <spacer name="verticalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="noResultsLabel">
-           <property name="styleSheet">
-            <string notr="true">font-size: 14pt; color: gray; font-weight: bold;</string>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-           <property name="margin">
-            <number>20</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
+       <widget class="QWidget" name="scrollAreaWidgetContents">
+        <layout class="QVBoxLayout" name="scrollLayout">
+         <property name="spacing">
+          <number>20</number>
+         </property>
         </layout>
        </widget>
       </widget>
-     </item>
-    </layout>
+      <widget class="QListWidget" name="searchResultsList"/>
+      <widget class="QWidget" name="noResultsPage">
+       <layout class="QVBoxLayout" name="noResultsLayout">
+        <item>
+         <spacer name="verticalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="noResultsLabel">
+          <property name="styleSheet">
+           <string notr="true">font-size: 14pt; color: gray; font-weight: bold;</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="margin">
+           <number>20</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/preferences/configdialog.ui
+++ b/src/preferences/configdialog.ui
@@ -53,6 +53,28 @@
          <property name="spacing">
           <number>20</number>
          </property>
+         <item>
+          <widget class="QLabel" name="noResultsLabel">
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">font-size: 14pt; color: gray; font-weight: bold;</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="margin">
+            <number>20</number>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </widget>

--- a/src/preferences/generalpage.ui
+++ b/src/preferences/generalpage.ui
@@ -6,148 +6,45 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>508</width>
-    <height>944</height>
+    <width>399</width>
+    <height>1093</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form1</string>
   </property>
-  <layout class="QVBoxLayout">
-   <item>
-    <widget class="QGroupBox" name="groupBox_connections">
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="7" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Connection</string>
+      <string>Settings Management</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="2" column="0">
-       <widget class="QLabel" name="textLabel4_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QPushButton" name="configurationExportButton">
         <property name="text">
-         <string>Local port number:</string>
-        </property>
-        <property name="buddy">
-         <cstring>localPort</cstring>
+         <string>Export...</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="remotePort">
-        <property name="maximum">
-         <number>65535</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="3">
-       <widget class="QLineEdit" name="remoteName">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="textLabel3_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
+      <item>
+       <widget class="QPushButton" name="configurationImportButton">
         <property name="text">
-         <string>Remote port number:</string>
-        </property>
-        <property name="buddy">
-         <cstring>remotePort</cstring>
+         <string>Import...</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QSpinBox" name="localPort">
-        <property name="maximum">
-         <number>65535</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QCheckBox" name="encryptionCheckBox">
-        <property name="toolTip">
-         <string>Require that your connection to MUME is always secure</string>
-        </property>
+      <item>
+       <widget class="QPushButton" name="configurationResetButton">
         <property name="text">
-         <string>Require encryption</string>
+         <string>Reset to Defaults</string>
         </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="textLabel2_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Remote server:</string>
-        </property>
-        <property name="buddy">
-         <cstring>remoteName</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>10</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Character encoding:</string>
-        </property>
-        <property name="buddy">
-         <cstring>charsetComboBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="charsetComboBox">
-        <item>
-         <property name="text">
-          <string extracomment="Default encoding">Latin-1</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string extracomment="Modern clients only">UTF-8</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string extracomment="No special characters">US-ASCII</string>
-         </property>
-        </item>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Account</string>
@@ -173,23 +70,310 @@
         </property>
        </widget>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QGroupBox" name="groupBox_modding">
+     <property name="title">
+      <string>Modding</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_modding">
       <item>
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+       <widget class="QLineEdit" name="resourceLineEdit">
+        <property name="placeholderText">
+         <string>Path to resources</string>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>10</width>
-          <height>20</height>
-         </size>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="resourcePushButton">
+        <property name="text">
+         <string>Select</string>
         </property>
-       </spacer>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="groupBox_statusbar">
+     <property name="title">
+      <string>Apperance</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="displayMumeClockCheckBox">
+        <property name="text">
+         <string>Show Mume clock</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Theme:</string>
+        </property>
+        <property name="buddy">
+         <cstring>themeComboBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="themeComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+        <item>
+         <property name="text">
+          <string>System</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Dark</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Light</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="displayXPStatusCheckBox">
+        <property name="text">
+         <string>Show Session XP</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="title">
+      <string>Proxy</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_7">
+      <item row="0" column="0">
+       <widget class="QLabel" name="textLabel4_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Port:</string>
+        </property>
+        <property name="buddy">
+         <cstring>localPort</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Character encoding:</string>
+        </property>
+        <property name="buddy">
+         <cstring>charsetComboBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QCheckBox" name="proxyListensOnAnyInterfaceCheckBox">
+        <property name="toolTip">
+         <string>Allow external traffic to connect to MMapper</string>
+        </property>
+        <property name="text">
+         <string>Expose to local network</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="proxyConnectionStatusCheckBox">
+        <property name="toolTip">
+         <string>Disconnect from the mud client when MUME disconnects</string>
+        </property>
+        <property name="text">
+         <string>Mirror connection status</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QSpinBox" name="localPort">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QComboBox" name="charsetComboBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+        <item>
+         <property name="text">
+          <string extracomment="Default encoding">Latin-1</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="Modern clients only">UTF-8</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string extracomment="No special characters">US-ASCII</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox_connections">
+     <property name="title">
+      <string>Remote Server</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="1" colspan="2">
+       <widget class="QLineEdit" name="remoteName">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="textLabel3_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Port:</string>
+        </property>
+        <property name="buddy">
+         <cstring>remotePort</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QCheckBox" name="encryptionCheckBox">
+        <property name="toolTip">
+         <string>Require that your connection to MUME is always secure</string>
+        </property>
+        <property name="text">
+         <string>Require encryption</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="remotePort">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="textLabel2_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Host:</string>
+        </property>
+        <property name="buddy">
+         <cstring>remoteName</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QGroupBox" name="groupBox_exits">
+     <property name="title">
+      <string>Emulated Exits</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="showHiddenExitFlagsCheckBox">
+        <property name="text">
+         <string>Show hidden exit flags</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="emulatedExitsCheckBox">
+        <property name="text">
+         <string>Show emulated exits</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="showNotesCheckBox">
+        <property name="text">
+         <string>Show notes</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Startup</string>
@@ -222,13 +406,6 @@
          <property name="spacing">
           <number>0</number>
          </property>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="autoLoadCheck">
-           <property name="text">
-            <string>Load world:</string>
-           </property>
-          </widget>
-         </item>
          <item row="2" column="1">
           <widget class="QLineEdit" name="autoLoadFileName">
            <property name="sizePolicy">
@@ -255,6 +432,13 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="autoLoadCheck">
+           <property name="text">
+            <string>Load world:</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -268,215 +452,6 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_statusbar">
-     <property name="title">
-      <string>Apperance</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="themeComboBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <item>
-         <property name="text">
-          <string>System</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Dark</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Light</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Theme:</string>
-        </property>
-        <property name="buddy">
-         <cstring>themeComboBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="displayMumeClockCheckBox">
-        <property name="text">
-         <string>Show Mume clock</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="displayXPStatusCheckBox">
-        <property name="text">
-         <string>Show Session XP</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_modding">
-     <property name="title">
-      <string>Modding</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_modding">
-      <item>
-       <widget class="QLineEdit" name="resourceLineEdit">
-        <property name="placeholderText">
-         <string>Path to resources</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="resourcePushButton">
-        <property name="text">
-         <string>Select</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_exits">
-     <property name="title">
-      <string>Emulated Exits</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_6">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="emulatedExitsCheckBox">
-        <property name="text">
-         <string>Show emulated exits</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="showHiddenExitFlagsCheckBox">
-        <property name="text">
-         <string>Show hidden exit flags</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="showNotesCheckBox">
-        <property name="text">
-         <string>Show notes</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Advanced</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="0">
-       <widget class="QPushButton" name="configurationResetButton">
-        <property name="text">
-         <string>Reset to Default Settings</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="proxyConnectionStatusCheckBox">
-        <property name="toolTip">
-         <string>Disconnect from the mud client when MUME disconnects</string>
-        </property>
-        <property name="text">
-         <string>Proxy connection status</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="configurationImportButton">
-        <property name="text">
-         <string>Import Settings...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="proxyListensOnAnyInterfaceCheckBox">
-        <property name="toolTip">
-         <string>Allow external traffic to connect to MMapper</string>
-        </property>
-        <property name="text">
-         <string>Proxy listens on any interface</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="configurationExportButton">
-        <property name="text">
-         <string>Export Settings...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <spacer name="horizontalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>10</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="1" colspan="2">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>10</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <tabstops>
@@ -485,6 +460,8 @@
   <tabstop>encryptionCheckBox</tabstop>
   <tabstop>localPort</tabstop>
   <tabstop>charsetComboBox</tabstop>
+  <tabstop>proxyListensOnAnyInterfaceCheckBox</tabstop>
+  <tabstop>proxyConnectionStatusCheckBox</tabstop>
   <tabstop>autoLogin</tabstop>
   <tabstop>setPassword</tabstop>
   <tabstop>checkForUpdateCheckBox</tabstop>
@@ -496,11 +473,9 @@
   <tabstop>displayXPStatusCheckBox</tabstop>
   <tabstop>resourceLineEdit</tabstop>
   <tabstop>resourcePushButton</tabstop>
-  <tabstop>emulatedExitsCheckBox</tabstop>
   <tabstop>showHiddenExitFlagsCheckBox</tabstop>
+  <tabstop>emulatedExitsCheckBox</tabstop>
   <tabstop>showNotesCheckBox</tabstop>
-  <tabstop>proxyListensOnAnyInterfaceCheckBox</tabstop>
-  <tabstop>proxyConnectionStatusCheckBox</tabstop>
   <tabstop>configurationExportButton</tabstop>
   <tabstop>configurationImportButton</tabstop>
   <tabstop>configurationResetButton</tabstop>

--- a/src/preferences/generalpage.ui
+++ b/src/preferences/generalpage.ui
@@ -109,7 +109,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -180,7 +180,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -442,7 +442,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -455,7 +455,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>

--- a/src/preferences/graphicspage.ui
+++ b/src/preferences/graphicspage.ui
@@ -69,7 +69,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -247,7 +247,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>

--- a/src/preferences/graphicspage.ui
+++ b/src/preferences/graphicspage.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>GraphicsPage</class>
  <widget class="QWidget" name="GraphicsPage">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>445</width>
-    <height>507</height>
-   </rect>
-  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
@@ -25,10 +17,7 @@
   <property name="windowTitle">
    <string>Form1</string>
   </property>
-  <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
+  <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>9</number>
    </property>
@@ -41,90 +30,20 @@
    <property name="bottomMargin">
     <number>9</number>
    </property>
-   <item>
-    <widget class="QGroupBox" name="groupBox_OpenGL">
-     <property name="title">
-      <string>OpenGL</string>
+   <item row="6" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
-     <layout class="QGridLayout">
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <item row="2" column="2">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>10</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="1" column="2">
-       <widget class="QComboBox" name="antialiasingSamplesComboBox">
-        <item>
-         <property name="text">
-          <string>0</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>2</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>4</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>8</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>16</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="trilinearFilteringCheckBox">
-        <property name="text">
-         <string>Trilinear filtering</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Anti-aliasing samples:</string>
-        </property>
-        <property name="buddy">
-         <cstring>antialiasingSamplesComboBox</cstring>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
-   <item>
+   <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox_Room">
      <property name="title">
       <string>Room Details</string>
@@ -162,7 +81,185 @@
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox_OpenGL">
+     <property name="title">
+      <string>OpenGL</string>
+     </property>
+     <layout class="QGridLayout">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Anti-aliasing samples:</string>
+        </property>
+        <property name="buddy">
+         <cstring>antialiasingSamplesComboBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QComboBox" name="antialiasingSamplesComboBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+        <item>
+         <property name="text">
+          <string>0</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>2</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>4</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>8</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>16</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="trilinearFilteringCheckBox">
+        <property name="text">
+         <string>Trilinear filtering</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>10</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="groupBox_Colour">
+     <property name="title">
+      <string>Colors</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item row="3" column="0">
+       <widget class="QLabel" name="connectionNormalLabel">
+        <property name="text">
+         <string>Normal Connection:</string>
+        </property>
+        <property name="buddy">
+         <cstring>connectionNormalPushButton</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="darkLabel">
+        <property name="text">
+         <string>Dark w/o Sundeath:</string>
+        </property>
+        <property name="buddy">
+         <cstring>darkPushButton</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QPushButton" name="connectionNormalPushButton">
+        <property name="text">
+         <string>Select</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="bgChangeColor">
+        <property name="text">
+         <string>Select</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="darkLitLabel">
+        <property name="text">
+         <string>Light w/o Sundeath:</string>
+        </property>
+        <property name="buddy">
+         <cstring>darkLitPushButton</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="bgLabel">
+        <property name="text">
+         <string>Background:</string>
+        </property>
+        <property name="buddy">
+         <cstring>bgChangeColor</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QPushButton" name="darkLitPushButton">
+        <property name="text">
+         <string>Select</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="darkPushButton">
+        <property name="text">
+         <string>Select</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Mapping Hints</string>
@@ -192,112 +289,7 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_Colour">
-     <property name="title">
-      <string>Colors</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <item row="2" column="1">
-       <widget class="QPushButton" name="darkLitPushButton">
-        <property name="text">
-         <string>Select</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="bgLabel">
-        <property name="text">
-         <string>Background:</string>
-        </property>
-        <property name="buddy">
-         <cstring>bgChangeColor</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="darkLabel">
-        <property name="text">
-         <string>Dark w/o Sundeath:</string>
-        </property>
-        <property name="buddy">
-         <cstring>darkPushButton</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>10</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="bgChangeColor">
-        <property name="text">
-         <string>Select</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="connectionNormalLabel">
-        <property name="text">
-         <string>Normal Connection:</string>
-        </property>
-        <property name="buddy">
-         <cstring>connectionNormalPushButton</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="darkPushButton">
-        <property name="text">
-         <string>Select</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="darkLitLabel">
-        <property name="text">
-         <string>Light w/o Sundeath:</string>
-        </property>
-        <property name="buddy">
-         <cstring>darkLitPushButton</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QPushButton" name="connectionNormalPushButton">
-        <property name="text">
-         <string>Select</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
+   <item row="4" column="0">
     <widget class="QGroupBox" name="groupBox_Weather">
      <property name="title">
       <string>Weather and Atmosphere</string>
@@ -305,6 +297,12 @@
      <layout class="QGridLayout" name="gridLayout_Weather">
       <item row="0" column="0">
        <widget class="QLabel" name="weatherAtmosphereLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Atmosphere Intensity:</string>
         </property>
@@ -312,16 +310,25 @@
       </item>
       <item row="0" column="1">
        <widget class="QSlider" name="weatherAtmosphereSlider">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
         <property name="maximum">
          <number>100</number>
+        </property>
+        <property name="tracking">
+         <bool>false</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="weatherPrecipitationLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Precipitation Intensity:</string>
         </property>
@@ -329,16 +336,25 @@
       </item>
       <item row="1" column="1">
        <widget class="QSlider" name="weatherPrecipitationSlider">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
         <property name="maximum">
          <number>100</number>
+        </property>
+        <property name="tracking">
+         <bool>false</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="weatherTimeOfDayLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>Time of Day Intensity:</string>
         </property>
@@ -346,36 +362,26 @@
       </item>
       <item row="2" column="1">
        <widget class="QSlider" name="weatherTimeOfDaySlider">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
         <property name="maximum">
          <number>100</number>
+        </property>
+        <property name="tracking">
+         <bool>false</bool>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="5" column="0">
     <widget class="QGroupBox" name="groupBox_Advanced">
      <property name="title">
       <string>Advanced Settings</string>
      </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/preferences/grouppage.ui
+++ b/src/preferences/grouppage.ui
@@ -40,7 +40,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -100,7 +100,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>

--- a/src/preferences/grouppage.ui
+++ b/src/preferences/grouppage.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>GroupPage</class>
  <widget class="QWidget" name="GroupPage">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>329</width>
-    <height>262</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
@@ -36,7 +28,7 @@
       <item row="0" column="5">
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -96,7 +88,7 @@
       <item row="1" column="1">
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -119,7 +111,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/preferences/parserpage.ui
+++ b/src/preferences/parserpage.ui
@@ -31,7 +31,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -183,7 +183,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -205,7 +205,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>

--- a/src/preferences/parserpage.ui
+++ b/src/preferences/parserpage.ui
@@ -27,7 +27,7 @@
       <item row="0" column="3">
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -56,10 +56,10 @@
          </font>
         </property>
         <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
+         <enum>QFrame::Shape::StyledPanel</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
         <property name="text">
          <string>roomname</string>
@@ -121,10 +121,10 @@
          </font>
         </property>
         <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
+         <enum>QFrame::Shape::StyledPanel</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
         <property name="text">
          <string>roomdesc</string>
@@ -179,7 +179,7 @@
       <item row="0" column="2">
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -201,7 +201,7 @@
       <item row="0" column="1">
        <spacer name="horizontalSpacer_3">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -231,7 +231,7 @@
    <item>
     <spacer>
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/preferences/pathmachinepage.ui
+++ b/src/preferences/pathmachinepage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>403</width>
+    <width>421</width>
     <height>350</height>
    </rect>
   </property>
@@ -71,6 +71,9 @@
       </item>
       <item row="2" column="1" colspan="2">
        <widget class="QDoubleSpinBox" name="acceptBestRelativeDoubleSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="decimals">
          <number>4</number>
         </property>
@@ -81,6 +84,9 @@
       </item>
       <item row="4" column="1" colspan="2">
        <widget class="QDoubleSpinBox" name="newRoomPenaltyDoubleSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="decimals">
          <number>4</number>
         </property>
@@ -105,6 +111,9 @@
       </item>
       <item row="5" column="1" colspan="2">
        <widget class="QDoubleSpinBox" name="correctPositionBonusDoubleSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="decimals">
          <number>4</number>
         </property>
@@ -122,6 +131,9 @@
       </item>
       <item row="3" column="1" colspan="2">
        <widget class="QDoubleSpinBox" name="acceptBestAbsoluteDoubleSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="decimals">
          <number>4</number>
         </property>
@@ -132,6 +144,9 @@
       </item>
       <item row="1" column="1">
        <widget class="QSpinBox" name="matchingToleranceSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="maximum">
          <number>100</number>
         </property>
@@ -146,6 +161,9 @@
       </item>
       <item row="0" column="1">
        <widget class="QSpinBox" name="maxPaths">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="maximum">
          <number>100000</number>
         </property>
@@ -167,6 +185,9 @@
       </item>
       <item row="6" column="1">
        <widget class="QDoubleSpinBox" name="multipleConnectionsPenaltyDoubleSpinBox">
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
         <property name="decimals">
          <number>4</number>
         </property>
@@ -181,7 +202,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>


### PR DESCRIPTION
This PR addresses an issue where typing in the configuration dialog's search bar would cause it to lose keyboard focus. It also adds a user-friendly "No results" message when a search query yields no matches.

Key changes:
- Modified `ConfigDialog::slot_search` to explicitly call `setFocus()` on the search bar after widgets are hidden/shown.
- Wrapped the search logic in `setUpdatesEnabled(false/true)` to eliminate flickering.
- Introduced `m_noResultsLabel` in `ConfigDialog` to display a styled message when no settings match the search criteria.
- Ensured `m_suppressScrollSync` is active during search to prevent unwanted scrolling while the layout reorganizes.
- Refactored `ConfigDialog` by removing unimplemented `createIcons()` and `updateSearch()` methods.

---
*PR created automatically by Jules for task [4110590009104172215](https://jules.google.com/task/4110590009104172215) started by @nschimme*

## Summary by Sourcery

Improve the configuration dialog search experience and messaging when no settings match a query.

New Features:
- Add a dedicated "no matches found" label in the configuration dialog that is shown when a search yields no results.

Bug Fixes:
- Preserve keyboard focus on the configuration dialog search bar after search-triggered layout updates.
- Prevent unwanted scrolling and UI flicker while filtering configuration pages via the search field.

Enhancements:
- Remove unused configuration dialog helper methods that were never implemented.