### PR TITLE
OSC 8 Hyperlink Support

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,43 +1,38 @@
-name: build-appimage
+name : build
+       - appimage
 
-on:
-  push:
-    tags:
-    - 'v*'
-    branches:
-    - master
-  pull_request:
-  workflow_dispatch:
+           on : push : tags : -'v*' branches : -master pull_request : workflow_dispatch :
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
+    concurrency : group : ${{github.workflow}}
+                          - $
+{
+    {
+        github.event_name == 'pull_request' && github.head_ref || github.sha
+    }
+}
+cancel - in
+        - progress : true
 
-jobs:
-  build-appimage:
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        submodules: true
+                     jobs : build
+                            - appimage : runs
+                                         - on
+    : ubuntu
+      - 22.04 steps : -uses : actions / checkout @v6 with : fetch
+      - depth : 0 submodules : true
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        create-symlink: true
-        key: ${{ github.job }}
+                               - name : ccache uses : hendrikmuhs / ccache
+                               - action @v1 .2 with : create
+                                                      - symlink : true key : ${{github.job}}
 
-    - name: Cache KDE Neon GPG key
-      id: cache-kde-neon-key
-      uses: actions/cache@v5
-      with:
-        path: kde-neon.gpg
-        key: kde-neon-key-v1
+                                                                             - name
+    : Cache KDE Neon GPG key id : cache
+                                  - kde
+                                  - neon
+                                  - key uses : actions / cache @v5 with : path : kde
+                                  - neon.gpg key
+    : kde - neon - key - v1
 
-    - name: Add KDE Neon repository
-      run: |
-        if [ ! -f kde-neon.gpg ]; then
+                                  - name : Add KDE Neon repository run : | if[!-f kde - neon.gpg]; then
           curl -sSfL --retry 5 --retry-delay 5 https://archive.neon.kde.org/public.key | gpg --dearmor --yes -o kde-neon.gpg
         fi
         sudo cp kde-neon.gpg /usr/share/keyrings/kde-neon.gpg
@@ -48,7 +43,7 @@ jobs:
       run: |
         sudo apt install -y \
           qt6-base-dev qt6-base-dev-tools libqt6opengl6-dev libqt6websockets6-dev \
-          qt6-multimedia-dev libqt6multimedia6 libqt6svg6-dev \
+          qt6-multimedia-dev libqt6multimedia6 qt6-svg-dev \
           libgl1-mesa-dev qt6-wayland qtkeychain-qt6-dev build-essential mold git \
           zlib1g-dev libssl-dev wget zsync fuse file cmake libxcb-cursor-dev
 
@@ -79,10 +74,10 @@ jobs:
         make -j$(getconf _NPROCESSORS_ONLN)
         make DESTDIR=appdir install
 
-        # Extract version from CPackConfig.cmake
+#Extract version from CPackConfig.cmake
         export VERSION=$(grep -i "SET(CPACK_PACKAGE_VERSION " CPackConfig.cmake | cut -d\" -f 2)
 
-        # Configure linuxdeploy and make sure the plugin can be found
+#Configure linuxdeploy and make sure the plugin can be found
         export PATH=$PATH:$(pwd)/..
         export UPDATE_INFORMATION="gh-releases-zsync|MUME|MMapper|latest|MMapper-*-x86_64.AppImage.zsync"
         export QMAKE=/usr/bin/qmake6
@@ -95,7 +90,7 @@ jobs:
             exit 1
         fi
 
-        # Run linuxdeploy
+#Run linuxdeploy
         ../linuxdeploy-x86_64.AppImage --appdir appdir --output appimage \
           --executable appdir/usr/bin/mmapper \
           --desktop-file appdir/usr/share/applications/org.mume.MMapper.desktop \

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         sudo apt install -y \
           qt6-base-dev qt6-base-dev-tools libqt6opengl6-dev libqt6websockets6-dev \
-          qt6-multimedia-dev libqt6multimedia6 qt6-svg-dev \
+          qt6-multimedia-dev libqt6multimedia6 libqt6svg6-dev \
           libgl1-mesa-dev qt6-wayland qtkeychain-qt6-dev build-essential mold git \
           zlib1g-dev libssl-dev wget zsync fuse file cmake libxcb-cursor-dev
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,50 +1,59 @@
-name: build-release
+name : build
+       - release
 
-on:
-  push:
-    tags:
-    - 'v*'
-    branches:
-    - master
-  pull_request:
-  workflow_dispatch:
+           on : push : tags : -'v*' branches : -master pull_request : workflow_dispatch :
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
+    concurrency : group : ${{github.workflow}}
+                          - $
+{
+    {
+        github.event_name == 'pull_request' && github.head_ref || github.sha
+    }
+}
+cancel - in
+    - progress : true
 
-jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    continue-on-error: false
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2022, macos-15-intel, macos-15, ubuntu-24.04, ubuntu-24.04-arm]
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        submodules: true
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        create-symlink: ${{ runner.os != 'Windows' }}
-        key: ${{ github.job }}-${{ matrix.os }}
+                 jobs : build : runs
+                                - on : $
+{
+    {
+        matrix.os
+    }
+}
+continue - on - error : false strategy : fail
+                                         - fast : false matrix : os
+    : [windows - 2022, macos - 15 - intel, macos - 15, ubuntu - 24.04, ubuntu - 24.04 - arm] steps
+    : -uses : actions
+              / checkout @v6 with
+    : fetch - depth : 0 submodules : true
+                                     - name : ccache uses : hendrikmuhs / ccache
+                                     - action @v1 .2 with : create
+                                                            - symlink : $
+{
+    {
+        runner.os != 'Windows'
+    }
+}
+key : ${{github.job}} - $
+{
+    {
+        matrix.os
+    }
+}
         variant: ${{ matrix.compiler == 'msvc' && 'sccache' || 'ccache' }}
     - if: runner.os == 'Windows' || runner.os == 'macOS'
       uses: lukka/get-cmake@latest
     - if: runner.os == 'Windows'
       uses: ilammy/msvc-dev-cmd@v1
 
-    # Install Dependencies (Ubuntu)
+#Install Dependencies(Ubuntu)
     - if: runner.os == 'Linux'
       name: Install Packages for Ubuntu
       run: |
         sudo apt update -qq
         sudo apt install -y \
           qt6-base-dev qt6-base-dev-tools libqt6opengl6-dev libqt6websockets6-dev \
-          qt6-multimedia-dev libqt6multimedia6 libqt6svg6-dev \
+          qt6-multimedia-dev libqt6multimedia6 qt6-svg-dev \
           libgl1-mesa-dev qtkeychain-qt6-dev build-essential cmake ninja-build mold git \
           zlib1g-dev libssl-dev
         echo "QMAKESPEC=linux-g++" >> $GITHUB_ENV
@@ -52,7 +61,7 @@ jobs:
         echo "CXX=g++-12" >> $GITHUB_ENV
         echo "MMAPPER_CMAKE_EXTRA=-DUSE_MOLD=true -DPACKAGE_TYPE=Deb" >> $GITHUB_ENV
 
-    # Install Dependencies (Mac)
+#Install Dependencies(Mac)
     - if: runner.os == 'macOS'
       name: Install Qt for Mac
       uses: jurplel/install-qt-action@v4
@@ -66,7 +75,7 @@ jobs:
       run: |
         echo "MMAPPER_CMAKE_EXTRA=-DCMAKE_PREFIX_PATH=$QT_ROOT_DIR -DPACKAGE_TYPE=Dmg" >> $GITHUB_ENV
 
-    # Install Dependencies (Windows)
+#Install Dependencies(Windows)
     - if: runner.os == 'Windows'
       name: Install Qt for Windows
       uses: jurplel/install-qt-action@v4
@@ -77,7 +86,7 @@ jobs:
         cache: true
         modules: 'qtwebsockets qtmultimedia'
 
-    # Build
+#Build
     - if: runner.os == 'Windows'
       name: Build MMapper for Windows
       shell: pwsh
@@ -87,7 +96,12 @@ jobs:
         cd build
         cmake --version
         $packageDir = ($env:GITHUB_WORKSPACE -replace '\\', '/') + "/artifact"
-        $launcher = ${{ matrix.compiler == 'msvc' && 'sccache' || 'ccache' }}
+        $launcher = $
+        {
+            {
+                matrix.compiler == 'msvc' && 'sccache' || 'ccache'
+            }
+        }
         cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -G 'Ninja' -DCPACK_PACKAGE_DIRECTORY="$packageDir" -DCMAKE_PREFIX_PATH=$env:QT_ROOT_DIR -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -DPACKAGE_TYPE=Nsis -DCMAKE_C_COMPILER_LAUNCHER="$launcher" -DCMAKE_CXX_COMPILER_LAUNCHER="$launcher" -S .. || exit -1
         cmake --build . --parallel
     - if: runner.os == 'Linux' || runner.os == 'macOS'
@@ -99,7 +113,7 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -G 'Ninja' -DCPACK_PACKAGE_DIRECTORY=${{ github.workspace }}/artifact $MMAPPER_CMAKE_EXTRA -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -S .. || exit -1
         cmake --build . --parallel
 
-    # Package
+#Package
     - name: Package MMapper
       run: cd build && cpack
     - if: runner.os == 'Linux'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -44,7 +44,7 @@ jobs:
         sudo apt update -qq
         sudo apt install -y \
           qt6-base-dev qt6-base-dev-tools libqt6opengl6-dev libqt6websockets6-dev \
-          qt6-multimedia-dev libqt6multimedia6 qt6-svg-dev \
+          qt6-multimedia-dev libqt6multimedia6 libqt6svg6-dev \
           libgl1-mesa-dev qtkeychain-qt6-dev build-essential cmake ninja-build mold git \
           zlib1g-dev libssl-dev
         echo "QMAKESPEC=linux-g++" >> $GITHUB_ENV

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -57,7 +57,7 @@ jobs:
         sudo apt update -qq
         sudo apt install -y \
           qt6-base-dev qt6-base-dev-tools libqt6opengl6-dev libqt6websockets6-dev \
-          qt6-multimedia-dev libqt6multimedia6 qt6-svg-dev \
+          qt6-multimedia-dev libqt6multimedia6 libqt6svg6-dev \
           libgl1-mesa-dev qtkeychain-qt6-dev build-essential cmake ninja-build mold git \
           zlib1g-dev libssl-dev
     - if: runner.os == 'Linux' && matrix.compiler == 'gcc'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,63 +1,69 @@
-name: build-test
+name : build
+       - test
 
-on:
-  push:
-    branches:
-    - master
-  pull_request:
-  workflow_dispatch:
+           on : push : branches : -master pull_request : workflow_dispatch :
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
+    concurrency : group : ${{github.workflow}}
+                          - $
+{
+    {
+        github.event_name == 'pull_request' && github.head_ref || github.sha
+    }
+}
+cancel - in
+    - progress : true
 
-jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    continue-on-error: false
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2022, macos-latest, ubuntu-latest]
-        compiler: ['clang', 'gcc', 'msvc']
-        exclude:
-        - os: ubuntu-latest
-          compiler: 'msvc'
-        - os: macos-latest
-          compiler: 'gcc'
-        - os: macos-latest
-          compiler: 'msvc'
-        - os: windows-2022
-          compiler: 'clang'
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        submodules: true
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        create-symlink: ${{ runner.os != 'Windows' }}
-        key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.compiler }}
+                 jobs : build : runs
+                                - on : $
+{
+    {
+        matrix.os
+    }
+}
+continue - on - error : false permissions : id - token : write contents : read strategy : fail
+                                                                                          - fast
+    : false matrix : os : [windows - 2022, macos - latest, ubuntu - latest] compiler
+    : ['clang', 'gcc', 'msvc'] exclude : -os : ubuntu
+                                               - latest compiler : 'msvc'
+                                                                   - os : macos
+                                                                          - latest compiler : 'gcc'
+                                                                                              - os
+    : macos
+      - latest compiler : 'msvc'
+                          - os
+    : windows
+      - 2022 compiler : 'clang' steps : -uses : actions / checkout @v6 with : fetch
+      - depth : 0 submodules : true
+                               - name : ccache uses : hendrikmuhs / ccache
+                               - action @v1 .2 with : create
+                                                      - symlink : $
+{
+    {
+        runner.os != 'Windows'
+    }
+}
+key : ${{github.job}} - ${{matrix.os}} - $
+{
+    {
+        matrix.compiler
+    }
+}
         variant: ${{ matrix.compiler == 'msvc' && 'sccache' || 'ccache' }}
     - if: runner.os == 'Windows' || runner.os == 'macOS'
       uses: lukka/get-cmake@latest
     - if: matrix.compiler == 'msvc'
       uses: ilammy/msvc-dev-cmd@v1
 
-      #
-      # Install Packages (Ubuntu)
-      #
+#
+#Install Packages(Ubuntu)
+#
     - if: runner.os == 'Linux'
       name: Install Packages for Ubuntu
       run: |
         sudo apt update -qq
         sudo apt install -y \
           qt6-base-dev qt6-base-dev-tools libqt6opengl6-dev libqt6websockets6-dev \
-          qt6-multimedia-dev libqt6multimedia6 libqt6svg6-dev \
+          qt6-multimedia-dev libqt6multimedia6 qt6-svg-dev \
           libgl1-mesa-dev qtkeychain-qt6-dev build-essential cmake ninja-build mold git \
           zlib1g-dev libssl-dev
     - if: runner.os == 'Linux' && matrix.compiler == 'gcc'
@@ -80,9 +86,9 @@ jobs:
         echo "STYLE=true" >> $GITHUB_ENV
         echo "MMAPPER_CMAKE_EXTRA=-DUSE_MOLD=true -DPACKAGE_TYPE=Deb" >> $GITHUB_ENV
 
-      #
-      # Install Packages (Mac)
-      #
+#
+#Install Packages(Mac)
+#
     - if: runner.os == 'macOS'
       name: Install Qt for Mac
       uses: jurplel/install-qt-action@v4
@@ -97,9 +103,9 @@ jobs:
         brew install lcov
         echo "MMAPPER_CMAKE_EXTRA=-DCMAKE_PREFIX_PATH=$QT_ROOT_DIR -DUSE_CODE_COVERAGE=true -DPACKAGE_TYPE=Dmg" >> $GITHUB_ENV
 
-      #
-      # Install Packages (Windows)
-      #
+#
+#Install Packages(Windows)
+#
     - if: runner.os == 'Windows' && matrix.compiler == 'msvc'
       name: Install Qt for Windows (MSVC)
       uses: jurplel/install-qt-action@v4
@@ -120,9 +126,9 @@ jobs:
         modules: 'qtwebsockets qtmultimedia'
         tools: 'tools_mingw1310'
 
-      #
-      # Build
-      #
+#
+#Build
+#
     - if: runner.os == 'Windows'
       name: Build MMapper for Windows
       shell: pwsh
@@ -136,7 +142,12 @@ jobs:
           $env:PATH = "C:\Qt\Tools\mingw1310_64\bin;$env:PATH"
         }
         $packageDir = ($env:GITHUB_WORKSPACE -replace '\\', '/') + "/artifact"
-        $launcher = ${{ matrix.compiler == 'msvc' && 'sccache' || 'ccache' }}
+        $launcher = $
+        {
+            {
+                matrix.compiler == 'msvc' && 'sccache' || 'ccache'
+            }
+        }
         cmake -DCMAKE_BUILD_TYPE=Debug -G 'Ninja' -DWITH_MAP=OFF -DCPACK_PACKAGE_DIRECTORY="$packageDir" -DCMAKE_PREFIX_PATH=$env:QT_ROOT_DIR -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -DPACKAGE_TYPE=Nsis -DCMAKE_C_COMPILER_LAUNCHER="$launcher" -DCMAKE_CXX_COMPILER_LAUNCHER="$launcher" -S .. || exit -1
         cmake --build . --parallel
     - if: runner.os == 'Linux' || runner.os == 'macOS'
@@ -148,9 +159,9 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Debug -G 'Ninja' -DWITH_MAP=OFF -DCPACK_PACKAGE_DIRECTORY=${{ github.workspace }}/artifact $MMAPPER_CMAKE_EXTRA -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -S .. || exit -1
         cmake --build . --parallel
 
-      #
-      # Run tests
-      #
+#
+#Run tests
+#
     - name: Run unit tests
       run: cd build && ctest -V --no-compress-output -T test --output-junit ../ctest-to-junit-results.xml
       env:
@@ -159,28 +170,47 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@v7
       with:
-        name: test-results ${{ matrix.os }} ${{ matrix.compiler }}
+        name: test-results $
+        {
+            {
+                matrix.os
+            }
+        }
+        $
+        {
+            {
+                matrix.compiler
+            }
+        }
         path: ctest-to-junit-results.xml
     - if: env.COVERAGE == 'true' && !cancelled()
       name: Run lcov
       run: |
         lcov --version
         gcov --version
-        lcov --directory build --capture --base-directory $(pwd) --output-file build/coverage.info --gcov-tool ${GCOV_TOOL:-gcov} --no-external --ignore-errors mismatch --ignore-errors negative --ignore-errors gcov --ignore-errors inconsistent --rc geninfo_unexecuted_blocks=1
-        lcov --list build/coverage.info --ignore-errors inconsistent
-        lcov --remove build/coverage.info '*/tests/*' '*/external/*' '*/build/*' --output-file build/filtered.info --ignore-errors unused --ignore-errors inconsistent
-    - if: env.COVERAGE == 'true' && !cancelled()
-      uses: codecov/codecov-action@v6
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./build/filtered.info
-        fail_ci_if_error: false
-      continue-on-error: true
-    - if: env.STYLE == 'true'
-      name: Text Encoding Sanity Check
-      run: |
-        cd build
-        if  [[ -n $(nm -C src/mmapper | grep -w 'QString::\(to\|from\)StdString') ]]; then
+        lcov --directory build --capture --base-directory $(pwd) --output-file build/coverage.info --gcov-tool $
+        {
+        GCOV_TOOL:
+            -gcov
+        }
+        --no - external-- ignore - errors mismatch-- ignore - errors negative-- ignore
+            - errors gcov-- ignore - errors inconsistent-- rc geninfo_unexecuted_blocks
+            = 1 lcov-- list build / coverage.info-- ignore
+                      - errors inconsistent lcov-- remove build
+                            / coverage.info '*/tests/*' '*/external/*' '*/build/*' --output
+                      - file build / filtered.info-- ignore - errors unused-- ignore
+                      - errors inconsistent - if : env.COVERAGE
+                  == 'true'
+              && !cancelled() uses : codecov / codecov - action @v6 with : token : $
+        {
+            {
+                secrets.CODECOV_TOKEN
+            }
+        }
+        files :./ build / filtered.info fail_ci_if_error : false continue - on
+                    - error : true - if : env.STYLE
+                == 'true' name : Text Encoding Sanity Check run
+            : | cd build if[[-n $(nm - C src / mmapper | grep - w 'QString::\(to\|from\)StdString')]]; then
           nm -C src/mmapper | grep -w 'QString::\(to\|from\)StdString'
           echo
           echo
@@ -193,9 +223,9 @@ jobs:
           exit -1
         fi
 
-      #
-      # Package
-      #
+#
+#Package
+#
     - name: Package MMapper
       run: cd build && cpack
     - if: runner.os == 'Linux'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if(Qt6Core_FOUND)
     if(Qt6Core_VERSION VERSION_LESS 6.4.0)
         message(FATAL_ERROR "Minimum supported Qt version is 6.4")
     endif()
-    add_definitions(/DQT_DISABLE_DEPRECATED_UP_TO=0x060400)
+    add_compile_definitions(QT_DISABLE_DEPRECATED_UP_TO=0x060400)
 endif()
 
 if(Qt6OpenGL_FOUND)

--- a/src/client/ClientWidget.cpp
+++ b/src/client/ClientWidget.cpp
@@ -279,7 +279,7 @@ bool ClientWidget::isUsingClient() const
 
 void ClientWidget::displayReconnectHint()
 {
-    constexpr const auto whiteOnCyan = getRawAnsi(AnsiColor16Enum::white, AnsiColor16Enum::cyan);
+    const auto whiteOnCyan = getRawAnsi(AnsiColor16Enum::white, AnsiColor16Enum::cyan);
     std::stringstream oss;
     AnsiOstream aos{oss};
     aos.writeWithColor(whiteOnCyan, "\n\n\nPress return to reconnect.\n");

--- a/src/client/ClientWidget.cpp
+++ b/src/client/ClientWidget.cpp
@@ -167,6 +167,8 @@ void ClientWidget::initDisplayWidget()
         }
         void virt_returnFocusToInput() final { getSelf().getInput().setFocus(); }
         void virt_showPreview(bool visible) final { getSelf().getPreview().setVisible(visible); }
+        void virt_sendUserInput(const QString &msg) final { getSelf().getTelnet().sendToMud(msg); }
+        void virt_setPrompt(const QString &msg) final { getSelf().getInput().setPrompt(msg); }
     };
     auto &out = m_pipeline.outputs.displayWidgetOutputs;
     out = std::make_unique<LocalDisplayWidgetOutputs>(*this);

--- a/src/client/displaywidget.cpp
+++ b/src/client/displaywidget.cpp
@@ -115,6 +115,29 @@ DisplayWidget::DisplayWidget(QWidget *const parent)
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
+    viewport()->installEventFilter(this);
+    viewport()->setMouseTracking(true);
+
+    connect(this, &DisplayWidget::anchorClicked, this, [this](const QUrl &url) {
+        QString scheme = url.scheme();
+        if (scheme == u"send") {
+            getOutput().sendUserInput(url.path() + u"\n");
+        } else if (scheme == u"prompt") {
+            // Pre-fill input widget
+            getOutput().setPrompt(url.path());
+        } else if (scheme == u"file") {
+            // Security check for file:// URIs
+            QString host = url.host();
+            if (host.isEmpty() || host == u"localhost" || host == QHostInfo::localHostName()) {
+                QDesktopServices::openUrl(url);
+            } else {
+                qWarning() << "OSC 8: Ignored file URI with non-local host:" << host;
+            }
+        } else {
+            QDesktopServices::openUrl(url);
+        }
+    });
+
     connect(this, &DisplayWidget::copyAvailable, this, [this](const bool available) {
         m_canCopy = available;
         if (available) {
@@ -220,6 +243,50 @@ void DisplayWidget::keyPressEvent(QKeyEvent *event)
     }
 }
 
+bool DisplayWidget::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == viewport()) {
+        if (event->type() == QEvent::MouseMove) {
+            QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+            QTextCursor cursor = cursorForPosition(mouseEvent->pos());
+            QString urlId = cursor.charFormat().property(AnsiTextHelper::URL_ID_PROPERTY).toString();
+            updateHoverUnderline(urlId);
+        } else if (event->type() == QEvent::Leave) {
+            updateHoverUnderline({});
+        }
+    }
+    return base::eventFilter(watched, event);
+}
+
+void DisplayWidget::updateHoverUnderline(const QString &urlId)
+{
+    if (urlId == m_lastUrlId) {
+        return;
+    }
+    m_lastUrlId = urlId;
+
+    QList<QTextEdit::ExtraSelection> selections;
+    if (!urlId.isEmpty()) {
+        QTextDocument *doc = document();
+        for (QTextBlock it = doc->begin(); it != doc->end(); it = it.next()) {
+            for (QTextBlock::iterator fragmentIt = it.begin(); !fragmentIt.atEnd(); ++fragmentIt) {
+                QTextFragment fragment = fragmentIt.fragment();
+                if (fragment.isValid()
+                    && fragment.charFormat().property(AnsiTextHelper::URL_ID_PROPERTY).toString()
+                           == urlId) {
+                    QTextEdit::ExtraSelection sel;
+                    sel.cursor = QTextCursor(fragment);
+                    sel.format = fragment.charFormat();
+                    sel.format.setFontUnderline(true);
+                    sel.format.setUnderlineStyle(QTextCharFormat::SingleUnderline);
+                    selections.append(sel);
+                }
+            }
+        }
+    }
+    setExtraSelections(selections);
+}
+
 void setDefaultFormat(QTextCharFormat &format, const FontDefaults &defaults)
 {
     format.setFont(defaults.serverOutputFont);
@@ -235,7 +302,8 @@ void AnsiTextHelper::displayText(const QStringView input_str)
 {
     // ANSI codes are formatted as the following:
     // escape + [ + n1 (+ n2) + m
-    static const QRegularExpression ansi_regex{R"regex(\x1B[^A-Za-z\x1B]*[A-Za-z]?)regex"};
+    // or OSC sequences: escape + ] + ... + (escape + \ or bell)
+    static const QRegularExpression ansi_regex{R"regex(\x1B(?:\[[[:digit:];:]*[[:alpha:]]?|\][^\x1B\x07]*(?:\x1B\\|\x07)))regex"};
     static const QRegularExpression url_regex{
         R"regex(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*))regex"};
 
@@ -338,10 +406,8 @@ void AnsiTextHelper::displayText(const QStringView input_str)
         input_str,
         [this, &add_raw](const QStringView ansiStr) {
             assert(!ansiStr.isEmpty() && ansiStr.front() == char_consts::C_ESC);
-            if (mmqt::isAnsiColor(ansiStr)) {
-                if (auto optNewColor = mmqt::parseAnsiColor(currentAnsi, ansiStr)) {
-                    currentAnsi = updateFormat(format, defaults, currentAnsi, *optNewColor);
-                }
+            if (auto optNewColor = mmqt::parseAnsiColor(currentAnsi, ansiStr)) {
+                currentAnsi = updateFormat(format, defaults, currentAnsi, *optNewColor);
             } else if (mmqt::isAnsiEraseLine(ansiStr)) {
                 cursor.movePosition(QTextCursor::Left, QTextCursor::MoveAnchor, 1);
                 cursor.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
@@ -547,6 +613,16 @@ RawAnsi updateFormat(QTextCharFormat &format,
     format.setBackground(bg);
     format.setForeground(fg);
     format.setUnderlineColor(ul);
+
+    if (updated.url.isEmpty()) {
+        format.setAnchor(false);
+        format.setAnchorHref({});
+    } else {
+        format.setAnchor(true);
+        format.setAnchorHref(updated.url);
+    }
+    format.setProperty(AnsiTextHelper::URL_ID_PROPERTY, updated.urlId);
+
     return updated;
 }
 

--- a/src/client/displaywidget.cpp
+++ b/src/client/displaywidget.cpp
@@ -121,7 +121,7 @@ DisplayWidget::DisplayWidget(QWidget *const parent)
     connect(this, &DisplayWidget::anchorClicked, this, [this](const QUrl &url) {
         QString scheme = url.scheme();
         if (scheme == u"send") {
-            getOutput().sendUserInput(url.path() + u"\n");
+            getOutput().sendUserInput(url.path() + QStringLiteral("\n"));
         } else if (scheme == u"prompt") {
             // Pre-fill input widget
             getOutput().setPrompt(url.path());
@@ -275,7 +275,10 @@ void DisplayWidget::updateHoverUnderline(const QString &urlId)
                     && fragment.charFormat().property(AnsiTextHelper::URL_ID_PROPERTY).toString()
                            == urlId) {
                     QTextEdit::ExtraSelection sel;
-                    sel.cursor = QTextCursor(fragment);
+                    sel.cursor = QTextCursor(document());
+                    sel.cursor.setPosition(fragment.position());
+                    sel.cursor.setPosition(fragment.position() + fragment.length(),
+                                           QTextCursor::KeepAnchor);
                     sel.format = fragment.charFormat();
                     sel.format.setFontUnderline(true);
                     sel.format.setUnderlineStyle(QTextCharFormat::SingleUnderline);
@@ -303,7 +306,8 @@ void AnsiTextHelper::displayText(const QStringView input_str)
     // ANSI codes are formatted as the following:
     // escape + [ + n1 (+ n2) + m
     // or OSC sequences: escape + ] + ... + (escape + \ or bell)
-    static const QRegularExpression ansi_regex{R"regex(\x1B(?:\[[[:digit:];:]*[[:alpha:]]?|\][^\x1B\x07]*(?:\x1B\\|\x07)))regex"};
+    static const QRegularExpression ansi_regex{
+        R"regex(\x1B(?:\[[[:digit:];:]*[[:alpha:]]?|\][^\x1B\x07]*(?:\x1B\\|\x07)))regex"};
     static const QRegularExpression url_regex{
         R"regex(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*))regex"};
 

--- a/src/client/displaywidget.h
+++ b/src/client/displaywidget.h
@@ -10,6 +10,7 @@
 
 #include <QColor>
 #include <QFont>
+#include <QHostInfo>
 #include <QSize>
 #include <QString>
 #include <QTextBrowser>
@@ -45,6 +46,7 @@ NODISCARD extern RawAnsi updateFormat(QTextCharFormat &format,
 
 struct NODISCARD AnsiTextHelper final
 {
+    static constexpr const int URL_ID_PROPERTY = QTextFormat::UserProperty + 1;
     QTextEdit &textEdit;
     QTextCursor cursor;
     QTextCharFormat format;
@@ -84,12 +86,16 @@ public:
     }
     void returnFocusToInput() { virt_returnFocusToInput(); }
     void showPreview(bool visible) { virt_showPreview(visible); }
+    void sendUserInput(const QString &msg) { virt_sendUserInput(msg); }
+    void setPrompt(const QString &msg) { virt_setPrompt(msg); }
 
 private:
     virtual void virt_showMessage(const QString &msg, int timeout) = 0;
     virtual void virt_windowSizeChanged(int width, int height) = 0;
     virtual void virt_returnFocusToInput() = 0;
     virtual void virt_showPreview(bool visible) = 0;
+    virtual void virt_sendUserInput(const QString &msg) = 0;
+    virtual void virt_setPrompt(const QString &msg) = 0;
 };
 
 class NODISCARD_QOBJECT DisplayWidget final : public QTextBrowser
@@ -135,6 +141,11 @@ public:
 protected:
     void resizeEvent(QResizeEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+    void updateHoverUnderline(const QString &urlId);
+    QString m_lastUrlId;
 
 public slots:
     void slot_displayText(const QStringView str);

--- a/src/client/stackedinputwidget.cpp
+++ b/src/client/stackedinputwidget.cpp
@@ -145,6 +145,13 @@ void StackedInputWidget::gotMultiLineInput(const QString &input)
     displayInputMessage(input);
 }
 
+void StackedInputWidget::setPrompt(const QString &msg)
+{
+    getInputWidget().setPlainText(msg);
+    getInputWidget().moveCursor(QTextCursor::End);
+    getInputWidget().setFocus();
+}
+
 void StackedInputWidget::gotPasswordInput(const QString &input)
 {
     getOutput().sendUserInput(input + "\n");

--- a/src/client/stackedinputwidget.h
+++ b/src/client/stackedinputwidget.h
@@ -117,6 +117,7 @@ public:
     void requestPassword();
     void setEchoMode(EchoModeEnum echoMode);
     EchoModeEnum getEchoMode() const { return m_echoMode; }
+    void setPrompt(const QString &msg);
 
 private:
     void gotMultiLineInput(const QString &);

--- a/src/clock/mumeclock.cpp
+++ b/src/clock/mumeclock.cpp
@@ -158,7 +158,11 @@ void MumeClock::parseMumeTime(const QString &mumeTime, const int64_t secsSinceEp
         // 3 pm on Highday, the 18th of Halimath, year 3030 of the Third Age.
         static const QRegularExpression rx(
             R"(^(\d+)(?::\d{2})?\W*(am|pm) on (\w+), the (\d+).{2} of (\w+), year (\d+) of the Third Age.$)");
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+        auto match = rx.matchView(mumeTime);
+#else
         auto match = rx.match(mumeTime);
+#endif
         if (!match.hasMatch()) {
             return;
         }
@@ -187,7 +191,11 @@ void MumeClock::parseMumeTime(const QString &mumeTime, const int64_t secsSinceEp
         // "Highday, the 18th of Halimath, year 3030 of the Third Age."
         static const QRegularExpression rx(
             R"(^(\w+), the (\d+).{2} of (\w+), year (\d+) of the Third Age.$)");
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+        auto match = rx.matchView(mumeTime);
+#else
         auto match = rx.match(mumeTime);
+#endif
         if (!match.hasMatch()) {
             return;
         }
@@ -335,7 +343,11 @@ void MumeClock::parseClockTime(const QString &clockTime, const int64_t secsSince
 {
     // The current time is 5:23pm.
     static const QRegularExpression rx(R"(^The current time is (\d+):(\d+)\W*(am|pm).$)");
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    auto match = rx.matchView(clockTime);
+#else
     auto match = rx.match(clockTime);
+#endif
     if (!match.hasMatch()) {
         return;
     }

--- a/src/clock/mumeclock.cpp
+++ b/src/clock/mumeclock.cpp
@@ -18,6 +18,7 @@
 #include <QObject>
 #include <QRegularExpression>
 #include <QString>
+#include <QtGlobal>
 
 namespace { // anonymous
 

--- a/src/global/AnsiTextUtils.cpp
+++ b/src/global/AnsiTextUtils.cpp
@@ -26,6 +26,7 @@
 
 #include <QRegularExpression>
 #include <QString>
+#include <QtGlobal>
 
 static const volatile bool verbose_debugging = false;
 static constexpr const int ANSI_RESET = 0;

--- a/src/global/AnsiTextUtils.cpp
+++ b/src/global/AnsiTextUtils.cpp
@@ -73,7 +73,8 @@ static constexpr const std::array<int, 24> ansi_greys24{
 namespace mmqt {
 
 /* visible */
-const QRegularExpression weakAnsiRegex(R"(\x1B(?:\[[[:digit:];:]*[[:alpha:]]?|\][^\x1B\x07]*(?:\x1B\\|\x07)))");
+const QRegularExpression weakAnsiRegex(
+    R"(\x1B(?:\[[[:digit:];:]*[[:alpha:]]?|\][^\x1B\x07]*(?:\x1B\\|\x07)))");
 
 } // namespace mmqt
 

--- a/src/global/AnsiTextUtils.cpp
+++ b/src/global/AnsiTextUtils.cpp
@@ -73,7 +73,7 @@ static constexpr const std::array<int, 24> ansi_greys24{
 namespace mmqt {
 
 /* visible */
-const QRegularExpression weakAnsiRegex(R"(\x1B\[?[[:digit:];:]*[[:alpha:]]?)");
+const QRegularExpression weakAnsiRegex(R"(\x1B(?:\[[[:digit:];:]*[[:alpha:]]?|\][^\x1B\x07]*(?:\x1B\\|\x07)))");
 
 } // namespace mmqt
 
@@ -1701,6 +1701,45 @@ bool isAnsiColor(QStringView ansi)
     return true;
 }
 
+static bool isOsc8(QStringView ansi)
+{
+    return ansi.startsWith(u"\x1B]8;") && (ansi.endsWith(u"\x1B\\") || ansi.endsWith(u"\x07"));
+}
+
+static void parseOsc8(RawAnsi &next, QStringView ansi)
+{
+    // strip ESC ] 8 ; and terminator
+    QStringView content = ansi.mid(4);
+    if (ansi.endsWith(u"\x1B\\")) {
+        content = content.left(content.length() - 2);
+    } else {
+        content = content.left(content.length() - 1);
+    }
+
+    // content is now "params;URI"
+    int semi = content.indexOf(u';');
+    if (semi < 0) {
+        // Invalid, but we'll clear the URL just in case this was meant to be a closer
+        next.url.clear();
+        next.urlId.clear();
+        return;
+    }
+
+    QStringView params = content.left(semi);
+    QStringView uri = content.mid(semi + 1);
+
+    next.url = uri.toString();
+    next.urlId.clear();
+
+    // parse id from params "id=xxx:foo=bar"
+    for (auto param : params.split(u':')) {
+        if (param.startsWith(u"id=")) {
+            next.urlId = param.mid(3).toString();
+            break;
+        }
+    }
+}
+
 bool isAnsiColor(const QString &ansi)
 {
     return isAnsiColor(QStringView{ansi});
@@ -1831,6 +1870,12 @@ void AnsiColorParser::for_each(QStringView ansi) const
 
 std::optional<RawAnsi> parseAnsiColor(const RawAnsi before, const QStringView ansi)
 {
+    if (isOsc8(ansi)) {
+        RawAnsi next = before;
+        parseOsc8(next, ansi);
+        return next;
+    }
+
     if (!isAnsiColor(ansi)) {
         return std::nullopt;
     }
@@ -2000,6 +2045,26 @@ AnsiStringToken AnsiTokenizer::Iterator::getCurrent()
 
 AnsiTokenizer::Iterator::size_type AnsiTokenizer::Iterator::skip_ansi() const
 {
+    if (m_str.size() >= 2 && m_str[1] == u']') {
+        // OSC sequence: ESC ] ... (ST or BEL)
+        qsizetype pos = 2;
+        const qsizetype len = m_str.size();
+        while (pos < len) {
+            if (m_str[pos] == char_consts::C_ALERT) {
+                return pos + 1;
+            }
+            if (m_str[pos] == char_consts::C_ESC && pos + 1 < len && m_str[pos + 1] == u'\\') {
+                return pos + 2;
+            }
+            if (m_str[pos] == char_consts::C_ESC) {
+                // Nested ESC is not expected in OSC
+                return pos;
+            }
+            pos++;
+        }
+        return len; // Unterminated
+    }
+
     // hack to avoid having to have two separate stop return values
     // (one to stop before current value, and one to include it)
     bool sawLetter = false;
@@ -2560,6 +2625,28 @@ void testAnsiTextUtils()
 
     test_itu();
     test_ansi_parse();
+
+    {
+        // OSC 8 parsing tests
+        RawAnsi base;
+        auto opt = mmqt::parseAnsiColor(base, u"\x1B]8;;http://example.com\x1B\\");
+        TEST_ASSERT(opt.has_value());
+        TEST_ASSERT(opt->url == u"http://example.com");
+        TEST_ASSERT(opt->urlId.isEmpty());
+
+        opt = mmqt::parseAnsiColor(base, u"\x1B]8;id=123;https://mudlet.org\x07");
+        TEST_ASSERT(opt.has_value());
+        TEST_ASSERT(opt->url == u"https://mudlet.org");
+        TEST_ASSERT(opt->urlId == u"123");
+
+        // Closer
+        RawAnsi withUrl;
+        withUrl.url = QStringLiteral("something");
+        opt = mmqt::parseAnsiColor(withUrl, u"\x1B]8;;\x1B\\");
+        TEST_ASSERT(opt.has_value());
+        TEST_ASSERT(opt->url.isEmpty());
+        TEST_ASSERT(opt->urlId.isEmpty());
+    }
 }
 
 } // namespace test

--- a/src/global/AnsiTextUtils.cpp
+++ b/src/global/AnsiTextUtils.cpp
@@ -1718,7 +1718,7 @@ static void parseOsc8(RawAnsi &next, QStringView ansi)
     }
 
     // content is now "params;URI"
-    int semi = content.indexOf(u';');
+    const qsizetype semi = content.indexOf(u';');
     if (semi < 0) {
         // Invalid, but we'll clear the URL just in case this was meant to be a closer
         next.url.clear();

--- a/src/global/AnsiTextUtils.h
+++ b/src/global/AnsiTextUtils.h
@@ -422,10 +422,7 @@ public:
 
 public:
 #define X_DECL_ACCESSORS(_number, _lower, _UPPER, _Snake) \
-    NODISCARD bool has##_Snake() const \
-    { \
-        return m_flags.contains(AnsiStyleFlagEnum::_Snake); \
-    } \
+    NODISCARD bool has##_Snake() const { return m_flags.contains(AnsiStyleFlagEnum::_Snake); } \
     void set##_Snake() { m_flags.insert(AnsiStyleFlagEnum::_Snake); } \
     void clear##_Snake() { m_flags.remove(AnsiStyleFlagEnum::_Snake); }
     XFOREACH_ANSI_STYLE_EXCEPT_UNDERLINE(X_DECL_ACCESSORS)

--- a/src/global/AnsiTextUtils.h
+++ b/src/global/AnsiTextUtils.h
@@ -327,17 +327,19 @@ struct NODISCARD RawAnsi final
     AnsiColorVariant fg;
     AnsiColorVariant bg;
     AnsiColorVariant ul;
+    QString url;
+    QString urlId;
 
 private:
     AnsiStyleFlags m_flags; // only bits 0..9 are used; the other 6 are reserved
     AnsiUnderlineStyleEnum m_underlineStyle = AnsiUnderlineStyleEnum::None;
 
 public:
-    constexpr RawAnsi() = default;
-    constexpr RawAnsi(const AnsiStyleFlags flags,
-                      const AnsiColorVariant fg_,
-                      const AnsiColorVariant bg_,
-                      const AnsiColorVariant ul_)
+    RawAnsi() = default;
+    RawAnsi(const AnsiStyleFlags flags,
+            const AnsiColorVariant fg_,
+            const AnsiColorVariant bg_,
+            const AnsiColorVariant ul_)
         : fg{fg_}
         , bg{bg_}
         , ul{ul_}
@@ -351,25 +353,25 @@ public:
     }
 
 public:
-    NODISCARD constexpr bool hasForegroundColor() const { return !fg.hasDefaultColor(); }
-    NODISCARD constexpr bool hasBackgroundColor() const { return !bg.hasDefaultColor(); }
-    NODISCARD constexpr bool hasUnderlineColor() const { return !ul.hasDefaultColor(); }
+    NODISCARD bool hasForegroundColor() const { return !fg.hasDefaultColor(); }
+    NODISCARD bool hasBackgroundColor() const { return !bg.hasDefaultColor(); }
+    NODISCARD bool hasUnderlineColor() const { return !ul.hasDefaultColor(); }
 
 public:
 #define X_DECL_WITH(_number, _lower, _UPPER, _Snake) \
-    NODISCARD constexpr RawAnsi with##_Snake() const \
+    NODISCARD RawAnsi with##_Snake() const \
     { \
         auto copy = *this; \
         copy.set##_Snake(); \
         return copy; \
     } \
-    NODISCARD constexpr RawAnsi without##_Snake() const \
+    NODISCARD RawAnsi without##_Snake() const \
     { \
         auto copy = *this; \
         copy.clear##_Snake(); \
         return copy; \
     } \
-    NODISCARD constexpr RawAnsi withToggled##_Snake() const \
+    NODISCARD RawAnsi withToggled##_Snake() const \
     { \
         auto copy = *this; \
         copy.toggle##_Snake(); \
@@ -379,25 +381,25 @@ public:
 #undef X_DECL_WITH
 
 public:
-    NODISCARD constexpr RawAnsi withForeground(const AnsiColorVariant var) const
+    NODISCARD RawAnsi withForeground(const AnsiColorVariant var) const
     {
         auto copy = *this;
         copy.fg = var;
         return copy;
     }
-    NODISCARD constexpr RawAnsi withBackground(const AnsiColorVariant var) const
+    NODISCARD RawAnsi withBackground(const AnsiColorVariant var) const
     {
         auto copy = *this;
         copy.bg = var;
         return copy;
     }
-    NODISCARD constexpr RawAnsi withUnderlineColor(const AnsiColorVariant var) const
+    NODISCARD RawAnsi withUnderlineColor(const AnsiColorVariant var) const
     {
         auto copy = *this;
         copy.ul = var;
         return copy;
     }
-    NODISCARD constexpr RawAnsi withUnderlineStyle(const AnsiUnderlineStyleEnum style) const
+    NODISCARD RawAnsi withUnderlineStyle(const AnsiUnderlineStyleEnum style) const
     {
         auto copy = *this;
         copy.setUnderlineStyle(style);
@@ -405,32 +407,32 @@ public:
     }
 
 public:
-    NODISCARD constexpr RawAnsi withForeground(const AnsiColor16Enum newColor) const
+    NODISCARD RawAnsi withForeground(const AnsiColor16Enum newColor) const
     {
         return withForeground(AnsiColorVariant{newColor});
     }
-    NODISCARD constexpr RawAnsi withBackground(const AnsiColor16Enum newColor) const
+    NODISCARD RawAnsi withBackground(const AnsiColor16Enum newColor) const
     {
         return withBackground(AnsiColorVariant{newColor});
     }
-    NODISCARD constexpr RawAnsi withUnderlineColor(const AnsiColor16Enum newColor) const
+    NODISCARD RawAnsi withUnderlineColor(const AnsiColor16Enum newColor) const
     {
         return withUnderlineColor(AnsiColorVariant{newColor});
     }
 
 public:
 #define X_DECL_ACCESSORS(_number, _lower, _UPPER, _Snake) \
-    NODISCARD constexpr bool has##_Snake() const \
+    NODISCARD bool has##_Snake() const \
     { \
         return m_flags.contains(AnsiStyleFlagEnum::_Snake); \
     } \
-    constexpr void set##_Snake() { m_flags.insert(AnsiStyleFlagEnum::_Snake); } \
-    constexpr void clear##_Snake() { m_flags.remove(AnsiStyleFlagEnum::_Snake); }
+    void set##_Snake() { m_flags.insert(AnsiStyleFlagEnum::_Snake); } \
+    void clear##_Snake() { m_flags.remove(AnsiStyleFlagEnum::_Snake); }
     XFOREACH_ANSI_STYLE_EXCEPT_UNDERLINE(X_DECL_ACCESSORS)
 #undef X_DECL_ACCESSORS
 
 #define X_DECL_ACCESSORS(_number, _lower, _UPPER, _Snake) \
-    constexpr void toggle##_Snake() \
+    void toggle##_Snake() \
     { \
         if (has##_Snake()) { \
             clear##_Snake(); \
@@ -442,19 +444,16 @@ public:
 #undef X_DECL_ACCESSORS
 
 public:
-    NODISCARD constexpr bool hasUnderline() const
-    {
-        return m_flags.contains(AnsiStyleFlagEnum::Underline);
-    }
-    constexpr void setUnderline() { setUnderlineStyle(AnsiUnderlineStyleEnum::Normal); }
-    constexpr void clearUnderline()
+    NODISCARD bool hasUnderline() const { return m_flags.contains(AnsiStyleFlagEnum::Underline); }
+    void setUnderline() { setUnderlineStyle(AnsiUnderlineStyleEnum::Normal); }
+    void clearUnderline()
     {
         m_flags.remove(AnsiStyleFlagEnum::Underline);
         m_underlineStyle = AnsiUnderlineStyleEnum::None;
     }
 
 public:
-    constexpr void setUnderlineStyle(const AnsiUnderlineStyleEnum style)
+    void setUnderlineStyle(const AnsiUnderlineStyleEnum style)
     {
         if (style == AnsiUnderlineStyleEnum::None) {
             clearUnderline();
@@ -465,14 +464,11 @@ public:
     }
 
 public:
-    NODISCARD constexpr AnsiStyleFlags getFlags() const { return m_flags; }
-    NODISCARD constexpr AnsiUnderlineStyleEnum getUnderlineStyle() const
-    {
-        return m_underlineStyle;
-    }
+    NODISCARD AnsiStyleFlags getFlags() const { return m_flags; }
+    NODISCARD AnsiUnderlineStyleEnum getUnderlineStyle() const { return m_underlineStyle; }
 
 public:
-    constexpr void setFlag(const AnsiStyleFlagEnum flag)
+    void setFlag(const AnsiStyleFlagEnum flag)
     {
 #define X_CASE(_number, _lower, _UPPER, _Snake) \
     case (AnsiStyleFlagEnum::_Snake): \
@@ -486,7 +482,7 @@ public:
         std::abort();
 #undef X_CASE
     }
-    constexpr void removeFlag(const AnsiStyleFlagEnum flag)
+    void removeFlag(const AnsiStyleFlagEnum flag)
     {
 #define X_CASE(_number, _lower, _UPPER, _Snake) \
     case (AnsiStyleFlagEnum::_Snake): \
@@ -502,12 +498,12 @@ public:
     }
 
 public:
-    NODISCARD constexpr bool operator==(const RawAnsi &rhs) const
+    NODISCARD bool operator==(const RawAnsi &rhs) const
     {
         return fg == rhs.fg && bg == rhs.bg && ul == rhs.ul && m_flags == rhs.m_flags
-               && m_underlineStyle == rhs.m_underlineStyle;
+               && m_underlineStyle == rhs.m_underlineStyle && url == rhs.url && urlId == rhs.urlId;
     }
-    NODISCARD constexpr bool operator!=(const RawAnsi &rhs) const { return !(rhs == *this); }
+    NODISCARD bool operator!=(const RawAnsi &rhs) const { return !(rhs == *this); }
 
 public:
     friend std::ostream &to_stream(std::ostream &os, const RawAnsi &raw);
@@ -517,15 +513,15 @@ public:
     }
 };
 
-NODISCARD static inline constexpr RawAnsi getRawAnsi(const AnsiColor16Enum fgColor)
+NODISCARD static inline RawAnsi getRawAnsi(const AnsiColor16Enum fgColor)
 {
     RawAnsi ansi;
     ansi.fg = AnsiColorVariant{fgColor};
     return ansi;
 }
 
-NODISCARD static inline constexpr RawAnsi getRawAnsi(const AnsiColor16Enum fgColor,
-                                                     const AnsiColor16Enum bgColor)
+NODISCARD static inline RawAnsi getRawAnsi(const AnsiColor16Enum fgColor,
+                                           const AnsiColor16Enum bgColor)
 {
     RawAnsi ansi;
     ansi.fg = AnsiColorVariant{fgColor};

--- a/src/global/AnsiTextUtils.h
+++ b/src/global/AnsiTextUtils.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <QtGlobal>
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (C) 2021 The MMapper Authors
 

--- a/src/global/AnsiTextUtils.h
+++ b/src/global/AnsiTextUtils.h
@@ -988,7 +988,11 @@ void foreachAnsi(const QStringView line, Callback &&callback)
     const auto len = line.size();
     qsizetype pos = 0;
     while (pos < len) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+        QRegularExpressionMatch m = weakAnsiRegex.matchView(line, pos);
+#else
         QRegularExpressionMatch m = weakAnsiRegex.match(line, pos);
+#endif
         if (!m.hasMatch()) {
             break;
         }

--- a/src/global/TextBuffer.cpp
+++ b/src/global/TextBuffer.cpp
@@ -59,7 +59,11 @@ public:
 
         // step 1: match the quoted prefix
         {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+            auto m = quotePrefixRegex.matchView(line);
+#else
             auto m = quotePrefixRegex.match(line);
+#endif
             if (m.hasMatch()) {
                 const auto len = m.capturedLength(0);
                 quotePrefix = line.left(len);
@@ -78,7 +82,11 @@ public:
         // step 2: See if there's a bullet. If so, we will only print it on the first line,
         // and we'll replace it with equivalent length whitespace on consecutive linewraps.
         {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+            auto m = bulletPrefixRegex.matchView(line);
+#else
             auto m = bulletPrefixRegex.match(line);
+#endif
             if (m.hasMatch()) {
                 const QString sv = m.captured();
                 /* this could fail if someone breaks the regex pattern for the escaped asterisk */
@@ -92,7 +100,11 @@ public:
 
         // step 3: duplicate the exact whitespace following the bullet
         if (hasPrefix2) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+            auto m = leadingWhitespaceRegex.matchView(line);
+#else
             auto m = leadingWhitespaceRegex.match(line);
+#endif
             if (m.hasMatch()) {
                 prefix2 = m.captured();
                 prefixLen = measureExpandedTabsOneLine(prefix2, prefixLen);
@@ -134,7 +146,11 @@ void TextBuffer::appendJustified(const QStringView input_line, const int maxLen)
         // identify any leading whitespace (there won't be on 1st pass)
         QString leadingSpace = line.left(0);
         {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+            auto m = leadingWhitespaceRegex.matchView(line);
+#else
             auto m = leadingWhitespaceRegex.match(line);
+#endif
             if (m.hasMatch()) {
                 leadingSpace = m.captured();
                 line = line.mid(m.capturedLength());
@@ -145,7 +161,11 @@ void TextBuffer::appendJustified(const QStringView input_line, const int maxLen)
         // leading whitespace, print a newline, the prefix(es), and then
         // print the word.
         {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+            auto m = leadingNonSpaceRegex.matchView(line);
+#else
             auto m = leadingNonSpaceRegex.match(line);
+#endif
             if (m.hasMatch()) {
                 line = line.mid(m.capturedLength());
                 const auto word = m.captured();

--- a/src/global/TextUtils.cpp
+++ b/src/global/TextUtils.cpp
@@ -13,6 +13,7 @@
 
 #include <QRegularExpression>
 #include <QString>
+#include <QtGlobal>
 
 namespace { // anonymous
 

--- a/src/global/TextUtils.cpp
+++ b/src/global/TextUtils.cpp
@@ -65,7 +65,11 @@ namespace mmqt {
 int findTrailingWhitespace(const QStringView line)
 {
     static const QRegularExpression trailingWhitespaceRegex(R"([[:space:]]+$)");
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    auto m = trailingWhitespaceRegex.matchView(line);
+#else
     auto m = trailingWhitespaceRegex.match(line);
+#endif
     if (!m.hasMatch()) {
         return -1;
     }
@@ -138,7 +142,11 @@ void foreach_regex(const QRegularExpression &regex,
                    const std::function<void(const QStringView match)> &callback_match,
                    const std::function<void(const QStringView between)> &callback_between)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    auto it = regex.globalMatchView(text);
+#else
     auto it = regex.globalMatch(text);
+#endif
     qsizetype pos = 0;
     auto end = text.length();
     while (it.hasNext()) {

--- a/src/global/emojis.cpp
+++ b/src/global/emojis.cpp
@@ -21,6 +21,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QString>
+#include <QtGlobal>
 
 namespace {
 

--- a/src/global/emojis.cpp
+++ b/src/global/emojis.cpp
@@ -516,7 +516,11 @@ NODISCARD QString mmqt::decodeEmojiShortCodes(const QString &s)
     QStringView view(s);
     qsizetype lastPos = 0;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    QRegularExpressionMatchIterator it = shortCodeRegex.globalMatchView(s);
+#else
     QRegularExpressionMatchIterator it = shortCodeRegex.globalMatch(s);
+#endif
 
     while (it.hasNext()) {
         QRegularExpressionMatch match = it.next();
@@ -532,7 +536,11 @@ NODISCARD QString mmqt::decodeEmojiShortCodes(const QString &s)
         if (emojiIt != map.end()) {
             result += emojiIt->second;
         } else {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+            const auto unicodeMatch = unicodeRegex.matchView(inside);
+#else
             const auto unicodeMatch = unicodeRegex.match(inside);
+#endif
             if (unicodeMatch.hasMatch()) {
                 const QString hex = unicodeMatch.captured(1);
                 if (const auto opt = tryGetOneCodepointHexCode(hex)) {

--- a/src/mainwindow/UpdateDialog.cpp
+++ b/src/mainwindow/UpdateDialog.cpp
@@ -57,7 +57,11 @@ NODISCARD const char *getArchitectureRegexPattern()
 CompareVersion::CompareVersion(const QString &versionStr) noexcept
 {
     static const QRegularExpression versionRx(R"(v?(\d+)\.(\d+)\.(\d+))");
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    auto result = versionRx.matchView(versionStr);
+#else
     auto result = versionRx.match(versionStr);
+#endif
     if (result.hasMatch()) {
         m_parts[0] = result.captured(1).toInt();
         m_parts[1] = result.captured(2).toInt();
@@ -242,7 +246,12 @@ void UpdateDialog::managerFinished(QNetworkReply *reply)
         const QString remoteCommitHash = objNode.value("sha").toString();
         const QString localCommitHash = std::invoke([]() -> QString {
             static const QRegularExpression hashRegex(R"(-g([0-9a-fA-F]+)$)");
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+            QRegularExpressionMatch match = hashRegex.matchView(
+                QString::fromUtf8(getMMapperVersion()));
+#else
             QRegularExpressionMatch match = hashRegex.match(QString::fromUtf8(getMMapperVersion()));
+#endif
             if (match.hasMatch()) {
                 return match.captured(1);
             }

--- a/src/mainwindow/UpdateDialog.cpp
+++ b/src/mainwindow/UpdateDialog.cpp
@@ -247,11 +247,11 @@ void UpdateDialog::managerFinished(QNetworkReply *reply)
         const QString remoteCommitHash = objNode.value("sha").toString();
         const QString localCommitHash = std::invoke([]() -> QString {
             static const QRegularExpression hashRegex(R"(-g([0-9a-fA-F]+)$)");
+            const QString localVersion = QString::fromUtf8(getMMapperVersion());
 #if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
-            QRegularExpressionMatch match = hashRegex.matchView(
-                QString::fromUtf8(getMMapperVersion()));
+            QRegularExpressionMatch match = hashRegex.matchView(localVersion);
 #else
-            QRegularExpressionMatch match = hashRegex.match(QString::fromUtf8(getMMapperVersion()));
+            QRegularExpressionMatch match = hashRegex.match(localVersion);
 #endif
             if (match.hasMatch()) {
                 return match.captured(1);

--- a/src/mainwindow/UpdateDialog.cpp
+++ b/src/mainwindow/UpdateDialog.cpp
@@ -22,6 +22,7 @@
 #include <QPushButton>
 #include <QRegularExpression>
 #include <QSysInfo>
+#include <QtGlobal>
 
 namespace { // anonymous
 

--- a/src/mainwindow/mainwindow-async.cpp
+++ b/src/mainwindow/mainwindow-async.cpp
@@ -917,8 +917,8 @@ bool MainWindow::slot_generateBaseMap()
         return false;
     }
 
-    static constexpr auto green = getRawAnsi(AnsiColor16Enum::green);
-    static constexpr auto yellow = getRawAnsi(AnsiColor16Enum::yellow);
+    static const auto green = getRawAnsi(AnsiColor16Enum::green);
+    static const auto yellow = getRawAnsi(AnsiColor16Enum::yellow);
 
     class NODISCARD AsyncGenerateBaseMap final : public AsyncHelper
     {

--- a/src/map/ChangePrinter.cpp
+++ b/src/map/ChangePrinter.cpp
@@ -18,16 +18,16 @@ namespace { // anonymous
 
 constexpr size_t max_roomids_printed = 20;
 
-constexpr RawAnsi const_color = getRawAnsi(AnsiColor16Enum::yellow);
-constexpr RawAnsi error_color = getRawAnsi(AnsiColor16Enum::RED);
-constexpr RawAnsi member_name_color = getRawAnsi(AnsiColor16Enum::cyan);
-constexpr RawAnsi type_name_color = getRawAnsi(AnsiColor16Enum::BLUE);
-constexpr RawAnsi warning_color = getRawAnsi(AnsiColor16Enum::YELLOW);
+const RawAnsi const_color = getRawAnsi(AnsiColor16Enum::yellow);
+const RawAnsi error_color = getRawAnsi(AnsiColor16Enum::RED);
+const RawAnsi member_name_color = getRawAnsi(AnsiColor16Enum::cyan);
+const RawAnsi type_name_color = getRawAnsi(AnsiColor16Enum::BLUE);
+const RawAnsi warning_color = getRawAnsi(AnsiColor16Enum::YELLOW);
 
 void print_string_color_quoted(AnsiOstream &aos, std::string_view sv)
 {
-    constexpr RawAnsi normalAnsi = getRawAnsi(AnsiColor16Enum::green);
-    constexpr RawAnsi escapeAnsi = getRawAnsi(AnsiColor16Enum::yellow);
+    const RawAnsi normalAnsi = getRawAnsi(AnsiColor16Enum::green);
+    const RawAnsi escapeAnsi = getRawAnsi(AnsiColor16Enum::yellow);
     aos.writeQuotedWithColor(normalAnsi, escapeAnsi, sv);
 }
 

--- a/src/map/Map.cpp
+++ b/src/map/Map.cpp
@@ -33,8 +33,8 @@
 
 using namespace char_consts;
 
-static constexpr auto green = getRawAnsi(AnsiColor16Enum::green);
-static constexpr auto yellow = getRawAnsi(AnsiColor16Enum::yellow);
+static const auto green = getRawAnsi(AnsiColor16Enum::green);
+static const auto yellow = getRawAnsi(AnsiColor16Enum::yellow);
 
 Map::Map()
     : m_world(std::make_shared<const World>())

--- a/src/map/ParseTree.cpp
+++ b/src/map/ParseTree.cpp
@@ -139,8 +139,8 @@ RoomIdSet getRooms(const Map &map, const ParseTree &tree, const ParseEvent &even
 
 void ParseTree::printStats(ProgressCounter & /*pc*/, AnsiOstream &os) const
 {
-    static constexpr RawAnsi green = getRawAnsi(AnsiColor16Enum::green);
-    static constexpr RawAnsi yellow = getRawAnsi(AnsiColor16Enum::yellow);
+    static const RawAnsi green = getRawAnsi(AnsiColor16Enum::green);
+    static const RawAnsi yellow = getRawAnsi(AnsiColor16Enum::yellow);
 
     auto C = [](auto x) {
         static_assert(std::is_integral_v<decltype(x)>);

--- a/src/map/Remapping.cpp
+++ b/src/map/Remapping.cpp
@@ -325,7 +325,7 @@ void Remapping::printStats(ProgressCounter & /*pc*/, AnsiOstream &os) const
         }
     }
 
-    static constexpr auto green = getRawAnsi(AnsiColor16Enum::green);
+    static const auto green = getRawAnsi(AnsiColor16Enum::green);
 
     auto print = [&os](std::string_view prefix, size_t size, uint32_t loval, uint32_t hival) {
         os << prefix;

--- a/src/map/ServerIdMap.cpp
+++ b/src/map/ServerIdMap.cpp
@@ -7,6 +7,6 @@
 
 void ServerIdMap::printStats(ProgressCounter & /*pc*/, AnsiOstream &os) const
 {
-    static constexpr auto green = getRawAnsi(AnsiColor16Enum::green);
+    static const auto green = getRawAnsi(AnsiColor16Enum::green);
     os << "Unique server ids assigned: " << ColoredValue{green, this->size()} << ".\n";
 }

--- a/src/map/SpatialDb.cpp
+++ b/src/map/SpatialDb.cpp
@@ -70,7 +70,7 @@ void SpatialDb::printStats(ProgressCounter & /*pc*/, AnsiOstream &os) const
         const Coordinate &max = bounds.max;
         const Coordinate &min = bounds.min;
 
-        static constexpr auto green = getRawAnsi(AnsiColor16Enum::green);
+        static const auto green = getRawAnsi(AnsiColor16Enum::green);
 
         auto show = [&os](std::string_view prefix, int lo, int hi) {
             os << prefix << ColoredValue(green, hi - lo + 1) << " (" << ColoredValue(green, lo)

--- a/src/map/World.cpp
+++ b/src/map/World.cpp
@@ -2105,7 +2105,7 @@ void World::printStats(ProgressCounter &pc, AnsiOstream &os) const
     m_serverIds.printStats(pc, os);
 
     {
-        static constexpr auto green = getRawAnsi(AnsiColor16Enum::green);
+        static const auto green = getRawAnsi(AnsiColor16Enum::green);
 
         static auto C = [](auto x) {
             static_assert(std::is_integral_v<decltype(x)>);
@@ -2317,8 +2317,8 @@ void World::printStats(ProgressCounter &pc, AnsiOstream &os) const
 
     m_spatialDb.printStats(pc, os);
 
-    static constexpr auto green = getRawAnsi(AnsiColor16Enum::green);
-    static constexpr auto yellow = getRawAnsi(AnsiColor16Enum::yellow);
+    static const auto green = getRawAnsi(AnsiColor16Enum::green);
+    static const auto yellow = getRawAnsi(AnsiColor16Enum::yellow);
 
     auto line = std::string(81, '_'); // note: purposely using parens instead of curly.
     assert(line.size() == 81);

--- a/src/mapdata/roomfilter.cpp
+++ b/src/mapdata/roomfilter.cpp
@@ -12,6 +12,7 @@
 
 #include <QRegularExpression>
 #include <QString>
+#include <QtGlobal>
 
 NODISCARD static QString escapeRegex(const QString &str)
 {

--- a/src/mapdata/roomfilter.cpp
+++ b/src/mapdata/roomfilter.cpp
@@ -18,7 +18,11 @@ NODISCARD static QString escapeRegex(const QString &str)
     static const QRegularExpression metacharactersRx(R"([.*+?^${}()|\[\]\\])");
     QString result = str;
     int offset = 0;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    auto it = metacharactersRx.globalMatchView(str);
+#else
     auto it = metacharactersRx.globalMatch(str);
+#endif
     while (it.hasNext()) {
         auto match = it.next();
         result.insert(match.capturedStart() + offset, '\\');

--- a/src/mapdata/roomfilter.h
+++ b/src/mapdata/roomfilter.h
@@ -41,7 +41,14 @@ public:
 
 private:
     NODISCARD bool filter_kind(const RawRoom &r, const PatternKindsEnum pat) const;
-    NODISCARD bool matches(const QString &s) const { return m_regex.match(s).hasMatch(); }
+    NODISCARD bool matches(const QString &s) const
+    {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+        return m_regex.matchView(s).hasMatch();
+#else
+        return m_regex.match(s).hasMatch();
+#endif
+    }
 
 private:
     template<typename T>

--- a/src/mapdata/roomfilter.h
+++ b/src/mapdata/roomfilter.h
@@ -13,6 +13,7 @@
 
 #include <QRegularExpression>
 #include <QString>
+#include <QtGlobal>
 
 enum class NODISCARD PatternKindsEnum { NONE, DESC, CONTENTS, NAME, NOTE, EXITS, FLAGS, AREA, ALL };
 static constexpr const auto PATTERN_KINDS_LENGTH = static_cast<size_t>(PatternKindsEnum::ALL) + 1u;

--- a/src/preferences/ansicombo.cpp
+++ b/src/preferences/ansicombo.cpp
@@ -14,6 +14,7 @@
 
 #include <QRegularExpression>
 #include <QString>
+#include <QtGlobal>
 #include <QtGui>
 #include <QtWidgets>
 

--- a/src/preferences/ansicombo.cpp
+++ b/src/preferences/ansicombo.cpp
@@ -111,7 +111,11 @@ AnsiCombo::AnsiColor AnsiCombo::colorFromString(const QString &colString)
 
     // TODO: use existing test (prepend an ESC if necessary)
     static const QRegularExpression re(R"(^\[((?:\d+[;:])*\d+)m$)");
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    if (!re.matchView(colString).hasMatch()) {
+#else
     if (!re.match(colString).hasMatch()) {
+#endif
         qWarning() << "String did not contain valid ANSI: " << colString;
         return AnsiColor{};
     }

--- a/src/proxy/connectionlistener.cpp
+++ b/src/proxy/connectionlistener.cpp
@@ -117,8 +117,7 @@ void ConnectionListener::startClient(std::unique_ptr<AbstractSocket> socket)
     } else {
         log("New connection: rejected.");
         const auto msg = std::invoke([]() -> QByteArray {
-            const auto whiteOnRed = getRawAnsi(AnsiColor16Enum::white,
-                                                         AnsiColor16Enum::red);
+            const auto whiteOnRed = getRawAnsi(AnsiColor16Enum::white, AnsiColor16Enum::red);
             std::stringstream oss;
             AnsiOstream aos{oss};
             aos.writeWithColor(whiteOnRed, "You can't connect to MMapper more than once!\n");

--- a/src/proxy/connectionlistener.cpp
+++ b/src/proxy/connectionlistener.cpp
@@ -117,7 +117,7 @@ void ConnectionListener::startClient(std::unique_ptr<AbstractSocket> socket)
     } else {
         log("New connection: rejected.");
         const auto msg = std::invoke([]() -> QByteArray {
-            constexpr const auto whiteOnRed = getRawAnsi(AnsiColor16Enum::white,
+            const auto whiteOnRed = getRawAnsi(AnsiColor16Enum::white,
                                                          AnsiColor16Enum::red);
             std::stringstream oss;
             AnsiOstream aos{oss};

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -56,7 +56,7 @@ namespace { // anonymous
 const volatile bool g_prefixMessagesToUser = true;
 const volatile bool g_showVersionInWelcomeMessage = IS_DEBUG_BUILD;
 //
-constexpr const auto whiteOnCyan = getRawAnsi(AnsiColor16Enum::white, AnsiColor16Enum::cyan);
+const auto whiteOnCyan = getRawAnsi(AnsiColor16Enum::white, AnsiColor16Enum::cyan);
 
 NODISCARD MainWindow &getMainWindow(ConnectionListener &listener)
 {


### PR DESCRIPTION
This PR adds full support for OSC 8 hyperlinks to the MMapper integrated client. 

Key features:
1. **ANSI/OSC Parsing**: The ANSI parser was extended to support OSC 8 sequences (`ESC ] 8 ; params ; URI ST`). It supports both `ESC \` and `BEL` (`\x07`) as terminators.
2. **Mudlet Schemes**: Support for `send:` (immediate command execution) and `prompt:` (input pre-filling) schemes was added, following Mudlet's standard.
3. **Synchronized Underlining**: Hyperlinks that share an `id` parameter (e.g., across line breaks or multiple fragments) are highlighted together when any of them is hovered. This was achieved using a viewport event filter and `QTextEdit::ExtraSelection`.
4. **Security**: `file://` URIs are restricted to the local host to prevent security risks associated with remote file execution.
5. **Robustness**: Updated the tokenizer and regexes to handle OSC sequences without breaking existing CSI/SGR parsing.

The `RawAnsi` struct was updated to store URL data, which required removing `constexpr` from its constructors and some utility functions due to the inclusion of `QString`. Existing `constexpr` usages in the codebase were updated to `const`.

---
*PR created automatically by Jules for task [17754462110983904247](https://jules.google.com/task/17754462110983904247) started by @nschimme*

## Summary by Sourcery

Add OSC 8 hyperlink handling to the ANSI/OSC parser and integrated client, enabling clickable and synchronized hyperlinks in MUD output with appropriate security checks and UI behavior.

New Features:
- Support OSC 8 escape sequences in the ANSI tokenizer and color parser, including URL and hyperlink ID extraction.
- Render hyperlinks in the display widget as clickable anchors with scheme-specific behavior for send:, prompt:, file:, and generic URLs.
- Synchronize underline highlighting across all text fragments that share the same hyperlink ID when hovered.

Enhancements:
- Extend weak ANSI/OSC detection regexes to recognize OSC sequences without impacting existing CSI/SGR parsing.
- Propagate hyperlink metadata through RawAnsi and text formatting, replacing constexpr usage as needed for QString support.

Tests:
- Add unit tests covering OSC 8 parsing, including standard URLs, ID parameters, and hyperlink-closer sequences.