### PR TITLE
Implement MNES Telnet Option Proxying

### DIFF
--- a/src/client/ClientTelnet.cpp
+++ b/src/client/ClientTelnet.cpp
@@ -6,6 +6,7 @@
 #include "ClientTelnet.h"
 
 #include "../configuration/configuration.h"
+#include "../global/Version.h"
 #include "../global/io.h"
 #include "../global/utils.h"
 #include "../proxy/TextCodec.h"
@@ -117,4 +118,48 @@ void ClientTelnet::virt_sendToMapper(const RawBytes &data, bool /*goAhead*/)
 void ClientTelnet::virt_receiveEchoMode(const bool mode)
 {
     m_output.echoModeChanged(mode);
+}
+
+void ClientTelnet::virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
+                                              const QList<RawBytes> &userVars)
+{
+    const bool sendAll = vars.isEmpty() && userVars.isEmpty();
+
+    QMap<RawBytes, RawBytes> myVars;
+    QMap<RawBytes, RawBytes> myUserVars;
+
+    bool clientNameRequested = sendAll;
+    bool clientVersionRequested = sendAll;
+    bool charsetRequested = sendAll;
+    bool mttsRequested = sendAll;
+
+    for (const auto &v : vars) {
+        if (v == RawBytes("CLIENT_NAME")) {
+            clientNameRequested = true;
+        } else if (v == RawBytes("CLIENT_VERSION")) {
+            clientVersionRequested = true;
+        } else if (v == RawBytes("CHARSET")) {
+            charsetRequested = true;
+        } else if (v == RawBytes("MTTS")) {
+            mttsRequested = true;
+        }
+    }
+
+    if (clientNameRequested) {
+        myVars[RawBytes("CLIENT_NAME")] = RawBytes("MMapper");
+    }
+    if (clientVersionRequested) {
+        myVars[RawBytes("CLIENT_VERSION")] = RawBytes(getMMapperVersion());
+    }
+    if (charsetRequested) {
+        myVars[RawBytes("CHARSET")] = RawBytes("UTF-8");
+    }
+    if (mttsRequested) {
+        // bitvector = ANSI(1) | UTF-8(4) | 256 COLORS(8) | MNES(512) = 525
+        myVars[RawBytes("MTTS")] = RawBytes("525");
+    }
+
+    if (!myVars.isEmpty() || !myUserVars.isEmpty()) {
+        sendNewEnvironIs(myVars, myUserVars);
+    }
 }

--- a/src/client/ClientTelnet.h
+++ b/src/client/ClientTelnet.h
@@ -63,6 +63,8 @@ public:
 private:
     void virt_sendToMapper(const RawBytes &, bool goAhead) final;
     void virt_receiveEchoMode(bool) final;
+    void virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
+                                    const QList<RawBytes> &userVars) final;
     void virt_sendRawData(const TelnetIacBytes &data) final;
 
 public:

--- a/src/proxy/AbstractSocket.h
+++ b/src/proxy/AbstractSocket.h
@@ -21,11 +21,13 @@ public:
     void flush() { virt_flush(); }
     void disconnectFromHost() { virt_disconnectFromHost(); }
     NODISCARD bool isConnected() const { return virt_isConnected(); }
+    NODISCARD QString peerAddress() const { return virt_peerAddress(); }
 
 private:
     virtual void virt_flush() = 0;
     virtual void virt_disconnectFromHost() = 0;
     NODISCARD virtual bool virt_isConnected() const = 0;
+    NODISCARD virtual QString virt_peerAddress() const = 0;
 
 signals:
     void sig_connected();

--- a/src/proxy/AbstractTelnet.cpp
+++ b/src/proxy/AbstractTelnet.cpp
@@ -1008,16 +1008,16 @@ void AbstractTelnet::processTelnetSubnegotiation(const AppendBuffer &payload)
                     if (i + 1 < payload.length()) {
                         const uint8_t next = payload.unsigned_at(++i);
                         if (inVal) {
-                            currentVal.append(next);
+                            currentVal.append(static_cast<char>(next));
                         } else {
-                            currentVar.append(next);
+                            currentVar.append(static_cast<char>(next));
                         }
                     }
                 } else {
                     if (inVal) {
-                        currentVal.append(c);
+                        currentVal.append(static_cast<char>(c));
                     } else {
-                        currentVar.append(c);
+                        currentVar.append(static_cast<char>(c));
                     }
                 }
             }
@@ -1028,8 +1028,7 @@ void AbstractTelnet::processTelnetSubnegotiation(const AppendBuffer &payload)
                 } else {
                     isVars[currentVar] = currentVal;
                 }
-            } else if (!currentVar.isEmpty() || type == TNSB_SEND) {
-                // if it's SEND and no more bytes, it means send all
+            } else if (!currentVar.isEmpty()) {
                 if (type == TNSB_SEND) {
                     if (isUserVar) {
                         sendUserVars.append(currentVar);
@@ -1158,23 +1157,23 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
         if (c == TN_IAC) {
             // this is IAC, previous character was regular data
             state = TelnetStateEnum::IAC;
-            commandBuffer.append(c);
+            commandBuffer.append(static_cast<char>(c));
         } else {
             // plaintext
-            cleanData.append(c);
+            cleanData.append(static_cast<char>(c));
         }
         break;
     case TelnetStateEnum::IAC:
         // seq. of two IACs
         if (c == TN_IAC) {
             state = TelnetStateEnum::NORMAL;
-            cleanData.append(c);
+            cleanData.append(static_cast<char>(c));
             commandBuffer.clear();
         }
         // IAC DO/DONT/WILL/WONT
         else if ((c == TN_WILL) || (c == TN_WONT) || (c == TN_DO) || (c == TN_DONT)) {
             state = TelnetStateEnum::COMMAND;
-            commandBuffer.append(c);
+            commandBuffer.append(static_cast<char>(c));
         }
         // IAC SB
         else if (c == TN_SB) {
@@ -1189,7 +1188,7 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
         // IAC fol. by something else than IAC, SB, SE, DO, DONT, WILL, WONT
         else {
             state = TelnetStateEnum::NORMAL;
-            commandBuffer.append(c);
+            commandBuffer.append(static_cast<char>(c));
             processTelnetCommand(commandBuffer);
             // this could have set receivedGA to true; we'll handle that later
             // (at the end of this function)
@@ -1199,7 +1198,7 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
     case TelnetStateEnum::COMMAND:
         // IAC DO/DONT/WILL/WONT <command code>
         state = TelnetStateEnum::NORMAL;
-        commandBuffer.append(c);
+        commandBuffer.append(static_cast<char>(c));
         processTelnetCommand(commandBuffer);
         commandBuffer.clear();
         break;
@@ -1208,23 +1207,23 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
         if (c == TN_IAC) {
             // this is IAC, previous character was option payload
             state = TelnetStateEnum::SUBNEG_IAC;
-            commandBuffer.append(c);
+            commandBuffer.append(static_cast<char>(c));
         } else {
             // option payload
-            subnegBuffer.append(c);
+            subnegBuffer.append(static_cast<char>(c));
         }
         break;
     case TelnetStateEnum::SUBNEG_IAC:
         // seq. of two IACs
         if (c == TN_IAC) {
             state = TelnetStateEnum::SUBNEG;
-            subnegBuffer.append(c);
+            subnegBuffer.append(static_cast<char>(c));
             commandBuffer.clear();
         }
         // IAC DO/DONT/WILL/WONT
         else if ((c == TN_WILL) || (c == TN_WONT) || (c == TN_DO) || (c == TN_DONT)) {
             state = TelnetStateEnum::SUBNEG_COMMAND;
-            commandBuffer.append(c);
+            commandBuffer.append(static_cast<char>(c));
         }
         // IAC SE - end of subcommand
         else if (c == TN_SE) {
@@ -1242,7 +1241,7 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
         // IAC fol. by something else than IAC, SB, SE, DO, DONT, WILL, WONT
         else {
             state = TelnetStateEnum::SUBNEG;
-            commandBuffer.append(c);
+            commandBuffer.append(static_cast<char>(c));
             processTelnetCommand(commandBuffer);
             // this could have set receivedGA to true; we'll handle that later
             // (at the end of this function)
@@ -1252,7 +1251,7 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
     case TelnetStateEnum::SUBNEG_COMMAND:
         // IAC DO/DONT/WILL/WONT <command code>
         state = TelnetStateEnum::SUBNEG;
-        commandBuffer.append(c);
+        commandBuffer.append(static_cast<char>(c));
         processTelnetCommand(commandBuffer);
         commandBuffer.clear();
         break;

--- a/src/proxy/AbstractTelnet.cpp
+++ b/src/proxy/AbstractTelnet.cpp
@@ -70,6 +70,7 @@ NODISCARD static QString telnetOptionName(uint8_t opt)
         CASE(TERMINAL_TYPE);
         CASE(NAWS);
         CASE(CHARSET);
+        CASE(NEW_ENVIRON);
         CASE(COMPRESS2);
         CASE(GMCP);
         CASE(MSSP);
@@ -79,23 +80,57 @@ NODISCARD static QString telnetOptionName(uint8_t opt)
     return QString::asprintf("%u", opt);
 #undef CASE
 }
-NODISCARD static QString telnetSubnegName(uint8_t opt)
+NODISCARD static QString telnetSubnegName(uint8_t option, uint8_t opt)
 {
-#define CASE(x) \
-    case TNSB_##x: \
-        return #x
     switch (opt) {
-        CASE(IS);
-        CASE(SEND); // TODO: conflict between SEND, REQUEST, EDIT, MODE
-        CASE(ACCEPTED);
-        CASE(REJECTED);
-        CASE(TTABLE_IS);
-        CASE(TTABLE_REJECTED);
-        CASE(TTABLE_ACK);
-        CASE(TTABLE_NAK);
+    case 0: // TNSB_IS / TNSB_VAR
+        if (option == OPT_NEW_ENVIRON) {
+            return "IS/VAR";
+        }
+        return "IS";
+    case 1: // TNSB_SEND / TNSB_VAL / TNSB_REQUEST / TNSB_MODE / TNSB_EDIT / TNSB_MSSP_VAR
+        if (option == OPT_NEW_ENVIRON) {
+            return "SEND/VAL";
+        }
+        if (option == OPT_CHARSET) {
+            return "REQUEST";
+        }
+        if (option == OPT_LINEMODE) {
+            return "MODE/EDIT";
+        }
+        if (option == OPT_MSSP) {
+            return "MSSP_VAR";
+        }
+        return "SEND";
+    case 2: // TNSB_ESC / TNSB_INFO / TNSB_ACCEPTED / TNSB_MSSP_VAL
+        if (option == OPT_NEW_ENVIRON) {
+            return "ESC/INFO";
+        }
+        if (option == OPT_CHARSET) {
+            return "ACCEPTED";
+        }
+        if (option == OPT_MSSP) {
+            return "MSSP_VAL";
+        }
+        return "ESC/ACCEPTED";
+    case 3: // TNSB_USERVAR / TNSB_REJECTED
+        if (option == OPT_NEW_ENVIRON) {
+            return "USERVAR";
+        }
+        if (option == OPT_CHARSET) {
+            return "REJECTED";
+        }
+        return "USERVAR/REJECTED";
+    case 4:
+        return "TTABLE_IS";
+    case 5:
+        return "TTABLE_REJECTED";
+    case 6:
+        return "TTABLE_ACK";
+    case 7:
+        return "TTABLE_NAK";
     }
     return QString::asprintf("%u", opt);
-#undef CASE
 }
 
 NODISCARD static bool containsIAC(const std::string_view arr)
@@ -474,6 +509,12 @@ void AbstractTelnet::sendTerminalType(const TelnetTermTypeBytes &terminalType)
     s.addEscaped(TNSB_IS); /* NOTE: "IS" will never actually be escaped */
     s.addEscapedBytes(terminalType.getQByteArray());
     s.addSubnegEnd();
+
+    if (m_options.myOptionState[OPT_NEW_ENVIRON]) {
+        QMap<RawBytes, RawBytes> vars;
+        vars[RawBytes("TERMINAL_TYPE")] = RawBytes(terminalType.getQByteArray());
+        sendNewEnvironInfo(vars, {});
+    }
 }
 
 void AbstractTelnet::sendCharsetRejected()
@@ -495,6 +536,12 @@ void AbstractTelnet::sendCharsetAccepted(const TelnetCharsetBytes &characterSet)
     s.addRaw(TNSB_ACCEPTED);
     s.addEscapedBytes(characterSet.getQByteArray());
     s.addSubnegEnd();
+
+    if (m_options.myOptionState[OPT_NEW_ENVIRON]) {
+        QMap<RawBytes, RawBytes> vars;
+        vars[RawBytes("CHARSET")] = RawBytes(characterSet.getQByteArray());
+        sendNewEnvironInfo(vars, {});
+    }
 }
 
 void AbstractTelnet::sendOptionStatus()
@@ -526,6 +573,73 @@ void AbstractTelnet::sendTerminalTypeRequest()
     TelnetFormatter s{*this};
     s.addSubnegBegin(OPT_TERMINAL_TYPE);
     s.addEscaped(TNSB_SEND);
+    s.addSubnegEnd();
+}
+
+void AbstractTelnet::sendNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                                     const QMap<RawBytes, RawBytes> &userVars)
+{
+    if (m_debug) {
+        qDebug() << "Sending NEW-ENVIRON IS" << vars << userVars;
+    }
+    TelnetFormatter s{*this};
+    s.addSubnegBegin(OPT_NEW_ENVIRON);
+    s.addRaw(TNSB_IS);
+    for (auto it = vars.begin(); it != vars.end(); ++it) {
+        s.addRaw(TNSB_VAR);
+        s.addEscapedBytes(it.key().getQByteArray());
+        s.addRaw(TNSB_VAL);
+        s.addEscapedBytes(it.value().getQByteArray());
+    }
+    for (auto it = userVars.begin(); it != userVars.end(); ++it) {
+        s.addRaw(TNSB_USERVAR);
+        s.addEscapedBytes(it.key().getQByteArray());
+        s.addRaw(TNSB_VAL);
+        s.addEscapedBytes(it.value().getQByteArray());
+    }
+    s.addSubnegEnd();
+}
+
+void AbstractTelnet::sendNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                                       const QMap<RawBytes, RawBytes> &userVars)
+{
+    if (m_debug) {
+        qDebug() << "Sending NEW-ENVIRON INFO" << vars << userVars;
+    }
+    TelnetFormatter s{*this};
+    s.addSubnegBegin(OPT_NEW_ENVIRON);
+    s.addRaw(TNSB_INFO);
+    for (auto it = vars.begin(); it != vars.end(); ++it) {
+        s.addRaw(TNSB_VAR);
+        s.addEscapedBytes(it.key().getQByteArray());
+        s.addRaw(TNSB_VAL);
+        s.addEscapedBytes(it.value().getQByteArray());
+    }
+    for (auto it = userVars.begin(); it != userVars.end(); ++it) {
+        s.addRaw(TNSB_USERVAR);
+        s.addEscapedBytes(it.key().getQByteArray());
+        s.addRaw(TNSB_VAL);
+        s.addEscapedBytes(it.value().getQByteArray());
+    }
+    s.addSubnegEnd();
+}
+
+void AbstractTelnet::sendNewEnvironSend(const QList<RawBytes> &vars, const QList<RawBytes> &userVars)
+{
+    if (m_debug) {
+        qDebug() << "Sending NEW-ENVIRON SEND" << vars << userVars;
+    }
+    TelnetFormatter s{*this};
+    s.addSubnegBegin(OPT_NEW_ENVIRON);
+    s.addRaw(TNSB_SEND);
+    for (const auto &v : vars) {
+        s.addRaw(TNSB_VAR);
+        s.addEscapedBytes(v.getQByteArray());
+    }
+    for (const auto &v : userVars) {
+        s.addRaw(TNSB_USERVAR);
+        s.addEscapedBytes(v.getQByteArray());
+    }
     s.addSubnegEnd();
 }
 
@@ -588,12 +702,18 @@ void AbstractTelnet::processTelnetCommand(const AppendBuffer &command)
                     } else if (option == OPT_CHARSET) {
                         sendCharsetRequest();
                     }
+                } else if (option == OPT_NEW_ENVIRON) {
+                    sendTelnetOption(TN_DO, option);
+                    hisOptionState[option] = true;
                 } else {
                     sendTelnetOption(TN_DONT, option);
                     hisOptionState[option] = false;
                 }
             }
             heAnnouncedState[option] = true;
+            if (option == OPT_NEW_ENVIRON) {
+                virt_receiveNewEnvironWill();
+            }
             break;
         case TN_WONT:
             // peer refuses to enable some option...
@@ -605,6 +725,21 @@ void AbstractTelnet::processTelnetCommand(const AppendBuffer &command)
             hisOptionState[option] = false;
             if (option == OPT_ECHO) {
                 receiveEchoMode(true);
+            }
+            if (option == OPT_NEW_ENVIRON) {
+                virt_receiveNewEnvironWont();
+            }
+            if (option == OPT_TERMINAL_TYPE || option == OPT_CHARSET) {
+                if (myOptionState[OPT_NEW_ENVIRON]) {
+                    QMap<RawBytes, RawBytes> vars;
+                    if (option == OPT_TERMINAL_TYPE) {
+                        vars[RawBytes("TERMINAL_TYPE")] = RawBytes(m_termType.getQByteArray());
+                    } else {
+                        vars[RawBytes("CHARSET")] = RawBytes(
+                            mmqt::toQByteArrayRaw(std::string(m_textCodec.getName())));
+                    }
+                    sendNewEnvironInfo(vars, {});
+                }
             }
             break;
         case TN_DO:
@@ -642,12 +777,18 @@ void AbstractTelnet::processTelnetCommand(const AppendBuffer &command)
                         // REVISIT: Start deflating after sending IAC SB COMPRESS2 IAC SE
                     } else if (option == OPT_CHARSET && heAnnouncedState[option]) {
                         sendCharsetRequest();
+                    } else if (option == OPT_NEW_ENVIRON) {
+                        // sendTelnetOption(TN_WILL, option);
+                        // myOptionState[option] = true;
                     }
                 } else {
                     sendTelnetOption(TN_WONT, option);
                     myOptionState[option] = false;
                 }
                 announcedState[option] = true;
+                if (option == OPT_NEW_ENVIRON) {
+                    virt_receiveNewEnvironDo();
+                }
             }
             break;
         case TN_DONT:
@@ -681,7 +822,7 @@ void AbstractTelnet::processTelnetSubnegotiation(const AppendBuffer &payload)
         } else if (payload.length() >= 2) {
             qDebug() << "* Processing Telnet Subnegotiation:"
                      << telnetOptionName(payload.unsigned_at(0))
-                     << telnetSubnegName(payload.unsigned_at(1));
+                     << telnetSubnegName(payload.unsigned_at(0), payload.unsigned_at(1));
         }
     }
 
@@ -819,6 +960,92 @@ void AbstractTelnet::processTelnetSubnegotiation(const AppendBuffer &payload)
             }
 
             receiveMudServerStatus(TelnetMsspBytes{payload.getQByteArray()});
+        }
+        break;
+
+    case OPT_NEW_ENVIRON:
+        if (myOptionState[OPT_NEW_ENVIRON] || hisOptionState[OPT_NEW_ENVIRON]) {
+            if (payload.length() < 2) {
+                break;
+            }
+            const uint8_t type = payload.unsigned_at(1);
+            QList<RawBytes> sendVars;
+            QList<RawBytes> sendUserVars;
+            QMap<RawBytes, RawBytes> isVars;
+            QMap<RawBytes, RawBytes> isUserVars;
+
+            RawBytes currentVar;
+            RawBytes currentVal;
+            bool inVal = false;
+            bool isUserVar = false;
+
+            for (int i = 2; i < payload.length(); ++i) {
+                const uint8_t c = payload.unsigned_at(i);
+                if (c == TNSB_VAR || c == TNSB_USERVAR) {
+                    if (inVal) {
+                        if (isUserVar) {
+                            isUserVars[currentVar] = currentVal;
+                        } else {
+                            isVars[currentVar] = currentVal;
+                        }
+                    } else if (!currentVar.isEmpty()) {
+                        if (type == TNSB_SEND) {
+                            if (isUserVar) {
+                                sendUserVars.append(currentVar);
+                            } else {
+                                sendVars.append(currentVar);
+                            }
+                        }
+                    }
+                    currentVar.clear();
+                    currentVal.clear();
+                    inVal = false;
+                    isUserVar = (c == TNSB_USERVAR);
+                } else if (c == TNSB_VAL) {
+                    inVal = true;
+                    currentVal.clear();
+                } else if (c == TNSB_ESC) {
+                    if (i + 1 < payload.length()) {
+                        const uint8_t next = payload.unsigned_at(++i);
+                        if (inVal) {
+                            currentVal.append(next);
+                        } else {
+                            currentVar.append(next);
+                        }
+                    }
+                } else {
+                    if (inVal) {
+                        currentVal.append(c);
+                    } else {
+                        currentVar.append(c);
+                    }
+                }
+            }
+            // Add last one
+            if (inVal) {
+                if (isUserVar) {
+                    isUserVars[currentVar] = currentVal;
+                } else {
+                    isVars[currentVar] = currentVal;
+                }
+            } else if (!currentVar.isEmpty() || type == TNSB_SEND) {
+                // if it's SEND and no more bytes, it means send all
+                if (type == TNSB_SEND) {
+                    if (isUserVar) {
+                        sendUserVars.append(currentVar);
+                    } else {
+                        sendVars.append(currentVar);
+                    }
+                }
+            }
+
+            if (type == TNSB_SEND) {
+                virt_receiveNewEnvironSend(sendVars, sendUserVars);
+            } else if (type == TNSB_IS) {
+                virt_receiveNewEnvironIs(isVars, isUserVars);
+            } else if (type == TNSB_INFO) {
+                virt_receiveNewEnvironInfo(isVars, isUserVars);
+            }
         }
         break;
 

--- a/src/proxy/AbstractTelnet.cpp
+++ b/src/proxy/AbstractTelnet.cpp
@@ -577,7 +577,7 @@ void AbstractTelnet::sendTerminalTypeRequest()
 }
 
 void AbstractTelnet::sendNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
-                                     const QMap<RawBytes, RawBytes> &userVars)
+                                      const QMap<RawBytes, RawBytes> &userVars)
 {
     if (m_debug) {
         qDebug() << "Sending NEW-ENVIRON IS" << vars << userVars;
@@ -601,7 +601,7 @@ void AbstractTelnet::sendNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
 }
 
 void AbstractTelnet::sendNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
-                                       const QMap<RawBytes, RawBytes> &userVars)
+                                        const QMap<RawBytes, RawBytes> &userVars)
 {
     if (m_debug) {
         qDebug() << "Sending NEW-ENVIRON INFO" << vars << userVars;

--- a/src/proxy/AbstractTelnet.cpp
+++ b/src/proxy/AbstractTelnet.cpp
@@ -1157,23 +1157,23 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
         if (c == TN_IAC) {
             // this is IAC, previous character was regular data
             state = TelnetStateEnum::IAC;
-            commandBuffer.append(static_cast<char>(c));
+            commandBuffer.append(c);
         } else {
             // plaintext
-            cleanData.append(static_cast<char>(c));
+            cleanData.append(c);
         }
         break;
     case TelnetStateEnum::IAC:
         // seq. of two IACs
         if (c == TN_IAC) {
             state = TelnetStateEnum::NORMAL;
-            cleanData.append(static_cast<char>(c));
+            cleanData.append(c);
             commandBuffer.clear();
         }
         // IAC DO/DONT/WILL/WONT
         else if ((c == TN_WILL) || (c == TN_WONT) || (c == TN_DO) || (c == TN_DONT)) {
             state = TelnetStateEnum::COMMAND;
-            commandBuffer.append(static_cast<char>(c));
+            commandBuffer.append(c);
         }
         // IAC SB
         else if (c == TN_SB) {
@@ -1188,7 +1188,7 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
         // IAC fol. by something else than IAC, SB, SE, DO, DONT, WILL, WONT
         else {
             state = TelnetStateEnum::NORMAL;
-            commandBuffer.append(static_cast<char>(c));
+            commandBuffer.append(c);
             processTelnetCommand(commandBuffer);
             // this could have set receivedGA to true; we'll handle that later
             // (at the end of this function)
@@ -1198,7 +1198,7 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
     case TelnetStateEnum::COMMAND:
         // IAC DO/DONT/WILL/WONT <command code>
         state = TelnetStateEnum::NORMAL;
-        commandBuffer.append(static_cast<char>(c));
+        commandBuffer.append(c);
         processTelnetCommand(commandBuffer);
         commandBuffer.clear();
         break;
@@ -1207,23 +1207,23 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
         if (c == TN_IAC) {
             // this is IAC, previous character was option payload
             state = TelnetStateEnum::SUBNEG_IAC;
-            commandBuffer.append(static_cast<char>(c));
+            commandBuffer.append(c);
         } else {
             // option payload
-            subnegBuffer.append(static_cast<char>(c));
+            subnegBuffer.append(c);
         }
         break;
     case TelnetStateEnum::SUBNEG_IAC:
         // seq. of two IACs
         if (c == TN_IAC) {
             state = TelnetStateEnum::SUBNEG;
-            subnegBuffer.append(static_cast<char>(c));
+            subnegBuffer.append(c);
             commandBuffer.clear();
         }
         // IAC DO/DONT/WILL/WONT
         else if ((c == TN_WILL) || (c == TN_WONT) || (c == TN_DO) || (c == TN_DONT)) {
             state = TelnetStateEnum::SUBNEG_COMMAND;
-            commandBuffer.append(static_cast<char>(c));
+            commandBuffer.append(c);
         }
         // IAC SE - end of subcommand
         else if (c == TN_SE) {
@@ -1241,7 +1241,7 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
         // IAC fol. by something else than IAC, SB, SE, DO, DONT, WILL, WONT
         else {
             state = TelnetStateEnum::SUBNEG;
-            commandBuffer.append(static_cast<char>(c));
+            commandBuffer.append(c);
             processTelnetCommand(commandBuffer);
             // this could have set receivedGA to true; we'll handle that later
             // (at the end of this function)
@@ -1251,7 +1251,7 @@ void AbstractTelnet::onReadInternal2(AppendBuffer &cleanData, const uint8_t c)
     case TelnetStateEnum::SUBNEG_COMMAND:
         // IAC DO/DONT/WILL/WONT <command code>
         state = TelnetStateEnum::SUBNEG;
-        commandBuffer.append(static_cast<char>(c));
+        commandBuffer.append(c);
         processTelnetCommand(commandBuffer);
         commandBuffer.clear();
         break;

--- a/src/proxy/AbstractTelnet.h
+++ b/src/proxy/AbstractTelnet.h
@@ -288,7 +288,7 @@ protected:
 
 protected:
     void sendNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
-                         const QMap<RawBytes, RawBytes> &userVars);
+                          const QMap<RawBytes, RawBytes> &userVars);
     void sendNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
                             const QMap<RawBytes, RawBytes> &userVars);
     void sendNewEnvironSend(const QList<RawBytes> &vars, const QList<RawBytes> &userVars);

--- a/src/proxy/AbstractTelnet.h
+++ b/src/proxy/AbstractTelnet.h
@@ -231,14 +231,12 @@ private:
     virtual void virt_receiveTerminalType(const TelnetTermTypeBytes &) {}
     virtual void virt_receiveMudServerStatus(const TelnetMsspBytes &) {}
     virtual void virt_receiveWindowSize(int, int) {}
-    virtual void virt_receiveNewEnvironSend(const QList<RawBytes> & /*vars*/,
-                                            const QList<RawBytes> & /*userVars*/)
+    virtual void virt_receiveNewEnvironSend(const QList<RawBytes> &, const QList<RawBytes> &) {}
+    virtual void virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> &,
+                                          const QMap<RawBytes, RawBytes> &)
     {}
-    virtual void virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> & /*vars*/,
-                                          const QMap<RawBytes, RawBytes> & /*userVars*/)
-    {}
-    virtual void virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> & /*vars*/,
-                                            const QMap<RawBytes, RawBytes> & /*userVars*/)
+    virtual void virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> &,
+                                            const QMap<RawBytes, RawBytes> &)
     {}
     virtual void virt_receiveNewEnvironDo() {}
     virtual void virt_receiveNewEnvironWill() {}
@@ -287,11 +285,11 @@ protected:
     NODISCARD CharacterEncodingEnum getEncoding() const { return m_textCodec.getEncoding(); }
 
 protected:
-    void sendNewEnvironIs(const QMap<RawBytes, RawBytes> & /*vars*/,
-                          const QMap<RawBytes, RawBytes> & /*userVars*/);
-    void sendNewEnvironInfo(const QMap<RawBytes, RawBytes> & /*vars*/,
-                            const QMap<RawBytes, RawBytes> & /*userVars*/);
-    void sendNewEnvironSend(const QList<RawBytes> & /*vars*/, const QList<RawBytes> & /*userVars*/);
+    void sendNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                          const QMap<RawBytes, RawBytes> &userVars);
+    void sendNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                            const QMap<RawBytes, RawBytes> &userVars);
+    void sendNewEnvironSend(const QList<RawBytes> &vars, const QList<RawBytes> &userVars);
 
 private:
     void onReadInternal2(AppendBuffer &, uint8_t);

--- a/src/proxy/AbstractTelnet.h
+++ b/src/proxy/AbstractTelnet.h
@@ -46,6 +46,7 @@ static constexpr const uint8_t OPT_TERMINAL_TYPE = 24;
 static constexpr const uint8_t OPT_EOR = 25;
 static constexpr const uint8_t OPT_NAWS = 31;
 static constexpr const uint8_t OPT_LINEMODE = 34;
+static constexpr const uint8_t OPT_NEW_ENVIRON = 39;
 static constexpr const uint8_t OPT_CHARSET = 42;
 static constexpr const uint8_t OPT_MSSP = 70;
 static constexpr const uint8_t OPT_COMPRESS2 = 86;
@@ -53,7 +54,12 @@ static constexpr const uint8_t OPT_GMCP = 201;
 
 // telnet SB suboption types
 static constexpr const uint8_t TNSB_IS = 0;
+static constexpr const uint8_t TNSB_VAR = 0;
 static constexpr const uint8_t TNSB_SEND = 1;
+static constexpr const uint8_t TNSB_VAL = 1;
+static constexpr const uint8_t TNSB_ESC = 2;
+static constexpr const uint8_t TNSB_INFO = 2;
+static constexpr const uint8_t TNSB_USERVAR = 3;
 static constexpr const uint8_t TNSB_REQUEST = 1;
 static constexpr const uint8_t TNSB_MODE = 1;
 static constexpr const uint8_t TNSB_EDIT = 1;
@@ -225,6 +231,18 @@ private:
     virtual void virt_receiveTerminalType(const TelnetTermTypeBytes &) {}
     virtual void virt_receiveMudServerStatus(const TelnetMsspBytes &) {}
     virtual void virt_receiveWindowSize(int, int) {}
+    virtual void virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
+                                            const QList<RawBytes> &userVars)
+    {}
+    virtual void virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                                          const QMap<RawBytes, RawBytes> &userVars)
+    {}
+    virtual void virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                                            const QMap<RawBytes, RawBytes> &userVars)
+    {}
+    virtual void virt_receiveNewEnvironDo() {}
+    virtual void virt_receiveNewEnvironWill() {}
+    virtual void virt_receiveNewEnvironWont() {}
     virtual void virt_sendRawData(const TelnetIacBytes &data) = 0;
     virtual void virt_sendToMapper(const RawBytes &, bool goAhead) = 0;
 
@@ -264,8 +282,16 @@ protected:
     void reset();
     void onReadInternal(const TelnetIacBytes &);
     void setTerminalType(const TelnetTermTypeBytes &terminalType) { m_termType = terminalType; }
+    void setEncodingForName(const std::string &name) { m_textCodec.setEncodingForName(name); }
 
     NODISCARD CharacterEncodingEnum getEncoding() const { return m_textCodec.getEncoding(); }
+
+protected:
+    void sendNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                         const QMap<RawBytes, RawBytes> &userVars);
+    void sendNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                            const QMap<RawBytes, RawBytes> &userVars);
+    void sendNewEnvironSend(const QList<RawBytes> &vars, const QList<RawBytes> &userVars);
 
 private:
     void onReadInternal2(AppendBuffer &, uint8_t);

--- a/src/proxy/AbstractTelnet.h
+++ b/src/proxy/AbstractTelnet.h
@@ -231,14 +231,14 @@ private:
     virtual void virt_receiveTerminalType(const TelnetTermTypeBytes &) {}
     virtual void virt_receiveMudServerStatus(const TelnetMsspBytes &) {}
     virtual void virt_receiveWindowSize(int, int) {}
-    virtual void virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
-                                            const QList<RawBytes> &userVars)
+    virtual void virt_receiveNewEnvironSend(const QList<RawBytes> & /*vars*/,
+                                            const QList<RawBytes> & /*userVars*/)
     {}
-    virtual void virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
-                                          const QMap<RawBytes, RawBytes> &userVars)
+    virtual void virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> & /*vars*/,
+                                          const QMap<RawBytes, RawBytes> & /*userVars*/)
     {}
-    virtual void virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
-                                            const QMap<RawBytes, RawBytes> &userVars)
+    virtual void virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> & /*vars*/,
+                                            const QMap<RawBytes, RawBytes> & /*userVars*/)
     {}
     virtual void virt_receiveNewEnvironDo() {}
     virtual void virt_receiveNewEnvironWill() {}
@@ -287,11 +287,11 @@ protected:
     NODISCARD CharacterEncodingEnum getEncoding() const { return m_textCodec.getEncoding(); }
 
 protected:
-    void sendNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
-                          const QMap<RawBytes, RawBytes> &userVars);
-    void sendNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
-                            const QMap<RawBytes, RawBytes> &userVars);
-    void sendNewEnvironSend(const QList<RawBytes> &vars, const QList<RawBytes> &userVars);
+    void sendNewEnvironIs(const QMap<RawBytes, RawBytes> & /*vars*/,
+                          const QMap<RawBytes, RawBytes> & /*userVars*/);
+    void sendNewEnvironInfo(const QMap<RawBytes, RawBytes> & /*vars*/,
+                            const QMap<RawBytes, RawBytes> & /*userVars*/);
+    void sendNewEnvironSend(const QList<RawBytes> & /*vars*/, const QList<RawBytes> & /*userVars*/);
 
 private:
     void onReadInternal2(AppendBuffer &, uint8_t);

--- a/src/proxy/MudTelnet.cpp
+++ b/src/proxy/MudTelnet.cpp
@@ -417,16 +417,16 @@ void MudTelnet::onRelayTermType(const TelnetTermTypeBytes &terminalType)
     }
 }
 
-void MudTelnet::onRelayNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
-                                    const QMap<RawBytes, RawBytes> &userVars)
+void MudTelnet::onRelayNewEnvironIs(const QMap<RawBytes, RawBytes> & /*vars*/,
+                                    const QMap<RawBytes, RawBytes> & /*userVars*/)
 {
     if (getOptions().myOptionState[OPT_NEW_ENVIRON]) {
         sendNewEnvironIs(vars, userVars);
     }
 }
 
-void MudTelnet::onRelayNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
-                                      const QMap<RawBytes, RawBytes> &userVars)
+void MudTelnet::onRelayNewEnvironInfo(const QMap<RawBytes, RawBytes> & /*vars*/,
+                                      const QMap<RawBytes, RawBytes> & /*userVars*/)
 {
     if (getOptions().myOptionState[OPT_NEW_ENVIRON]) {
         sendNewEnvironInfo(vars, userVars);

--- a/src/proxy/MudTelnet.cpp
+++ b/src/proxy/MudTelnet.cpp
@@ -417,6 +417,34 @@ void MudTelnet::onRelayTermType(const TelnetTermTypeBytes &terminalType)
     }
 }
 
+void MudTelnet::onRelayNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                                   const QMap<RawBytes, RawBytes> &userVars)
+{
+    if (getOptions().myOptionState[OPT_NEW_ENVIRON]) {
+        sendNewEnvironIs(vars, userVars);
+    }
+}
+
+void MudTelnet::onRelayNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                                     const QMap<RawBytes, RawBytes> &userVars)
+{
+    if (getOptions().myOptionState[OPT_NEW_ENVIRON]) {
+        sendNewEnvironInfo(vars, userVars);
+    }
+}
+
+void MudTelnet::onUserNewEnvironNegotiated(const bool supported)
+{
+    m_userSupportsNewEnviron = supported;
+    if (supported) {
+        if (getOptions().hisOptionState[OPT_NEW_ENVIRON]
+            && !getOptions().myOptionState[OPT_NEW_ENVIRON]) {
+            sendTelnetOption(TN_WILL, OPT_NEW_ENVIRON);
+            m_options.myOptionState[OPT_NEW_ENVIRON] = true;
+        }
+    }
+}
+
 void MudTelnet::onLoginCredentials(const QString &name, const QString &password)
 {
     sendGmcpMessage(
@@ -510,6 +538,73 @@ void MudTelnet::virt_receiveMudServerStatus(const TelnetMsspBytes &ba)
 {
     parseMudServerStatus(ba);
     m_outputs.onSendMSSPToUser(ba);
+}
+
+void MudTelnet::virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
+                                           const QList<RawBytes> &userVars)
+{
+    if (!m_userSupportsNewEnviron) {
+        // We wait until we get data from the client.
+        // But for now, we just relay the request.
+        m_outputs.onRelayNewEnvironSendFromMudToUser(vars, userVars);
+        return;
+    }
+
+    const bool sendAll = vars.isEmpty() && userVars.isEmpty();
+
+    QMap<RawBytes, RawBytes> myVars;
+    QMap<RawBytes, RawBytes> myUserVars;
+
+    bool mttsRequested = sendAll;
+    bool ipRequested = sendAll;
+
+    for (const auto &v : vars) {
+        if (v == RawBytes("MTTS")) {
+            mttsRequested = true;
+        } else if (v == RawBytes("IPADDRESS")) {
+            ipRequested = true;
+        }
+    }
+
+    if (mttsRequested) {
+        // MMapper capabilities: ANSI(1) | UTF-8(4) | 256 COLORS(8) | PROXY(128) | MNES(512)
+        // bitvector = 1 + 4 + 8 + 128 + 512 = 653
+        myVars[RawBytes("MTTS")] = RawBytes("653");
+    }
+
+    if (ipRequested) {
+        myVars[RawBytes("IPADDRESS")] = RawBytes(m_outputs.onGetPeerAddress().toUtf8());
+    }
+
+    if (!myVars.isEmpty() || !myUserVars.isEmpty()) {
+        sendNewEnvironIs(myVars, myUserVars);
+    }
+
+    // Relay the request to the user client as well
+    m_outputs.onRelayNewEnvironSendFromMudToUser(vars, userVars);
+}
+
+void MudTelnet::virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                                         const QMap<RawBytes, RawBytes> &userVars)
+{
+    // A server shouldn't send IS to a client, but if it does, ignore it.
+}
+
+void MudTelnet::virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                                           const QMap<RawBytes, RawBytes> &userVars)
+{
+    // A server shouldn't send INFO to a client, but if it does, ignore it.
+}
+
+void MudTelnet::virt_receiveNewEnvironDo()
+{
+    // If the mud sends DO NEW-ENVIRON, we check if the user supports it.
+    if (m_userSupportsNewEnviron) {
+        if (!getOptions().myOptionState[OPT_NEW_ENVIRON]) {
+            sendTelnetOption(TN_WILL, OPT_NEW_ENVIRON);
+            m_options.myOptionState[OPT_NEW_ENVIRON] = true;
+        }
+    }
 }
 
 void MudTelnet::virt_onGmcpEnabled()

--- a/src/proxy/MudTelnet.cpp
+++ b/src/proxy/MudTelnet.cpp
@@ -437,8 +437,7 @@ void MudTelnet::onUserNewEnvironNegotiated(const bool supported)
 {
     m_userSupportsNewEnviron = supported;
     if (supported) {
-        if (getOptions().hisOptionState[OPT_NEW_ENVIRON]
-            && !getOptions().myOptionState[OPT_NEW_ENVIRON]) {
+        if (m_serverRequestedNewEnviron && !getOptions().myOptionState[OPT_NEW_ENVIRON]) {
             sendTelnetOption(TN_WILL, OPT_NEW_ENVIRON);
             m_options.myOptionState[OPT_NEW_ENVIRON] = true;
         }
@@ -584,20 +583,21 @@ void MudTelnet::virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
     m_outputs.onRelayNewEnvironSendFromMudToUser(vars, userVars);
 }
 
-void MudTelnet::virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
-                                         const QMap<RawBytes, RawBytes> &userVars)
+void MudTelnet::virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> & /*vars*/,
+                                         const QMap<RawBytes, RawBytes> & /*userVars*/)
 {
     // A server shouldn't send IS to a client, but if it does, ignore it.
 }
 
-void MudTelnet::virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
-                                           const QMap<RawBytes, RawBytes> &userVars)
+void MudTelnet::virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> & /*vars*/,
+                                           const QMap<RawBytes, RawBytes> & /*userVars*/)
 {
     // A server shouldn't send INFO to a client, but if it does, ignore it.
 }
 
 void MudTelnet::virt_receiveNewEnvironDo()
 {
+    m_serverRequestedNewEnviron = true;
     // If the mud sends DO NEW-ENVIRON, we check if the user supports it.
     if (m_userSupportsNewEnviron) {
         if (!getOptions().myOptionState[OPT_NEW_ENVIRON]) {

--- a/src/proxy/MudTelnet.cpp
+++ b/src/proxy/MudTelnet.cpp
@@ -418,7 +418,7 @@ void MudTelnet::onRelayTermType(const TelnetTermTypeBytes &terminalType)
 }
 
 void MudTelnet::onRelayNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
-                                   const QMap<RawBytes, RawBytes> &userVars)
+                                    const QMap<RawBytes, RawBytes> &userVars)
 {
     if (getOptions().myOptionState[OPT_NEW_ENVIRON]) {
         sendNewEnvironIs(vars, userVars);
@@ -426,7 +426,7 @@ void MudTelnet::onRelayNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
 }
 
 void MudTelnet::onRelayNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
-                                     const QMap<RawBytes, RawBytes> &userVars)
+                                      const QMap<RawBytes, RawBytes> &userVars)
 {
     if (getOptions().myOptionState[OPT_NEW_ENVIRON]) {
         sendNewEnvironInfo(vars, userVars);

--- a/src/proxy/MudTelnet.cpp
+++ b/src/proxy/MudTelnet.cpp
@@ -417,16 +417,16 @@ void MudTelnet::onRelayTermType(const TelnetTermTypeBytes &terminalType)
     }
 }
 
-void MudTelnet::onRelayNewEnvironIs(const QMap<RawBytes, RawBytes> & /*vars*/,
-                                    const QMap<RawBytes, RawBytes> & /*userVars*/)
+void MudTelnet::onRelayNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                                    const QMap<RawBytes, RawBytes> &userVars)
 {
     if (getOptions().myOptionState[OPT_NEW_ENVIRON]) {
         sendNewEnvironIs(vars, userVars);
     }
 }
 
-void MudTelnet::onRelayNewEnvironInfo(const QMap<RawBytes, RawBytes> & /*vars*/,
-                                      const QMap<RawBytes, RawBytes> & /*userVars*/)
+void MudTelnet::onRelayNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                                      const QMap<RawBytes, RawBytes> &userVars)
 {
     if (getOptions().myOptionState[OPT_NEW_ENVIRON]) {
         sendNewEnvironInfo(vars, userVars);

--- a/src/proxy/MudTelnet.h
+++ b/src/proxy/MudTelnet.h
@@ -78,6 +78,7 @@ private:
     QString m_lineBuffer;
     bool m_receivedExternalDiscordHello = false;
     bool m_userSupportsNewEnviron = false;
+    bool m_serverRequestedNewEnviron = false;
 
 public:
     explicit MudTelnet(MudTelnetOutputs &outputs);

--- a/src/proxy/MudTelnet.h
+++ b/src/proxy/MudTelnet.h
@@ -42,6 +42,12 @@ public:
         virt_onMumeClientEdit(id, title, body);
     }
     void onMumeClientError(const QString &errmsg) { virt_onMumeClientError(errmsg); }
+    void onRelayNewEnvironSendFromMudToUser(const QList<RawBytes> &vars,
+                                            const QList<RawBytes> &userVars)
+    {
+        virt_onRelayNewEnvironSendFromMudToUser(vars, userVars);
+    }
+    NODISCARD QString onGetPeerAddress() const { return virt_onGetPeerAddress(); }
 
 private:
     virtual void virt_onAnalyzeMudStream(const RawBytes &, bool goAhead) = 0;
@@ -57,6 +63,10 @@ private:
                                        const QString &body)
         = 0;
     virtual void virt_onMumeClientError(const QString &errmsg) = 0;
+    virtual void virt_onRelayNewEnvironSendFromMudToUser(const QList<RawBytes> &vars,
+                                                         const QList<RawBytes> &userVars)
+        = 0;
+    NODISCARD virtual QString virt_onGetPeerAddress() const = 0;
 };
 
 class NODISCARD MudTelnet final : public AbstractTelnet
@@ -67,6 +77,7 @@ private:
     GmcpModuleSet m_gmcp;
     QString m_lineBuffer;
     bool m_receivedExternalDiscordHello = false;
+    bool m_userSupportsNewEnviron = false;
 
 public:
     explicit MudTelnet(MudTelnetOutputs &outputs);
@@ -77,6 +88,13 @@ private:
     void virt_receiveEchoMode(bool toggle) final;
     void virt_receiveGmcpMessage(const GmcpMessage &) final;
     void virt_receiveMudServerStatus(const TelnetMsspBytes &) final;
+    void virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
+                                    const QList<RawBytes> &userVars) final;
+    void virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                                  const QMap<RawBytes, RawBytes> &userVars) final;
+    void virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                                    const QMap<RawBytes, RawBytes> &userVars) final;
+    void virt_receiveNewEnvironDo() final;
     void virt_onGmcpEnabled() final;
     void virt_sendRawData(const TelnetIacBytes &data) final;
 
@@ -98,6 +116,11 @@ public:
     void onSendToMud(const QString &);
     void onRelayNaws(int, int);
     void onRelayTermType(const TelnetTermTypeBytes &);
+    void onRelayNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                             const QMap<RawBytes, RawBytes> &userVars);
+    void onRelayNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                               const QMap<RawBytes, RawBytes> &userVars);
+    void onUserNewEnvironNegotiated(bool supported);
     void onGmcpToMud(const GmcpMessage &);
     void onLoginCredentials(const QString &, const QString &);
 };

--- a/src/proxy/TaggedBytes.h
+++ b/src/proxy/TaggedBytes.h
@@ -80,6 +80,10 @@ public:
     {
         return !(a == b);
     }
+    NODISCARD friend bool operator<(const TaggedBytes &a, const TaggedBytes &b)
+    {
+        return a.getQByteArray() < b.getQByteArray();
+    }
     friend QDebug operator<<(QDebug debug, const TaggedBytes &tagged)
     {
         return debug << tagged.getQByteArray();

--- a/src/proxy/TcpSocket.cpp
+++ b/src/proxy/TcpSocket.cpp
@@ -43,6 +43,11 @@ bool TcpSocket::virt_isConnected() const
     return m_socket.state() == QAbstractSocket::ConnectedState;
 }
 
+QString TcpSocket::virt_peerAddress() const
+{
+    return m_socket.peerAddress().toString();
+}
+
 qint64 TcpSocket::bytesAvailable() const
 {
     return m_socket.bytesAvailable();

--- a/src/proxy/TcpSocket.h
+++ b/src/proxy/TcpSocket.h
@@ -21,6 +21,7 @@ public:
     void virt_flush() override;
     void virt_disconnectFromHost() override;
     NODISCARD bool virt_isConnected() const override;
+    NODISCARD QString virt_peerAddress() const override;
 
     NODISCARD qint64 bytesAvailable() const override;
 

--- a/src/proxy/UserTelnet.cpp
+++ b/src/proxy/UserTelnet.cpp
@@ -143,8 +143,8 @@ void UserTelnet::onSendMSSPToUser(const TelnetMsspBytes &data)
     sendMudServerStatus(data);
 }
 
-void UserTelnet::onRelayNewEnvironSend(const QList<RawBytes> & /*vars*/,
-                                       const QList<RawBytes> & /*userVars*/)
+void UserTelnet::onRelayNewEnvironSend(const QList<RawBytes> &vars,
+                                       const QList<RawBytes> &userVars)
 {
     if (!getOptions().myOptionState[OPT_NEW_ENVIRON]) {
         return;

--- a/src/proxy/UserTelnet.cpp
+++ b/src/proxy/UserTelnet.cpp
@@ -101,6 +101,7 @@ void UserTelnet::onConnected()
     requestTelnetOption(TN_WILL, OPT_GMCP);
     // Request permission to replace IAC GA with IAC EOR
     requestTelnetOption(TN_WILL, OPT_EOR);
+    requestTelnetOption(TN_DO, OPT_NEW_ENVIRON);
 }
 
 void UserTelnet::onAnalyzeUserStream(const TelnetIacBytes &data)
@@ -140,6 +141,14 @@ void UserTelnet::onSendMSSPToUser(const TelnetMsspBytes &data)
     }
 
     sendMudServerStatus(data);
+}
+
+void UserTelnet::onRelayNewEnvironSend(const QList<RawBytes> &vars, const QList<RawBytes> &userVars)
+{
+    if (!getOptions().myOptionState[OPT_NEW_ENVIRON]) {
+        return;
+    }
+    sendNewEnvironSend(vars, userVars);
 }
 
 void UserTelnet::virt_sendToMapper(const RawBytes &data, const bool goAhead)
@@ -236,6 +245,65 @@ void UserTelnet::virt_receiveTerminalType(const TelnetTermTypeBytes &data)
 void UserTelnet::virt_receiveWindowSize(const int x, const int y)
 {
     m_outputs.onRelayNawsFromUserToMud(x, y);
+}
+
+void UserTelnet::virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
+                                            const QList<RawBytes> &userVars)
+{
+    // A client shouldn't send SEND to a server, but if it does, ignore it for now as a proxy.
+}
+
+void UserTelnet::virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                                          const QMap<RawBytes, RawBytes> &userVars)
+{
+    auto it = vars.find(RawBytes("MTTS"));
+    if (it != vars.end()) {
+        bool ok = false;
+        int mtts = it.value().getQByteArray().toInt(&ok);
+        if (ok && (mtts & 4)) { // UTF-8 bit
+            setEncodingForName(ENCODING_UTF_8);
+        }
+    }
+    it = vars.find(RawBytes("CHARSET"));
+    if (it != vars.end()) {
+        setEncodingForName(mmqt::toStdStringUtf8(it.value().getQByteArray()));
+    }
+
+    m_outputs.onRelayNewEnvironIsFromUserToMud(vars, userVars);
+}
+
+void UserTelnet::virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                                            const QMap<RawBytes, RawBytes> &userVars)
+{
+    auto it = vars.find(RawBytes("MTTS"));
+    if (it != vars.end()) {
+        bool ok = false;
+        int mtts = it.value().getQByteArray().toInt(&ok);
+        if (ok && (mtts & 4)) { // UTF-8 bit
+            setEncodingForName(ENCODING_UTF_8);
+        }
+    }
+    it = vars.find(RawBytes("CHARSET"));
+    if (it != vars.end()) {
+        setEncodingForName(mmqt::toStdStringUtf8(it.value().getQByteArray()));
+    }
+
+    m_outputs.onRelayNewEnvironInfoFromUserToMud(vars, userVars);
+}
+
+void UserTelnet::virt_receiveNewEnvironDo()
+{
+    m_outputs.onNewEnvironNegotiated(true);
+}
+
+void UserTelnet::virt_receiveNewEnvironWill()
+{
+    m_outputs.onNewEnvironNegotiated(true);
+}
+
+void UserTelnet::virt_receiveNewEnvironWont()
+{
+    m_outputs.onNewEnvironNegotiated(false);
 }
 
 void UserTelnet::virt_sendRawData(const TelnetIacBytes &data)

--- a/src/proxy/UserTelnet.cpp
+++ b/src/proxy/UserTelnet.cpp
@@ -247,8 +247,8 @@ void UserTelnet::virt_receiveWindowSize(const int x, const int y)
     m_outputs.onRelayNawsFromUserToMud(x, y);
 }
 
-void UserTelnet::virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
-                                            const QList<RawBytes> &userVars)
+void UserTelnet::virt_receiveNewEnvironSend(const QList<RawBytes> & /*vars*/,
+                                            const QList<RawBytes> & /*userVars*/)
 {
     // A client shouldn't send SEND to a server, but if it does, ignore it for now as a proxy.
 }

--- a/src/proxy/UserTelnet.cpp
+++ b/src/proxy/UserTelnet.cpp
@@ -143,7 +143,8 @@ void UserTelnet::onSendMSSPToUser(const TelnetMsspBytes &data)
     sendMudServerStatus(data);
 }
 
-void UserTelnet::onRelayNewEnvironSend(const QList<RawBytes> &vars, const QList<RawBytes> &userVars)
+void UserTelnet::onRelayNewEnvironSend(const QList<RawBytes> & /*vars*/,
+                                       const QList<RawBytes> & /*userVars*/)
 {
     if (!getOptions().myOptionState[OPT_NEW_ENVIRON]) {
         return;

--- a/src/proxy/UserTelnet.h
+++ b/src/proxy/UserTelnet.h
@@ -29,6 +29,17 @@ public:
     {
         virt_onRelayTermTypeFromUserToMud(bytes);
     }
+    void onRelayNewEnvironIsFromUserToMud(const QMap<RawBytes, RawBytes> &vars,
+                                          const QMap<RawBytes, RawBytes> &userVars)
+    {
+        virt_onRelayNewEnvironIsFromUserToMud(vars, userVars);
+    }
+    void onRelayNewEnvironInfoFromUserToMud(const QMap<RawBytes, RawBytes> &vars,
+                                            const QMap<RawBytes, RawBytes> &userVars)
+    {
+        virt_onRelayNewEnvironInfoFromUserToMud(vars, userVars);
+    }
+    void onNewEnvironNegotiated(bool supported) { virt_onNewEnvironNegotiated(supported); }
 
 private:
     virtual void virt_onAnalyzeUserStream(const RawBytes &, bool) = 0;
@@ -36,6 +47,13 @@ private:
     virtual void virt_onRelayGmcpFromUserToMud(const GmcpMessage &) = 0;
     virtual void virt_onRelayNawsFromUserToMud(int, int) = 0;
     virtual void virt_onRelayTermTypeFromUserToMud(const TelnetTermTypeBytes &) = 0;
+    virtual void virt_onRelayNewEnvironIsFromUserToMud(const QMap<RawBytes, RawBytes> &vars,
+                                                       const QMap<RawBytes, RawBytes> &userVars)
+        = 0;
+    virtual void virt_onRelayNewEnvironInfoFromUserToMud(const QMap<RawBytes, RawBytes> &vars,
+                                                         const QMap<RawBytes, RawBytes> &userVars)
+        = 0;
+    virtual void virt_onNewEnvironNegotiated(bool supported) = 0;
 };
 
 class NODISCARD UserTelnet final : public AbstractTelnet
@@ -63,6 +81,15 @@ private:
     void virt_receiveGmcpMessage(const GmcpMessage &) final;
     void virt_receiveTerminalType(const TelnetTermTypeBytes &) final;
     void virt_receiveWindowSize(int, int) final;
+    void virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
+                                    const QList<RawBytes> &userVars) final;
+    void virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                                  const QMap<RawBytes, RawBytes> &userVars) final;
+    void virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                                    const QMap<RawBytes, RawBytes> &userVars) final;
+    void virt_receiveNewEnvironDo() final;
+    void virt_receiveNewEnvironWill() final;
+    void virt_receiveNewEnvironWont() final;
     void virt_sendRawData(const TelnetIacBytes &data) final;
 
 private:
@@ -78,4 +105,5 @@ public:
     void onRelayEchoMode(bool);
     void onGmcpToUser(const GmcpMessage &);
     void onSendMSSPToUser(const TelnetMsspBytes &);
+    void onRelayNewEnvironSend(const QList<RawBytes> &vars, const QList<RawBytes> &userVars);
 };

--- a/src/proxy/VirtualSocket.cpp
+++ b/src/proxy/VirtualSocket.cpp
@@ -61,6 +61,11 @@ bool VirtualSocket::virt_isConnected() const
     return m_peer != nullptr && m_peer->m_peer != nullptr;
 }
 
+QString VirtualSocket::virt_peerAddress() const
+{
+    return "127.0.0.1";
+}
+
 void VirtualSocket::slot_onPeerDestroyed()
 {
     if (m_peer) {

--- a/src/proxy/VirtualSocket.h
+++ b/src/proxy/VirtualSocket.h
@@ -24,6 +24,7 @@ public:
     void virt_flush() override;
     void virt_disconnectFromHost() override;
     NODISCARD bool virt_isConnected() const override;
+    NODISCARD QString virt_peerAddress() const override;
 
     void connectToPeer(VirtualSocket *peer);
 

--- a/src/proxy/proxy.cpp
+++ b/src/proxy/proxy.cpp
@@ -411,6 +411,22 @@ void Proxy::allocUserTelnet()
             // forwarded (to mud)
             getMudTelnet().onRelayTermType(bytes);
         }
+        void virt_onRelayNewEnvironIsFromUserToMud(const QMap<RawBytes, RawBytes> &vars,
+                                                   const QMap<RawBytes, RawBytes> &userVars) final
+        {
+            // forwarded (to mud)
+            getMudTelnet().onRelayNewEnvironIs(vars, userVars);
+        }
+        void virt_onRelayNewEnvironInfoFromUserToMud(const QMap<RawBytes, RawBytes> &vars,
+                                                     const QMap<RawBytes, RawBytes> &userVars) final
+        {
+            // forwarded (to mud)
+            getMudTelnet().onRelayNewEnvironInfo(vars, userVars);
+        }
+        void virt_onNewEnvironNegotiated(bool supported) final
+        {
+            getMudTelnet().onUserNewEnvironNegotiated(supported);
+        }
     };
 
     auto &pipe = getPipeline();
@@ -443,7 +459,7 @@ void Proxy::allocMudTelnet()
         {}
 
     private:
-        NODISCARD Proxy &getProxy() { return m_proxy; }
+        NODISCARD Proxy &getProxy() const { return m_proxy; }
         NODISCARD TelnetLineFilter &getMudTelnetFilter() { return getProxy().getMudTelnetFilter(); }
         NODISCARD UserTelnet &getUserTelnet() { return getProxy().getUserTelnet(); }
         NODISCARD MumeXmlParser &getMudParser() { return getProxy().getMudParser(); }
@@ -527,6 +543,17 @@ void Proxy::allocMudTelnet()
             qInfo() << errmsg;
             getProxy().sendToUser(SendToUserSourceEnum::FromMMapper,
                                   QString("MUME.Client protocol error: %1").arg(errmsg));
+        }
+
+        void virt_onRelayNewEnvironSendFromMudToUser(const QList<RawBytes> &vars,
+                                                     const QList<RawBytes> &userVars) final
+        {
+            getUserTelnet().onRelayNewEnvironSend(vars, userVars);
+        }
+
+        NODISCARD QString virt_onGetPeerAddress() const final
+        {
+            return getProxy().getUserSocketAddress();
         }
     };
 
@@ -1184,4 +1211,9 @@ void Proxy::log(const QString &msg)
 RemoteEdit &Proxy::getRemoteEdit()
 {
     return deref(m_remoteEdit);
+}
+
+QString Proxy::getUserSocketAddress() const
+{
+    return m_userSocket->peerAddress();
 }

--- a/src/proxy/proxy.h
+++ b/src/proxy/proxy.h
@@ -329,4 +329,5 @@ private:
 
 private:
     NODISCARD bool hasConnectedUserSocket() const;
+    NODISCARD QString getUserSocketAddress() const;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,7 +129,11 @@ set(proxy_SRCS
     ../src/proxy/GmcpUtils.h
     ../src/proxy/telnetfilter.cpp
     ../src/proxy/telnetfilter.h
-     )
+    ../src/proxy/AbstractTelnet.cpp
+    ../src/proxy/AbstractTelnet.h
+    ../src/proxy/TextCodec.cpp
+    ../src/proxy/TextCodec.h
+)
 set(TestProxy_SRCS TestProxy.cpp)
 add_executable(TestProxy ${TestProxy_SRCS} ${proxy_SRCS})
 add_dependencies(TestProxy mm_test mm_global)

--- a/tests/TestProxy.cpp
+++ b/tests/TestProxy.cpp
@@ -5,6 +5,7 @@
 
 #include "../src/global/TextUtils.h"
 #include "../src/proxy/GmcpMessage.h"
+#include "../src/proxy/AbstractTelnet.h"
 #include "../src/proxy/GmcpModule.h"
 #include "../src/proxy/GmcpUtils.h"
 #include "../src/proxy/telnetfilter.h"
@@ -66,6 +67,101 @@ void TestProxy::gmcpModuleTest()
 void TestProxy::telnetFilterTest()
 {
     test::test_telnetfilter();
+}
+
+class TestTelnet final : public AbstractTelnet
+{
+public:
+    TestTelnet()
+        : AbstractTelnet(TextCodecStrategyEnum::FORCE_UTF_8, TelnetTermTypeBytes{"test"})
+    {}
+    void virt_sendRawData(const TelnetIacBytes &data) override { lastRaw = data; }
+    void virt_sendToMapper(const RawBytes &data, bool goAhead) override {}
+    void virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
+                                    const QList<RawBytes> &userVars) override
+    {
+        receivedVars = vars;
+        receivedUserVars = userVars;
+        receivedType = 1; // SEND
+    }
+    void virt_receiveNewEnvironIs(const QMap<RawBytes, RawBytes> &vars,
+                                  const QMap<RawBytes, RawBytes> &userVars) override
+    {
+        receivedIsVars = vars;
+        receivedIsUserVars = userVars;
+        receivedType = 0; // IS
+    }
+    void virt_receiveNewEnvironInfo(const QMap<RawBytes, RawBytes> &vars,
+                                    const QMap<RawBytes, RawBytes> &userVars) override
+    {
+        receivedIsVars = vars;
+        receivedIsUserVars = userVars;
+        receivedType = 2; // INFO
+    }
+
+    void onRead(const QByteArray &data) { onReadInternal(TelnetIacBytes{data}); }
+    void enableNewEnviron() { m_options.myOptionState[OPT_NEW_ENVIRON] = true; }
+
+    TelnetIacBytes lastRaw;
+    QList<RawBytes> receivedVars;
+    QList<RawBytes> receivedUserVars;
+    QMap<RawBytes, RawBytes> receivedIsVars;
+    QMap<RawBytes, RawBytes> receivedIsUserVars;
+    int receivedType = -1;
+};
+
+void TestProxy::mnesTest()
+{
+    TestTelnet telnet;
+    telnet.enableNewEnviron();
+
+    // Test SEND ALL
+    // IAC SB NEW-ENVIRON SEND IAC SE -> 255 250 39 1 255 240
+    QByteArray sendAll;
+    sendAll.append((char)255);
+    sendAll.append((char)250);
+    sendAll.append((char)39);
+    sendAll.append((char)1);
+    sendAll.append((char)255);
+    sendAll.append((char)240);
+    telnet.onRead(sendAll);
+    QCOMPARE(telnet.receivedType, 1);
+    QVERIFY(telnet.receivedVars.isEmpty());
+    QVERIFY(telnet.receivedUserVars.isEmpty());
+
+    // Test SEND VAR
+    // IAC SB NEW-ENVIRON SEND VAR "MTTS" IAC SE
+    QByteArray sendVar;
+    sendVar.append((char)255);
+    sendVar.append((char)250);
+    sendVar.append((char)39);
+    sendVar.append((char)1);
+    sendVar.append((char)0);
+    sendVar.append("MTTS");
+    sendVar.append((char)255);
+    sendVar.append((char)240);
+    telnet.onRead(sendVar);
+    QCOMPARE(telnet.receivedType, 1);
+    QCOMPARE(telnet.receivedVars.size(), 1);
+    QCOMPARE(telnet.receivedVars[0].getQByteArray(), QByteArray("MTTS"));
+
+    // Test IS
+    // IAC SB NEW-ENVIRON IS VAR "CHARSET" VAL "UTF-8" IAC SE
+    QByteArray isVar;
+    isVar.append((char)255);
+    isVar.append((char)250);
+    isVar.append((char)39);
+    isVar.append((char)0);
+    isVar.append((char)0);
+    isVar.append("CHARSET");
+    isVar.append((char)1);
+    isVar.append("UTF-8");
+    isVar.append((char)255);
+    isVar.append((char)240);
+    telnet.onRead(isVar);
+    QCOMPARE(telnet.receivedType, 0);
+    QCOMPARE(telnet.receivedIsVars.size(), 1);
+    QCOMPARE(telnet.receivedIsVars[RawBytes("CHARSET")].getQByteArray(), QByteArray("UTF-8"));
 }
 
 QTEST_MAIN(TestProxy)

--- a/tests/TestProxy.cpp
+++ b/tests/TestProxy.cpp
@@ -75,8 +75,10 @@ public:
     TestTelnet()
         : AbstractTelnet(TextCodecStrategyEnum::FORCE_UTF_8, TelnetTermTypeBytes{"test"})
     {}
+    ~TestTelnet() override;
+
     void virt_sendRawData(const TelnetIacBytes &data) override { lastRaw = data; }
-    void virt_sendToMapper(const RawBytes &data, bool goAhead) override {}
+    void virt_sendToMapper(const RawBytes & /*data*/, bool /*goAhead*/) override {}
     void virt_receiveNewEnvironSend(const QList<RawBytes> &vars,
                                     const QList<RawBytes> &userVars) override
     {
@@ -109,6 +111,8 @@ public:
     QMap<RawBytes, RawBytes> receivedIsUserVars;
     int receivedType = -1;
 };
+
+TestTelnet::~TestTelnet() = default;
 
 void TestProxy::mnesTest()
 {

--- a/tests/TestProxy.cpp
+++ b/tests/TestProxy.cpp
@@ -4,8 +4,8 @@
 #include "TestProxy.h"
 
 #include "../src/global/TextUtils.h"
-#include "../src/proxy/GmcpMessage.h"
 #include "../src/proxy/AbstractTelnet.h"
+#include "../src/proxy/GmcpMessage.h"
 #include "../src/proxy/GmcpModule.h"
 #include "../src/proxy/GmcpUtils.h"
 #include "../src/proxy/telnetfilter.h"
@@ -118,12 +118,12 @@ void TestProxy::mnesTest()
     // Test SEND ALL
     // IAC SB NEW-ENVIRON SEND IAC SE -> 255 250 39 1 255 240
     QByteArray sendAll;
-    sendAll.append((char)255);
-    sendAll.append((char)250);
-    sendAll.append((char)39);
-    sendAll.append((char)1);
-    sendAll.append((char)255);
-    sendAll.append((char)240);
+    sendAll.append(static_cast<char>(255u));
+    sendAll.append(static_cast<char>(250u));
+    sendAll.append(static_cast<char>(39u));
+    sendAll.append(static_cast<char>(1u));
+    sendAll.append(static_cast<char>(255u));
+    sendAll.append(static_cast<char>(240u));
     telnet.onRead(sendAll);
     QCOMPARE(telnet.receivedType, 1);
     QVERIFY(telnet.receivedVars.isEmpty());
@@ -132,14 +132,14 @@ void TestProxy::mnesTest()
     // Test SEND VAR
     // IAC SB NEW-ENVIRON SEND VAR "MTTS" IAC SE
     QByteArray sendVar;
-    sendVar.append((char)255);
-    sendVar.append((char)250);
-    sendVar.append((char)39);
-    sendVar.append((char)1);
-    sendVar.append((char)0);
+    sendVar.append(static_cast<char>(255u));
+    sendVar.append(static_cast<char>(250u));
+    sendVar.append(static_cast<char>(39u));
+    sendVar.append(static_cast<char>(1u));
+    sendVar.append(static_cast<char>(0u));
     sendVar.append("MTTS");
-    sendVar.append((char)255);
-    sendVar.append((char)240);
+    sendVar.append(static_cast<char>(255u));
+    sendVar.append(static_cast<char>(240u));
     telnet.onRead(sendVar);
     QCOMPARE(telnet.receivedType, 1);
     QCOMPARE(telnet.receivedVars.size(), 1);
@@ -148,16 +148,16 @@ void TestProxy::mnesTest()
     // Test IS
     // IAC SB NEW-ENVIRON IS VAR "CHARSET" VAL "UTF-8" IAC SE
     QByteArray isVar;
-    isVar.append((char)255);
-    isVar.append((char)250);
-    isVar.append((char)39);
-    isVar.append((char)0);
-    isVar.append((char)0);
+    isVar.append(static_cast<char>(255u));
+    isVar.append(static_cast<char>(250u));
+    isVar.append(static_cast<char>(39u));
+    isVar.append(static_cast<char>(0u));
+    isVar.append(static_cast<char>(0u));
     isVar.append("CHARSET");
-    isVar.append((char)1);
+    isVar.append(static_cast<char>(1u));
     isVar.append("UTF-8");
-    isVar.append((char)255);
-    isVar.append((char)240);
+    isVar.append(static_cast<char>(255u));
+    isVar.append(static_cast<char>(240u));
     telnet.onRead(isVar);
     QCOMPARE(telnet.receivedType, 0);
     QCOMPARE(telnet.receivedIsVars.size(), 1);

--- a/tests/TestProxy.h
+++ b/tests/TestProxy.h
@@ -20,4 +20,5 @@ private Q_SLOTS:
     static void gmcpMessageSerializeTest();
     static void gmcpModuleTest();
     static void telnetFilterTest();
+    static void mnesTest();
 };


### PR DESCRIPTION
This change implements the MNES (Mud New-Environ Standard) protocol as requested.

Key features:
1. **Context-Aware Proxying**: MMapper now waits for the connected user client to negotiate NEW-ENVIRON before announcing its own support to the MUD server.
2. **IP Address Reporting**: Automatically reports the real IP address of the connected user to the MUD via the `IPADDRESS` variable.
3. **Capability Reporting**: Reports MMapper's own capabilities via `MTTS` bitvector (currently set to 653: ANSI | UTF-8 | 256 COLORS | PROXY | MNES).
4. **Internal Client Defaults**: The built-in ClientTelnet has sane defaults for `CLIENT_NAME`, `CLIENT_VERSION`, and `CHARSET`.
5. **Protocol Synchronization**: Character encoding is now automatically synchronized if the client specifies it via MNES variables.
6. **Robust Parsing**: The NEW-ENVIRON parser handles `VAR`, `VAL`, `USERVAR`, and `ESC` sequences, and correctly identifies "Send All" requests.
7. **Better Debugging**: Improved telnet subnegotiation logging by disambiguating constants that share the same value (like `SEND`, `REQUEST`, `MODE`, `EDIT`).

---
*PR created automatically by Jules for task [2551435476655868122](https://jules.google.com/task/2551435476655868122) started by @nschimme*

## Summary by Sourcery

Add support for Telnet NEW-ENVIRON (MNES) negotiation and proxying across client, proxy, and MUD connections, including environment variable exchange and capability reporting.

New Features:
- Introduce full NEW-ENVIRON subnegotiation handling in the telnet core, including VAR/VAL/USERVAR/ESC parsing and send/is/info helpers.
- Proxy NEW-ENVIRON negotiations between user clients and the MUD, reporting MMapper capabilities via MTTS and the user's IP via IPADDRESS.
- Extend the internal ClientTelnet to answer NEW-ENVIRON SEND requests with default CLIENT_NAME, CLIENT_VERSION, CHARSET, and MTTS values.
- Automatically synchronize character encoding based on MNES variables received from the client or server.

Enhancements:
- Improve telnet subnegotiation debug logging by disambiguating shared subnegotiation codes based on the active option.
- Expose peer IP address through the abstract socket layer and proxy so it can be surfaced to MNES.
- Add comparison support for TaggedBytes to enable use in ordered containers like QMap.