### PR TITLE
Fix GroupWidget destruction crash on Mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
     libgl1-mesa-dev \
     libglib2.0-0 \
     libxkbcommon-dev \
+    librsvg2-bin \
     ninja-build \
     pkg-config \
     python3 \

--- a/cmake/WasmHtml.cmake
+++ b/cmake/WasmHtml.cmake
@@ -12,7 +12,7 @@
 #         -DFAVICON_SRC=<path/mmapper-lo-release.svg>
 #         -P WasmHtml.cmake
 
-foreach(var HTML_FILE LOGO_SRC FAVICON_SRC)
+foreach(var HTML_FILE LOGO_SRC FAVICON_SRC THEME_COLOR)
     if(NOT ${var})
         message(FATAL_ERROR "${var} not specified for WasmHtml.cmake")
     endif()
@@ -20,10 +20,10 @@ endforeach()
 
 file(READ "${HTML_FILE}" HTML_CONTENT)
 
-# Inject favicon link and COI service worker script after <head>
+# Inject favicon link, PWA manifest, and COI service worker script after <head>
 string(REPLACE
     "<head>"
-    "<head>\n    <link rel=\"icon\" href=\"favicon.svg\" type=\"image/svg+xml\">\n    <script src=\"./coi-serviceworker.js\"></script>"
+    "<head>\n    <link rel=\"icon\" href=\"favicon.svg\" type=\"image/svg+xml\">\n    <link rel=\"manifest\" href=\"manifest.json\">\n    <meta name=\"theme-color\" content=\"${THEME_COLOR}\">\n    <script src=\"./coi-serviceworker.js\"></script>"
     HTML_CONTENT "${HTML_CONTENT}"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -856,15 +856,52 @@ endif()
 
 if(EMSCRIPTEN)
     add_dependencies(mmapper assets_manifest)
+    if(MMAPPER_BETA)
+        set(MMAPPER_THEME_COLOR "#5281c4")
+    else()
+        set(MMAPPER_THEME_COLOR "#32a6de")
+    endif()
+
+    configure_file(resources/wasm/manifest.json.in ${CMAKE_CURRENT_BINARY_DIR}/manifest.json @ONLY)
+
+    set(ICON_SVG "${CMAKE_SOURCE_DIR}/src/resources/icons/mmapper-hi-${MMAPPER_BRAND_SUFFIX}.svg")
+    set(ICON_192 "${CMAKE_CURRENT_BINARY_DIR}/icon-192.png")
+    set(ICON_512 "${CMAKE_CURRENT_BINARY_DIR}/icon-512.png")
+
+    find_program(RSVG_CONVERT rsvg-convert)
+    if(RSVG_CONVERT)
+        add_custom_command(
+            OUTPUT "${ICON_192}" "${ICON_512}"
+            COMMAND "${RSVG_CONVERT}" -w 192 -h 192 "${ICON_SVG}" -o "${ICON_192}"
+            COMMAND "${RSVG_CONVERT}" -w 512 -h 512 "${ICON_SVG}" -o "${ICON_512}"
+            DEPENDS "${ICON_SVG}"
+            COMMENT "Generating PNG icons from SVG"
+            VERBATIM
+        )
+        add_custom_target(mmapper_icons DEPENDS "${ICON_192}" "${ICON_512}")
+        add_dependencies(mmapper mmapper_icons)
+    else()
+        message(WARNING "rsvg-convert not found. PWA icons will not be generated.")
+    endif()
+
     add_custom_command(TARGET mmapper POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/manifest.json" "$<TARGET_FILE_DIR:mmapper>/manifest.json"
         COMMAND ${CMAKE_COMMAND}
             "-DHTML_FILE=$<TARGET_FILE_DIR:mmapper>/mmapper.html"
             "-DLOGO_SRC=${CMAKE_SOURCE_DIR}/src/resources/icons/mmapper-hi-${MMAPPER_BRAND_SUFFIX}.svg"
             "-DFAVICON_SRC=${CMAKE_SOURCE_DIR}/src/resources/icons/mmapper-lo-${MMAPPER_BRAND_SUFFIX}.svg"
+            "-DTHEME_COLOR=${MMAPPER_THEME_COLOR}"
             -P "${CMAKE_SOURCE_DIR}/cmake/WasmHtml.cmake"
-        COMMENT "Patching Wasm HTML"
+        COMMENT "Patching Wasm HTML and deploying PWA assets"
         VERBATIM
     )
+    if(RSVG_CONVERT)
+        add_custom_command(TARGET mmapper POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "${ICON_192}" "$<TARGET_FILE_DIR:mmapper>/icon-192.png"
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "${ICON_512}" "$<TARGET_FILE_DIR:mmapper>/icon-512.png"
+            VERBATIM
+        )
+    endif()
 endif()
 
 if(WITH_ZLIB AND NOT EMSCRIPTEN)
@@ -984,10 +1021,20 @@ if(EMSCRIPTEN)
             "$<TARGET_FILE_DIR:mmapper>/qtloader.js"
             "$<TARGET_FILE_DIR:mmapper>/logo.svg"
             "$<TARGET_FILE_DIR:mmapper>/favicon.svg"
+            "$<TARGET_FILE_DIR:mmapper>/manifest.json"
             "$<TARGET_FILE_DIR:mmapper>/coi-serviceworker.js"
         DESTINATION "."
         COMPONENT applications
     )
+    if(RSVG_CONVERT)
+        install(
+            FILES
+                "$<TARGET_FILE_DIR:mmapper>/icon-192.png"
+                "$<TARGET_FILE_DIR:mmapper>/icon-512.png"
+            DESTINATION "."
+            COMPONENT applications
+        )
+    endif()
     install(
         FILES "$<TARGET_FILE_DIR:mmapper>/mmapper.html"
         DESTINATION "."

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -17,7 +17,6 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
-#include <unordered_set>
 #include <vector>
 
 #include <QAction>

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
+#include <unordered_set>
 #include <vector>
 
 #include <QAction>

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
+#include <unordered_set>
 #include <vector>
 
 #include <QAction>
@@ -829,14 +830,7 @@ GroupWidget::GroupWidget(Mmapper2Group *const group, MapData *const md, QWidget 
     : QWidget(parent)
     , m_group(group)
     , m_map(md)
-    , m_model(this)
 {
-    if (m_group) {
-        m_model.setCharacters(m_group->selectAll());
-    } else {
-        m_model.setCharacters({});
-    }
-
     auto *layout = new QVBoxLayout(this);
     layout->setAlignment(Qt::AlignTop);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -849,8 +843,15 @@ GroupWidget::GroupWidget(Mmapper2Group *const group, MapData *const md, QWidget 
     m_table->horizontalHeader()->setStretchLastSection(true);
     m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
+    m_model = new GroupModel(m_table);
+    if (m_group) {
+        m_model->setCharacters(m_group->selectAll());
+    } else {
+        m_model->setCharacters({});
+    }
+
     m_proxyModel = new GroupProxyModel(m_table);
-    m_proxyModel->setSourceModel(&m_model);
+    m_proxyModel->setSourceModel(m_model);
     m_table->setModel(m_proxyModel);
 
     m_table->setDragEnabled(true);
@@ -912,7 +913,7 @@ GroupWidget::GroupWidget(Mmapper2Group *const group, MapData *const md, QWidget 
             return;
         }
 
-        selectedCharacter = m_model.getCharacter(sourceIndex.row());
+        selectedCharacter = m_model->getCharacter(sourceIndex.row());
         if (selectedCharacter) {
             // Build Context menu
             m_center->setText(
@@ -947,8 +948,6 @@ GroupWidget::GroupWidget(Mmapper2Group *const group, MapData *const md, QWidget 
 GroupWidget::~GroupWidget()
 {
     m_pulseTimer->stop();
-    delete m_table;
-    delete m_recolor;
 }
 
 QSize GroupWidget::sizeHint() const
@@ -964,7 +963,7 @@ void GroupWidget::updateColumnVisibility()
 {
     // Hide unnecessary columns like mana if everyone is a zorc/troll
     const auto one_character_had_mana = [this]() -> bool {
-        for (const auto &character : m_model.getCharacters()) {
+        for (const auto &character : m_model->getCharacters()) {
             if (character && (character->getMana() > 0 || character->getMaxMana() > 0)) {
                 return true;
             }
@@ -978,7 +977,7 @@ void GroupWidget::updateColumnVisibility()
 void GroupWidget::updatePulseTimer()
 {
     const auto needs_pulse = [this]() -> bool {
-        for (const auto &character : m_model.getCharacters()) {
+        for (const auto &character : m_model->getCharacters()) {
             if (!character) {
                 continue;
             }
@@ -1012,7 +1011,7 @@ void GroupWidget::updatePulseTimer()
 void GroupWidget::slot_onCharacterAdded(SharedGroupChar character)
 {
     assert(character);
-    m_model.insertCharacter(character);
+    m_model->insertCharacter(character);
     updateColumnVisibility();
     updatePulseTimer();
 }
@@ -1020,7 +1019,7 @@ void GroupWidget::slot_onCharacterAdded(SharedGroupChar character)
 void GroupWidget::slot_onCharacterRemoved(const GroupId characterId)
 {
     assert(characterId != INVALID_GROUPID);
-    m_model.removeCharacterById(characterId);
+    m_model->removeCharacterById(characterId);
     updateColumnVisibility();
     updatePulseTimer();
 }
@@ -1028,13 +1027,13 @@ void GroupWidget::slot_onCharacterRemoved(const GroupId characterId)
 void GroupWidget::slot_onCharacterUpdated(SharedGroupChar character)
 {
     assert(character);
-    m_model.updateCharacter(character);
+    m_model->updateCharacter(character);
     updatePulseTimer();
 }
 
 void GroupWidget::slot_onGroupReset(const GroupVector &newCharacterList)
 {
-    m_model.setCharacters(newCharacterList);
+    m_model->setCharacters(newCharacterList);
     updateColumnVisibility();
     updatePulseTimer();
 }

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -913,7 +913,7 @@ GroupWidget::GroupWidget(Mmapper2Group *const group, MapData *const md, QWidget 
             return;
         }
 
-        selectedCharacter = m_model->getCharacter(sourceIndex.row());
+        selectedCharacter = deref(m_model).getCharacter(sourceIndex.row());
         if (selectedCharacter) {
             // Build Context menu
             m_center->setText(
@@ -963,7 +963,7 @@ void GroupWidget::updateColumnVisibility()
 {
     // Hide unnecessary columns like mana if everyone is a zorc/troll
     const auto one_character_had_mana = [this]() -> bool {
-        for (const auto &character : m_model->getCharacters()) {
+        for (const auto &character : deref(m_model).getCharacters()) {
             if (character && (character->getMana() > 0 || character->getMaxMana() > 0)) {
                 return true;
             }
@@ -977,7 +977,7 @@ void GroupWidget::updateColumnVisibility()
 void GroupWidget::updatePulseTimer()
 {
     const auto needs_pulse = [this]() -> bool {
-        for (const auto &character : m_model->getCharacters()) {
+        for (const auto &character : deref(m_model).getCharacters()) {
             if (!character) {
                 continue;
             }
@@ -1011,7 +1011,7 @@ void GroupWidget::updatePulseTimer()
 void GroupWidget::slot_onCharacterAdded(SharedGroupChar character)
 {
     assert(character);
-    m_model->insertCharacter(character);
+    deref(m_model).insertCharacter(character);
     updateColumnVisibility();
     updatePulseTimer();
 }
@@ -1019,7 +1019,7 @@ void GroupWidget::slot_onCharacterAdded(SharedGroupChar character)
 void GroupWidget::slot_onCharacterRemoved(const GroupId characterId)
 {
     assert(characterId != INVALID_GROUPID);
-    m_model->removeCharacterById(characterId);
+    deref(m_model).removeCharacterById(characterId);
     updateColumnVisibility();
     updatePulseTimer();
 }
@@ -1027,13 +1027,13 @@ void GroupWidget::slot_onCharacterRemoved(const GroupId characterId)
 void GroupWidget::slot_onCharacterUpdated(SharedGroupChar character)
 {
     assert(character);
-    m_model->updateCharacter(character);
+    deref(m_model).updateCharacter(character);
     updatePulseTimer();
 }
 
 void GroupWidget::slot_onGroupReset(const GroupVector &newCharacterList)
 {
-    m_model->setCharacters(newCharacterList);
+    deref(m_model).setCharacters(newCharacterList);
     updateColumnVisibility();
     updatePulseTimer();
 }

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -564,7 +564,7 @@ int GroupModel::columnCount(const QModelIndex & /* parent */) const
     return GROUP_COLUMN_COUNT;
 }
 
-NODISCARD static QStringView getPrettyName(const CharacterPositionEnum position)
+NODISCARD static QString getPrettyName(const CharacterPositionEnum position)
 {
 #define X_CASE(UPPER_CASE, lower_case, CamelCase, friendly) \
     do { \
@@ -577,7 +577,7 @@ NODISCARD static QStringView getPrettyName(const CharacterPositionEnum position)
     return QString::asprintf("(CharacterPositionEnum)%d", static_cast<int>(position));
 #undef X_CASE
 }
-NODISCARD static QStringView getPrettyName(const CharacterAffectEnum affect)
+NODISCARD static QString getPrettyName(const CharacterAffectEnum affect)
 {
 #define X_CASE(UPPER_CASE, lower_case, CamelCase, friendly) \
     do { \

--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -849,7 +849,7 @@ GroupWidget::GroupWidget(Mmapper2Group *const group, MapData *const md, QWidget 
     m_table->horizontalHeader()->setStretchLastSection(true);
     m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
-    m_proxyModel = new GroupProxyModel(this);
+    m_proxyModel = new GroupProxyModel(m_table);
     m_proxyModel->setSourceModel(&m_model);
     m_table->setModel(m_proxyModel);
 
@@ -859,7 +859,7 @@ GroupWidget::GroupWidget(Mmapper2Group *const group, MapData *const md, QWidget 
     m_table->setDefaultDropAction(Qt::MoveAction);
     m_table->setDropIndicatorShown(true);
 
-    m_table->setItemDelegate(new GroupDelegate(this));
+    m_table->setItemDelegate(new GroupDelegate(m_table));
     layout->addWidget(m_table);
 
     m_pulseTimer = new QTimer(this);

--- a/src/group/groupwidget.h
+++ b/src/group/groupwidget.h
@@ -151,7 +151,7 @@ private:
     Mmapper2Group *m_group = nullptr;
     MapData *m_map = nullptr;
     GroupProxyModel *m_proxyModel = nullptr;
-    GroupModel m_model;
+    GroupModel *m_model = nullptr;
     QTimer *m_pulseTimer = nullptr;
 
     void updateColumnVisibility();
@@ -174,8 +174,8 @@ signals:
     void sig_center(glm::vec2);
 
 public slots:
-    void slot_mapUnloaded() { m_model.setMapLoaded(false); }
-    void slot_mapLoaded() { m_model.setMapLoaded(true); }
+    void slot_mapUnloaded() { m_model->setMapLoaded(false); }
+    void slot_mapLoaded() { m_model->setMapLoaded(true); }
 
 private slots:
     void slot_onCharacterAdded(SharedGroupChar character);

--- a/src/group/groupwidget.h
+++ b/src/group/groupwidget.h
@@ -174,8 +174,8 @@ signals:
     void sig_center(glm::vec2);
 
 public slots:
-    void slot_mapUnloaded() { m_model->setMapLoaded(false); }
-    void slot_mapLoaded() { m_model->setMapLoaded(true); }
+    void slot_mapUnloaded() { deref(m_model).setMapLoaded(false); }
+    void slot_mapLoaded() { deref(m_model).setMapLoaded(true); }
 
 private slots:
     void slot_onCharacterAdded(SharedGroupChar character);

--- a/src/mapdata/shortestpath.cpp
+++ b/src/mapdata/shortestpath.cpp
@@ -125,7 +125,7 @@ void MapData::shortestPathSearch(const RoomHandle &origin,
         const int spindex = utils::pop_top(future_paths).second;
         // REVISIT: Should thisr be a copy or a reference?
         // (can sp_nodes be modified during the lifetime of the reference?)
-        const auto &thisr = sp_nodes[spindex].r;
+        const auto thisr = sp_nodes[spindex].r;
         const auto thisdist = sp_nodes[spindex].dist;
         auto room_id = thisr.getId();
         if (visited.contains(room_id)) {

--- a/src/resources/wasm/manifest.json.in
+++ b/src/resources/wasm/manifest.json.in
@@ -1,0 +1,21 @@
+{
+  "name": "MUME Mapper",
+  "short_name": "MMapper",
+  "description": "MMapper is a graphical mapping tool that enhances the MUME (Multi-Users in Middle Earth) game experience.",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "@MMAPPER_THEME_COLOR@",
+  "theme_color": "@MMAPPER_THEME_COLOR@",
+  "icons": [
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/roompanel/RoomWidget.cpp
+++ b/src/roompanel/RoomWidget.cpp
@@ -209,7 +209,6 @@ void RoomModel::update()
 // ------------------------------- RoomWidget ----------------------------------
 RoomWidget::RoomWidget(RoomManager &rm, QWidget *const parent)
     : QWidget{parent}
-    , m_model{this, rm.getRoom()}
     , m_roomManager{rm}
 {
     auto *layout = new QVBoxLayout(this);
@@ -217,16 +216,17 @@ RoomWidget::RoomWidget(RoomManager &rm, QWidget *const parent)
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
 
-    auto *table = new QTableView(this);
-    table->setSelectionMode(QAbstractItemView::ContiguousSelection);
-    table->setSelectionBehavior(QAbstractItemView::SelectRows);
-    table->horizontalHeader()->setStretchLastSection(false);
-    table->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
-    table->setModel(&m_model);
-    layout->addWidget(table);
+    m_view = new QTableView(this);
+    m_model = new RoomModel(m_view, rm.getRoom());
+    m_view->setSelectionMode(QAbstractItemView::ContiguousSelection);
+    m_view->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_view->horizontalHeader()->setStretchLastSection(false);
+    m_view->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
+    m_view->setModel(m_model);
+    layout->addWidget(m_view);
 
     // Minimize row height
-    table->verticalHeader()->setDefaultSectionSize(table->verticalHeader()->minimumSectionSize());
+    m_view->verticalHeader()->setDefaultSectionSize(m_view->verticalHeader()->minimumSectionSize());
 
     connect(&m_roomManager, &RoomManager::sig_updateWidget, this, &RoomWidget::slot_update);
 
@@ -240,7 +240,7 @@ RoomWidget::~RoomWidget()
 
 void RoomWidget::slot_update()
 {
-    m_model.update();
+    deref(m_model).update();
 }
 
 void RoomWidget::readSettings()

--- a/src/roompanel/RoomWidget.cpp
+++ b/src/roompanel/RoomWidget.cpp
@@ -216,17 +216,18 @@ RoomWidget::RoomWidget(RoomManager &rm, QWidget *const parent)
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
 
-    m_view = new QTableView(this);
-    m_model = new RoomModel(m_view, rm.getRoom());
-    m_view->setSelectionMode(QAbstractItemView::ContiguousSelection);
-    m_view->setSelectionBehavior(QAbstractItemView::SelectRows);
-    m_view->horizontalHeader()->setStretchLastSection(false);
-    m_view->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
-    m_view->setModel(m_model);
-    layout->addWidget(m_view);
+    m_table = new QTableView(this);
+    m_model = new RoomModel(m_table, rm.getRoom());
+    m_table->setSelectionMode(QAbstractItemView::ContiguousSelection);
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->horizontalHeader()->setStretchLastSection(false);
+    m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
+    m_table->setModel(m_model);
+    layout->addWidget(m_table);
 
     // Minimize row height
-    m_view->verticalHeader()->setDefaultSectionSize(m_view->verticalHeader()->minimumSectionSize());
+    m_table->verticalHeader()->setDefaultSectionSize(
+        m_table->verticalHeader()->minimumSectionSize());
 
     connect(&m_roomManager, &RoomManager::sig_updateWidget, this, &RoomWidget::slot_update);
 

--- a/src/roompanel/RoomWidget.h
+++ b/src/roompanel/RoomWidget.h
@@ -70,7 +70,7 @@ class NODISCARD_QOBJECT RoomWidget final : public QWidget
 
 private:
     RoomModel *m_model = nullptr;
-    QTableView *m_view = nullptr;
+    QTableView *m_table = nullptr;
     RoomManager &m_roomManager;
 
 public:

--- a/src/roompanel/RoomWidget.h
+++ b/src/roompanel/RoomWidget.h
@@ -62,12 +62,15 @@ private:
 
 }; // class RoomModel
 
+class QTableView;
+
 class NODISCARD_QOBJECT RoomWidget final : public QWidget
 {
     Q_OBJECT
 
 private:
-    RoomModel m_model;
+    RoomModel *m_model = nullptr;
+    QTableView *m_view = nullptr;
     RoomManager &m_roomManager;
 
 public:

--- a/src/timers/TimerWidget.cpp
+++ b/src/timers/TimerWidget.cpp
@@ -20,10 +20,10 @@ TimerWidget::TimerWidget(CTimers &timers, QWidget *parent)
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
 
-    m_model = new TimerModel(m_timers, this);
     m_view = new QTableView(this);
+    m_model = new TimerModel(m_timers, m_view);
     m_view->setModel(m_model);
-    auto *delegate = new TimerDelegate(this);
+    auto *delegate = new TimerDelegate(m_view);
     for (int i = 0; i < TimerModel::ColCount; ++i) {
         m_view->setItemDelegateForColumn(i, delegate);
     }


### PR DESCRIPTION
Fixed a SIGSEGV crash on Mac occurring during application shutdown. The issue was traced to the `GroupWidget` class, where a `GroupModel` was declared as a member object but parented to the widget, causing memory corruption during destruction. The fix involved transitioning the model to a heap-allocated pointer parented to the table view and removing manual `delete` calls for child widgets in the destructor, following standard Qt lifecycle best practices.

---
*PR created automatically by Jules for task [5681465460701779635](https://jules.google.com/task/5681465460701779635) started by @nschimme*

## Summary by Sourcery

Prevent crashes during GroupWidget destruction by adjusting ownership and lifetime of its child objects.

Bug Fixes:
- Fix a Mac shutdown SIGSEGV caused by incorrect lifetime management of GroupWidget's GroupModel and child widgets.

Enhancements:
- Change GroupWidget to hold GroupModel as a heap-allocated QObject child of the table view instead of a value member and remove manual deletion of Qt child widgets to follow Qt ownership semantics.