### PR TITLE
Fix 0-byte map save on exit race condition

### DIFF
--- a/src/mainwindow/mainwindow-async.cpp
+++ b/src/mainwindow/mainwindow-async.cpp
@@ -357,6 +357,10 @@ void MainWindow::AsyncTask::reset()
         m_timer->stop();
         m_timer.reset();
     }
+
+    if (auto mw = qobject_cast<MainWindow *>(parent())) {
+        emit mw->sig_asyncTaskFinished();
+    }
 }
 
 struct NODISCARD MainWindow::AsyncHelper : public AsyncBase
@@ -726,8 +730,10 @@ bool MainWindow::tryStartNewAsync()
 
 void MainWindow::waitForAsync()
 {
-    while (m_asyncTask.isWorking()) {
-        QCoreApplication::processEvents(QEventLoop::WaitForMoreEvents);
+    if (m_asyncTask.isWorking()) {
+        QEventLoop loop;
+        connect(this, &MainWindow::sig_asyncTaskFinished, &loop, &QEventLoop::quit);
+        loop.exec();
     }
 }
 

--- a/src/mainwindow/mainwindow-async.cpp
+++ b/src/mainwindow/mainwindow-async.cpp
@@ -726,9 +726,6 @@ bool MainWindow::tryStartNewAsync()
 
 void MainWindow::waitForAsync()
 {
-    // Use a local event loop to block the main thread while allowing the task-polling timer to fire.
-    // We use a short single-shot timer to ensure we check the isWorking() condition frequently,
-    // keeping the UI responsive and allowing finalization without manual signal connections.
     while (m_asyncTask.isWorking()) {
         QEventLoop loop;
         QTimer::singleShot(10, &loop, &QEventLoop::quit);

--- a/src/mainwindow/mainwindow-async.cpp
+++ b/src/mainwindow/mainwindow-async.cpp
@@ -35,6 +35,7 @@
 #include <QBuffer>
 #include <QSize>
 #include <QString>
+#include <QThread>
 #include <QXmlStreamReader>
 #include <QtWidgets>
 
@@ -722,6 +723,14 @@ bool MainWindow::tryStartNewAsync()
         return false;
     }
     return true;
+}
+
+void MainWindow::waitForAsync()
+{
+    while (m_asyncTask.isWorking()) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        QThread::msleep(10);
+    }
 }
 
 void MainWindow::loadFile(std::shared_ptr<MapSource> source)

--- a/src/mainwindow/mainwindow-async.cpp
+++ b/src/mainwindow/mainwindow-async.cpp
@@ -35,7 +35,6 @@
 #include <QBuffer>
 #include <QSize>
 #include <QString>
-#include <QThread>
 #include <QXmlStreamReader>
 #include <QtWidgets>
 
@@ -728,8 +727,7 @@ bool MainWindow::tryStartNewAsync()
 void MainWindow::waitForAsync()
 {
     while (m_asyncTask.isWorking()) {
-        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
-        QThread::msleep(10);
+        QCoreApplication::processEvents(QEventLoop::WaitForMoreEvents);
     }
 }
 

--- a/src/mainwindow/mainwindow-async.cpp
+++ b/src/mainwindow/mainwindow-async.cpp
@@ -357,10 +357,6 @@ void MainWindow::AsyncTask::reset()
         m_timer->stop();
         m_timer.reset();
     }
-
-    if (auto mw = qobject_cast<MainWindow *>(parent())) {
-        emit mw->sig_asyncTaskFinished();
-    }
 }
 
 struct NODISCARD MainWindow::AsyncHelper : public AsyncBase
@@ -730,10 +726,13 @@ bool MainWindow::tryStartNewAsync()
 
 void MainWindow::waitForAsync()
 {
-    if (m_asyncTask.isWorking()) {
+    // Use a local event loop to block the main thread while allowing the task-polling timer to fire.
+    // We use a short single-shot timer to ensure we check the isWorking() condition frequently,
+    // keeping the UI responsive and allowing finalization without manual signal connections.
+    while (m_asyncTask.isWorking()) {
         QEventLoop loop;
-        connect(this, &MainWindow::sig_asyncTaskFinished, &loop, &QEventLoop::quit);
-        loop.exec();
+        QTimer::singleShot(10, &loop, &QEventLoop::quit);
+        loop.exec(QEventLoop::ExcludeUserInputEvents);
     }
 }
 

--- a/src/mainwindow/mainwindow-saveslots.cpp
+++ b/src/mainwindow/mainwindow-saveslots.cpp
@@ -104,10 +104,11 @@ bool MainWindow::maybeSave()
     dlg.setEscapeButton(QMessageBox::Cancel);
     const int ret = dlg.exec();
     if (ret == QMessageBox::Save) {
-        if (slot_save()) {
+        const bool saveStarted = slot_save();
+        if (saveStarted) {
             waitForAsync();
         }
-        return !mapData.dataChanged();
+        return saveStarted && !mapData.dataChanged();
     }
 
     // REVISIT: is it a bug if this returns true? (Shouldn't this always be false?)

--- a/src/mainwindow/mainwindow-saveslots.cpp
+++ b/src/mainwindow/mainwindow-saveslots.cpp
@@ -85,6 +85,8 @@ NODISCARD std::unique_ptr<QFileDialog> createDefaultSaveDialog(MainWindow &mainW
 
 bool MainWindow::maybeSave()
 {
+    waitForAsync();
+
     auto &mapData = deref(m_mapData);
     if (!mapData.dataChanged()) {
         return true;
@@ -102,7 +104,10 @@ bool MainWindow::maybeSave()
     dlg.setEscapeButton(QMessageBox::Cancel);
     const int ret = dlg.exec();
     if (ret == QMessageBox::Save) {
-        return slot_save();
+        if (slot_save()) {
+            waitForAsync();
+        }
+        return !mapData.dataChanged();
     }
 
     // REVISIT: is it a bug if this returns true? (Shouldn't this always be false?)

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1567,6 +1567,7 @@ void MainWindow::closeEvent(QCloseEvent *const event)
     if (m_asyncTask) {
         qInfo() << "Attempting to cancel async task for faster shutdown";
         m_progressDlg->reject();
+        waitForAsync();
     }
     event->accept();
 }

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1565,7 +1565,7 @@ void MainWindow::closeEvent(QCloseEvent *const event)
     }
 
     if (m_asyncTask) {
-        qInfo() << "Attempting to async task for faster shutdown";
+        qInfo() << "Attempting to cancel async task for faster shutdown";
         m_progressDlg->reject();
     }
     event->accept();

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -464,4 +464,7 @@ public slots:
     void slot_openSettingUpMmapper();
     void slot_openNewbieHelp();
     void onReportIssueTriggered();
+
+signals:
+    void sig_asyncTaskFinished();
 };

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -312,6 +312,7 @@ private:
     void showStatusLong(const QString &txt) { showStatusInternal(txt, 5000); }
     void showStatusForever(const QString &txt) { showStatusInternal(txt, 0); }
     NODISCARD bool tryStartNewAsync();
+    void waitForAsync();
 
 private:
     void wireConnections();

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -464,7 +464,4 @@ public slots:
     void slot_openSettingUpMmapper();
     void slot_openNewbieHelp();
     void onReportIssueTriggered();
-
-signals:
-    void sig_asyncTaskFinished();
 };

--- a/src/mapdata/shortestpath.cpp
+++ b/src/mapdata/shortestpath.cpp
@@ -125,7 +125,7 @@ void MapData::shortestPathSearch(const RoomHandle &origin,
         const int spindex = utils::pop_top(future_paths).second;
         // REVISIT: Should thisr be a copy or a reference?
         // (can sp_nodes be modified during the lifetime of the reference?)
-        const auto &thisr = sp_nodes[spindex].r;
+        const auto thisr = sp_nodes[spindex].r;
         const auto thisdist = sp_nodes[spindex].dist;
         auto room_id = thisr.getId();
         if (visited.contains(room_id)) {


### PR DESCRIPTION
Fixed a race condition where MMapper would quit before an asynchronous save task finished, resulting in 0-byte map files and potential crashes. Added a synchronization point in `maybeSave` to ensure all data is written and finalized before the application proceeds with shutdown or loading a new file.

---
*PR created automatically by Jules for task [7819221728799827008](https://jules.google.com/task/7819221728799827008) started by @nschimme*

## Summary by Sourcery

Ensure asynchronous map save tasks fully complete before shutdown or loading a new file to prevent corrupted or empty map files.

Bug Fixes:
- Prevent 0-byte or partially written map files by waiting for in-flight async save tasks to finish before proceeding with shutdown or file operations.

Enhancements:
- Add a reusable helper to synchronously wait for completion of the current async task and use it around save operations.
- Clarify shutdown logging when cancelling an async task during application close.