### PR TITLE
Enable ASAN for Windows debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,13 +326,15 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX)
     message(STATUS "Building with GCC (${CMAKE_CXX_COMPILER})")
     if(MMAPPER_IS_DEBUG)
-        message(STATUS "-- Building with GCC address sanitizer")
-        add_compile_options(-fsanitize=address)
-        add_link_options(-fsanitize=address)
+        if(NOT WIN32)
+            message(STATUS "-- Building with GCC address sanitizer")
+            add_compile_options(-fsanitize=address)
+            add_link_options(-fsanitize=address)
 
-        message(STATUS "Building with GCC undefined behavior sanitizer")
-        add_compile_options(-fsanitize=undefined)
-        add_link_options(-fsanitize=undefined)
+            message(STATUS "Building with GCC undefined behavior sanitizer")
+            add_compile_options(-fsanitize=undefined)
+            add_link_options(-fsanitize=undefined)
+        endif()
 
         add_compile_options(-Waddress)
         add_compile_options(-Wcast-align)
@@ -395,12 +397,14 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif()
 
     if(MMAPPER_IS_DEBUG)
-        # segfaults in ASAN initializer on 32-bit Ubuntu 18.04.1 with clang 6.0
-        # note: apparently -fsanitize=address can't be used with gnu libc 2.25+
-        # Ubuntu 18.04.1 has libc 2.27.
-        message(STATUS "Building with Clang address sanitizer")
-        add_compile_options(-fsanitize=address)
-        add_link_options(-fsanitize=address)
+        if(NOT WIN32)
+            # segfaults in ASAN initializer on 32-bit Ubuntu 18.04.1 with clang 6.0
+            # note: apparently -fsanitize=address can't be used with gnu libc 2.25+
+            # Ubuntu 18.04.1 has libc 2.27.
+            message(STATUS "Building with Clang address sanitizer")
+            add_compile_options(-fsanitize=address)
+            add_link_options(-fsanitize=address)
+        endif()
 
         if(TRUE)
             message(STATUS "Building with Clang undefined behavior sanitizer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,15 +326,13 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX)
     message(STATUS "Building with GCC (${CMAKE_CXX_COMPILER})")
     if(MMAPPER_IS_DEBUG)
-        if(NOT WIN32)
-            message(STATUS "-- Building with GCC address sanitizer")
-            add_compile_options(-fsanitize=address)
-            add_link_options(-fsanitize=address)
+        message(STATUS "-- Building with GCC address sanitizer")
+        add_compile_options(-fsanitize=address)
+        add_link_options(-fsanitize=address)
 
-	    message(STATUS "Building with GCC undefined behavior sanitizer")
-            add_compile_options(-fsanitize=undefined)
-            add_link_options(-fsanitize=undefined)
-        endif()
+        message(STATUS "Building with GCC undefined behavior sanitizer")
+        add_compile_options(-fsanitize=undefined)
+        add_link_options(-fsanitize=undefined)
 
         add_compile_options(-Waddress)
         add_compile_options(-Wcast-align)
@@ -397,14 +395,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif()
 
     if(MMAPPER_IS_DEBUG)
-        if(NOT WIN32)
-            # segfaults in ASAN initializer on 32-bit Ubuntu 18.04.1 with clang 6.0
-            # note: apparently -fsanitize=address can't be used with gnu libc 2.25+
-            # Ubuntu 18.04.1 has libc 2.27.
-            message(STATUS "Building with Clang address sanitizer")
-            add_compile_options(-fsanitize=address)
-            add_link_options(-fsanitize=address)
-        endif()
+        # segfaults in ASAN initializer on 32-bit Ubuntu 18.04.1 with clang 6.0
+        # note: apparently -fsanitize=address can't be used with gnu libc 2.25+
+        # Ubuntu 18.04.1 has libc 2.27.
+        message(STATUS "Building with Clang address sanitizer")
+        add_compile_options(-fsanitize=address)
+        add_link_options(-fsanitize=address)
 
         if(TRUE)
             message(STATUS "Building with Clang undefined behavior sanitizer")
@@ -474,6 +470,24 @@ if(MSVC)
     add_compile_options(/Zc:__cplusplus)
     add_compile_options(/utf-8)
     add_compile_options(/permissive-)
+
+    if(MMAPPER_IS_DEBUG)
+        message(STATUS "Building with MSVC address sanitizer")
+        add_compile_options(/fsanitize=address)
+        add_compile_options(/Oy-) # Disable frame-pointer omission
+
+        # ASAN is incompatible with /RTC (Runtime Checks)
+        # CMake defaults to /RTC1 for Debug builds. We need to remove it.
+        string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+        string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+
+        # Linker flags for ASAN
+        add_link_options(/fsanitize=address)
+        set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /INCREMENTAL:NO")
+        set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} /INCREMENTAL:NO")
+        set(CMAKE_MODULE_LINKER_FLAGS_DEBUG "${CMAKE_MODULE_LINKER_FLAGS_DEBUG} /INCREMENTAL:NO")
+    endif()
+
     if(CMAKE_BUILD_TYPE_UPPER MATCHES "^RELWITHDEBINFO$")
         # improve performance
         string(REPLACE "/Ob1" "/Ob2" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")


### PR DESCRIPTION
Enabled AddressSanitizer (ASAN) for Windows debug builds in CMakeLists.txt.
- For MSVC: Added /fsanitize=address, /Oy-, /INCREMENTAL:NO, and removed incompatible /RTC1.
- For GCC and Clang: Removed platform-specific restrictions to enable ASAN and UBSAN on Windows.
- Verified that Linux builds still correctly enable sanitizers.

---
*PR created automatically by Jules for task [16161270586414578848](https://jules.google.com/task/16161270586414578848) started by @nschimme*

## Summary by Sourcery

Enable address sanitizer support for debug builds across all supported compilers, including on Windows.

Build:
- Enable GCC and Clang address and undefined behavior sanitizers for Windows debug builds by removing WIN32-specific exclusions.
- Configure MSVC debug builds to use AddressSanitizer and compatible compiler/linker flags, replacing conflicting runtime check and incremental link settings.