### PR TITLE
Fix Mac release crash in model/table views

### DIFF
--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -567,27 +567,23 @@ int GroupModel::columnCount(const QModelIndex & /* parent */) const
 NODISCARD static QStringView getPrettyName(const CharacterPositionEnum position)
 {
 #define X_CASE(UPPER_CASE, lower_case, CamelCase, friendly) \
-    do { \
     case CharacterPositionEnum::UPPER_CASE: \
-        return QStringLiteral(friendly); \
-    } while (false);
+        return u"" friendly;
     switch (position) {
         XFOREACH_CHARACTER_POSITION(X_CASE)
     }
-    return QString::asprintf("(CharacterPositionEnum)%d", static_cast<int>(position));
+    return u"(unknown)";
 #undef X_CASE
 }
 NODISCARD static QStringView getPrettyName(const CharacterAffectEnum affect)
 {
 #define X_CASE(UPPER_CASE, lower_case, CamelCase, friendly) \
-    do { \
     case CharacterAffectEnum::UPPER_CASE: \
-        return QStringLiteral(friendly); \
-    } while (false);
+        return u"" friendly;
     switch (affect) {
         XFOREACH_CHARACTER_AFFECT(X_CASE)
     }
-    return QString::asprintf("(CharacterAffectEnum)%d", static_cast<int>(affect));
+    return u"(unknown)";
 #undef X_CASE
 }
 

--- a/src/mainwindow/roomeditattrdlg.cpp
+++ b/src/mainwindow/roomeditattrdlg.cpp
@@ -203,7 +203,7 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 
     for (const RoomMobFlagEnum flag : ALL_MOB_FLAGS) {
         m_mobListItems[flag] = std::make_unique<RoomListWidgetItem>(getIcon(flag),
-                                                                    getName(flag),
+                                                                    getName(flag).toString(),
                                                                     getPriority(flag));
     }
 
@@ -214,7 +214,7 @@ RoomEditAttrDlg::RoomEditAttrDlg(QWidget *parent)
 
     for (const RoomLoadFlagEnum flag : ALL_LOAD_FLAGS) {
         m_loadListItems[flag] = std::make_unique<RoomListWidgetItem>(getIcon(flag),
-                                                                     getName(flag),
+                                                                     getName(flag).toString(),
                                                                      getPriority(flag));
     }
 

--- a/src/map/mmapper2room.cpp
+++ b/src/map/mmapper2room.cpp
@@ -107,28 +107,24 @@ std::string_view to_string_view(const RoomTerrainEnum e)
     std::abort();
 }
 
-QString getName(const RoomTerrainEnum terrain)
+QStringView getName(const RoomTerrainEnum terrain)
 {
 #define X_CASE(UPPER) \
-    do { \
     case RoomTerrainEnum::UPPER: \
-        return #UPPER; \
-    } while (false);
+        return u"" #UPPER;
 
     switch (terrain) {
         XFOREACH_RoomTerrainEnum(X_CASE)
     }
-    return QString::asprintf("(RoomTerrainEnum)%d", static_cast<int>(terrain));
-#undef X_CASE2
+    return u"(unknown)";
+#undef X_CASE
 }
 
-QString getName(const RoomMobFlagEnum flag)
+QStringView getName(const RoomMobFlagEnum flag)
 {
 #define X_CASE2(UPPER, desc) \
-    do { \
     case RoomMobFlagEnum::UPPER: \
-        return desc; \
-    } while (false)
+        return u"" desc;
     switch (flag) {
         X_CASE2(RENT, "Rent place");
         X_CASE2(SHOP, "Generic shop");
@@ -150,17 +146,15 @@ QString getName(const RoomMobFlagEnum flag)
         X_CASE2(MILKABLE, "Milkable mob");
         X_CASE2(RATTLESNAKE, "Rattlesnake mob");
     }
-    return QString::asprintf("(RoomMobFlagEnum)%d", static_cast<int>(flag));
+    return u"(unknown)";
 #undef X_CASE2
 }
 
-QString getName(const RoomLoadFlagEnum flag)
+QStringView getName(const RoomLoadFlagEnum flag)
 {
 #define X_CASE2(UPPER, desc) \
-    do { \
     case RoomLoadFlagEnum::UPPER: \
-        return desc; \
-    } while (false)
+        return u"" desc;
     switch (flag) {
         X_CASE2(TREASURE, "Treasure");
         X_CASE2(ARMOUR, "Armour");
@@ -188,7 +182,7 @@ QString getName(const RoomLoadFlagEnum flag)
         X_CASE2(FERRY, "Ferry");
         X_CASE2(DEATHTRAP, "Deathtrap");
     }
-    return QString::asprintf("(RoomLoadFlagEnum)%d", static_cast<int>(flag));
+    return u"(unknown)";
 #undef X_CASE2
 }
 

--- a/src/map/mmapper2room.h
+++ b/src/map/mmapper2room.h
@@ -318,9 +318,9 @@ NODISCARD extern std::string_view to_string_view(RoomSundeathEnum);
 NODISCARD extern std::string_view to_string_view(RoomTerrainEnum);
 
 /* REVISIT: merge these with human-readable names used in parser output? */
-NODISCARD extern QString getName(RoomLoadFlagEnum flag);
-NODISCARD extern QString getName(RoomMobFlagEnum flag);
-NODISCARD extern QString getName(RoomTerrainEnum terrain);
+NODISCARD extern QStringView getName(RoomLoadFlagEnum flag);
+NODISCARD extern QStringView getName(RoomMobFlagEnum flag);
+NODISCARD extern QStringView getName(RoomTerrainEnum terrain);
 
 void sanitizeRoomArea(std::string &area);
 void sanitizeRoomName(std::string &name);

--- a/src/mapdata/shortestpath.cpp
+++ b/src/mapdata/shortestpath.cpp
@@ -125,7 +125,7 @@ void MapData::shortestPathSearch(const RoomHandle &origin,
         const int spindex = utils::pop_top(future_paths).second;
         // REVISIT: Should thisr be a copy or a reference?
         // (can sp_nodes be modified during the lifetime of the reference?)
-        const auto &thisr = sp_nodes[spindex].r;
+        const auto thisr = sp_nodes[spindex].r;
         const auto thisdist = sp_nodes[spindex].dist;
         auto room_id = thisr.getId();
         if (visited.contains(room_id)) {

--- a/src/timers/TimerWidget.cpp
+++ b/src/timers/TimerWidget.cpp
@@ -23,7 +23,7 @@ TimerWidget::TimerWidget(CTimers &timers, QWidget *parent)
     m_model = new TimerModel(m_timers, this);
     m_view = new QTableView(this);
     m_view->setModel(m_model);
-    auto *delegate = new TimerDelegate(this);
+    auto *delegate = new TimerDelegate(m_view);
     for (int i = 0; i < TimerModel::ColCount; ++i) {
         m_view->setItemDelegateForColumn(i, delegate);
     }


### PR DESCRIPTION
I have fixed the crash on Mac release builds by addressing two separate issues: dangling `QStringView` pointers in string conversion functions and an incorrect destruction order of the `TimerDelegate` in `TimerWidget`. I've also proactively applied the same string safety pattern to `getName` functions in `src/map/mmapper2room.cpp`. All tests passed successfully.

---
*PR created automatically by Jules for task [9937513932170245834](https://jules.google.com/task/9937513932170245834) started by @nschimme*

## Summary by Sourcery

Ensure safe, non-dangling string views in model- and map-related name helpers and correct timer delegate ownership to prevent crashes in Mac release builds.

Bug Fixes:
- Prevent crashes from dangling QStringView usage in character and room name helper functions by returning static QStringView literals with explicit unknown fallbacks.
- Fix potential crash in TimerWidget by making the TimerDelegate owned by the table view rather than the parent widget.

Enhancements:
- Align room name helper APIs to return QStringView consistently and update call sites to convert to QString only where needed.