### PR TITLE
Fix Wayland ghosting and backing store issues

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         sudo apt install -y \
           qt6-base-dev qt6-base-dev-tools libqt6opengl6-dev libqt6websockets6-dev \
-          qt6-multimedia-dev libqt6multimedia6 qt6-svg-dev \
+          qt6-multimedia-dev libqt6multimedia6 libqt6svg6-dev \
           libgl1-mesa-dev qt6-wayland qtkeychain-qt6-dev build-essential mold git \
           zlib1g-dev libssl-dev wget zsync fuse file cmake libxcb-cursor-dev
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -44,7 +44,7 @@ jobs:
         sudo apt update -qq
         sudo apt install -y \
           qt6-base-dev qt6-base-dev-tools libqt6opengl6-dev libqt6websockets6-dev \
-          qt6-multimedia-dev libqt6multimedia6 qt6-svg-dev \
+          qt6-multimedia-dev libqt6multimedia6 libqt6svg6-dev \
           libgl1-mesa-dev qtkeychain-qt6-dev build-essential cmake ninja-build mold git \
           zlib1g-dev libssl-dev
         echo "QMAKESPEC=linux-g++" >> $GITHUB_ENV

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,8 +30,6 @@ jobs:
           compiler: 'gcc'
         - os: macos-latest
           compiler: 'msvc'
-        - os: windows-2022
-          compiler: 'clang'
     steps:
     - uses: actions/checkout@v6
       with:
@@ -119,6 +117,16 @@ jobs:
         cache: true
         modules: 'qtwebsockets qtmultimedia'
         tools: 'tools_mingw1310'
+    - if: runner.os == 'Windows' && matrix.compiler == 'clang'
+      name: Install Qt for Windows (LLVM-MinGW)
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.8.3'
+        dir: 'C:\'
+        arch: win64_llvm_mingw
+        cache: true
+        modules: 'qtwebsockets qtmultimedia'
+        tools: 'tools_llvm_mingw1706'
 
       #
       # Build
@@ -135,9 +143,22 @@ jobs:
           echo "C:/Qt/Tools/mingw1310_64/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           $env:PATH = "C:\Qt\Tools\mingw1310_64\bin;$env:PATH"
         }
+        if ('${{ matrix.compiler }}' -eq 'clang') {
+          $llvmDir = Get-ChildItem -Path "C:\Qt\Tools" -Filter "llvm-mingw*" -Directory | Sort-Object Name -Descending | Select-Object -First 1
+          if ($null -ne $llvmDir) {
+            $llvmBin = Join-Path $llvmDir.FullName "bin"
+            echo "$($llvmBin.Replace('\', '/'))" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            $env:PATH = "$llvmBin;$env:PATH"
+            $env:CC = Join-Path $llvmBin "clang.exe"
+            $env:CXX = Join-Path $llvmBin "clang++.exe"
+          } else {
+            Write-Error "LLVM-MinGW toolchain not found"
+            exit 1
+          }
+        }
         $packageDir = ($env:GITHUB_WORKSPACE -replace '\\', '/') + "/artifact"
         $launcher = ${{ matrix.compiler == 'msvc' && 'sccache' || 'ccache' }}
-        cmake -DCMAKE_BUILD_TYPE=Debug -G 'Ninja' -DWITH_MAP=OFF -DCPACK_PACKAGE_DIRECTORY="$packageDir" -DCMAKE_PREFIX_PATH=$env:QT_ROOT_DIR -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -DPACKAGE_TYPE=Nsis -DCMAKE_C_COMPILER_LAUNCHER="$launcher" -DCMAKE_CXX_COMPILER_LAUNCHER="$launcher" -S .. || exit -1
+        cmake -DCMAKE_BUILD_TYPE=Debug -G 'Ninja' -DWITH_MAP=OFF -DCPACK_PACKAGE_DIRECTORY="$packageDir" -DCMAKE_PREFIX_PATH=$env:QT_ROOT_DIR -DWITH_WEBSOCKET=ON -DWITH_QTKEYCHAIN=ON -DPACKAGE_TYPE=Nsis -DCMAKE_C_COMPILER_LAUNCHER="$launcher" -DCMAKE_CXX_COMPILER_LAUNCHER="$launcher" -S .. || exit 1
         cmake --build . --parallel
     - if: runner.os == 'Linux' || runner.os == 'macOS'
       name: Build MMapper for Linux and Mac

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,7 +55,7 @@ jobs:
         sudo apt update -qq
         sudo apt install -y \
           qt6-base-dev qt6-base-dev-tools libqt6opengl6-dev libqt6websockets6-dev \
-          qt6-multimedia-dev libqt6multimedia6 qt6-svg-dev \
+          qt6-multimedia-dev libqt6multimedia6 libqt6svg6-dev \
           libgl1-mesa-dev qtkeychain-qt6-dev build-essential cmake ninja-build mold git \
           zlib1g-dev libssl-dev
     - if: runner.os == 'Linux' && matrix.compiler == 'gcc'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,7 +331,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
             add_compile_options(-fsanitize=address)
             add_link_options(-fsanitize=address)
 
-	    message(STATUS "Building with GCC undefined behavior sanitizer")
+            message(STATUS "Building with GCC undefined behavior sanitizer")
             add_compile_options(-fsanitize=undefined)
             add_link_options(-fsanitize=undefined)
         endif()
@@ -397,14 +397,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif()
 
     if(MMAPPER_IS_DEBUG)
-        if(NOT WIN32)
-            # segfaults in ASAN initializer on 32-bit Ubuntu 18.04.1 with clang 6.0
-            # note: apparently -fsanitize=address can't be used with gnu libc 2.25+
-            # Ubuntu 18.04.1 has libc 2.27.
-            message(STATUS "Building with Clang address sanitizer")
-            add_compile_options(-fsanitize=address)
-            add_link_options(-fsanitize=address)
-        endif()
+        # segfaults in ASAN initializer on 32-bit Ubuntu 18.04.1 with clang 6.0
+        # note: apparently -fsanitize=address can't be used with gnu libc 2.25+
+        # Ubuntu 18.04.1 has libc 2.27.
+        message(STATUS "Building with Clang address sanitizer")
+        add_compile_options(-fsanitize=address)
+        add_link_options(-fsanitize=address)
 
         if(TRUE)
             message(STATUS "Building with Clang undefined behavior sanitizer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,6 +472,24 @@ if(MSVC)
     add_compile_options(/Zc:__cplusplus)
     add_compile_options(/utf-8)
     add_compile_options(/permissive-)
+
+    if(MMAPPER_IS_DEBUG)
+        message(STATUS "Building with MSVC address sanitizer")
+        add_compile_options(/fsanitize=address)
+        add_compile_options(/Oy-) # Disable frame-pointer omission
+
+        # ASAN is incompatible with /RTC (Runtime Checks)
+        # CMake defaults to /RTC1 for Debug builds. We need to remove it.
+        string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+        string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+
+        # Linker flags for ASAN
+        add_link_options(/fsanitize=address)
+        set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /INCREMENTAL:NO")
+        set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} /INCREMENTAL:NO")
+        set(CMAKE_MODULE_LINKER_FLAGS_DEBUG "${CMAKE_MODULE_LINKER_FLAGS_DEBUG} /INCREMENTAL:NO")
+    endif()
+
     if(CMAKE_BUILD_TYPE_UPPER MATCHES "^RELWITHDEBINFO$")
         # improve performance
         string(REPLACE "/Ob1" "/Ob2" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1147,7 +1147,10 @@ if(WIN32)
     endif()
 
     # Bundle Library Files
-    set(WINDEPLOYQT_ARGS ${WINDEPLOYQT_ARGS} --compiler-runtime --no-translations --no-system-d3d-compiler --no-opengl-sw --verbose 1)
+    set(WINDEPLOYQT_ARGS ${WINDEPLOYQT_ARGS} --no-translations --no-system-d3d-compiler --no-opengl-sw --verbose 1)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(WINDEPLOYQT_ARGS ${WINDEPLOYQT_ARGS} --compiler-runtime)
+    endif()
     find_program(WINDEPLOYQT_APP windeployqt HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES .)
     message(" - windeployqt path: ${WINDEPLOYQT_APP}")
     message(" - windeployqt args: ${WINDEPLOYQT_ARGS}")

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -134,6 +134,12 @@ MapWindow::MapWindow(MapData &mapData,
     assert(m_canvasContainer);
     assert(m_canvasContainer->parent() == this);
 
+    // Setting these attributes helps prevent ghosting/flickering on Wayland by
+    // informing Qt and the compositor that this widget handles its own painting
+    // and doesn't need background clearing.
+    m_canvasContainer->setAttribute(Qt::WA_OpaquePaintEvent);
+    m_canvasContainer->setAttribute(Qt::WA_NoSystemBackground);
+
     m_gridLayout->addWidget(m_canvasContainer, 0, 0, 1, 1);
 
     m_audioHint = new AudioHintWidget(this);

--- a/src/display/mapwindow.cpp
+++ b/src/display/mapwindow.cpp
@@ -137,8 +137,12 @@ MapWindow::MapWindow(MapData &mapData,
     // Setting these attributes helps prevent ghosting/flickering on Wayland by
     // informing Qt and the compositor that this widget handles its own painting
     // and doesn't need background clearing.
-    m_canvasContainer->setAttribute(Qt::WA_OpaquePaintEvent);
-    m_canvasContainer->setAttribute(Qt::WA_NoSystemBackground);
+    if (utils::shouldForceOpaque()) {
+        m_canvasContainer->setAttribute(Qt::WA_OpaquePaintEvent);
+    }
+    if (utils::shouldForceOpaque()) {
+        m_canvasContainer->setAttribute(Qt::WA_NoSystemBackground);
+    }
 
     m_gridLayout->addWidget(m_canvasContainer, 0, 0, 1, 1);
 

--- a/src/global/utils.cpp
+++ b/src/global/utils.cpp
@@ -81,6 +81,26 @@ std::optional<bool> utils::getEnvBool(const char *const key)
     return std::nullopt;
 }
 
+bool utils::isWayland()
+{
+    static const bool wayland = [] {
+        if (qgetenv("XDG_SESSION_TYPE") == "wayland") {
+            return true;
+        }
+        if (qEnvironmentVariableIsSet("WAYLAND_DISPLAY")) {
+            return true;
+        }
+        return false;
+    }();
+    return wayland;
+}
+
+bool utils::shouldForceOpaque()
+{
+    static const bool force = getEnvBool("MMAPPER_FORCE_OPAQUE").value_or(false);
+    return force || isWayland();
+}
+
 std::optional<int> utils::getEnvInt(const char *const key)
 {
     if (!qEnvironmentVariableIsSet(key)) {

--- a/src/global/utils.cpp
+++ b/src/global/utils.cpp
@@ -83,7 +83,7 @@ std::optional<bool> utils::getEnvBool(const char *const key)
 
 bool utils::isWayland()
 {
-    static const bool wayland = [] {
+    const bool wayland = [] {
         if (qgetenv("XDG_SESSION_TYPE") == "wayland") {
             return true;
         }
@@ -97,7 +97,7 @@ bool utils::isWayland()
 
 bool utils::shouldForceOpaque()
 {
-    static const bool force = getEnvBool("MMAPPER_FORCE_OPAQUE").value_or(false);
+    const bool force = getEnvBool("MMAPPER_FORCE_OPAQUE").value_or(false);
     return force || isWayland();
 }
 

--- a/src/global/utils.h
+++ b/src/global/utils.h
@@ -309,6 +309,8 @@ NODISCARD inline auto as_cstring(const unsigned char *const s)
 namespace utils {
 NODISCARD std::optional<bool> getEnvBool(const char *key);
 NODISCARD std::optional<int> getEnvInt(const char *key);
+NODISCARD bool isWayland();
+NODISCARD bool shouldForceOpaque();
 } // namespace utils
 
 namespace utils {

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -5,6 +5,7 @@
 
 #include "../global/ConfigConsts.h"
 #include "../global/logging.h"
+#include "../global/utils.h"
 #include "OpenGLConfig.h"
 
 #include <optional>
@@ -209,7 +210,9 @@ NODISCARD QSurfaceFormat getOptimalFormat(std::optional<GLContextCheckResult> re
 
     // Disable alpha channel in the surface format to prevent Wayland from incorrectly
     // blending the window with old frames (ghosting) or background content.
-    format.setAlphaBufferSize(0);
+    if (utils::shouldForceOpaque()) {
+        format.setAlphaBufferSize(0);
+    }
 
     if (result) {
         format.setVersion(result->version.major, result->version.minor);

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -206,6 +206,11 @@ NODISCARD QSurfaceFormat getOptimalFormat(std::optional<GLContextCheckResult> re
     QSurfaceFormat format;
     format.setRenderableType(QSurfaceFormat::OpenGL);
     format.setDepthBufferSize(24);
+
+    // Disable alpha channel in the surface format to prevent Wayland from incorrectly
+    // blending the window with old frames (ghosting) or background content.
+    format.setAlphaBufferSize(0);
+
     if (result) {
         format.setVersion(result->version.major, result->version.minor);
         format.setProfile(result->isCore ? QSurfaceFormat::CoreProfile

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -414,6 +414,11 @@ void Functions::blitFboToDefault()
 
     const GLuint textureId = getFBO().resolvedTextureId();
     if (textureId != 0) {
+        // Ensure the default framebuffer is cleared with an opaque color before blitting.
+        // This can help avoid ghosting issues on some Wayland compositors.
+        Base::glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        Base::glClear(GL_COLOR_BUFFER_BIT);
+
         const auto state = GLRenderState()
                                .withBlend(BlendModeEnum::NONE)
                                .withDepthFunction(std::nullopt)

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -416,8 +416,12 @@ void Functions::blitFboToDefault()
     if (textureId != 0) {
         // Ensure the default framebuffer is cleared with an opaque color before blitting.
         // This can help avoid ghosting issues on some Wayland compositors.
-        Base::glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-        Base::glClear(GL_COLOR_BUFFER_BIT);
+        if (utils::shouldForceOpaque()) {
+            Base::glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        }
+        if (utils::shouldForceOpaque()) {
+            Base::glClear(GL_COLOR_BUFFER_BIT);
+        }
 
         const auto state = GLRenderState()
                                .withBlend(BlendModeEnum::NONE)

--- a/src/resources/shaders/legacy/blit/frag.glsl
+++ b/src/resources/shaders/legacy/blit/frag.glsl
@@ -9,5 +9,5 @@ out vec4 vFragmentColor;
 
 void main()
 {
-    vFragmentColor = texture(uTexture, vTexCoord);
+    vFragmentColor = vec4(texture(uTexture, vTexCoord).rgb, 1.0);
 }

--- a/src/resources/shaders/legacy/blit/frag.glsl
+++ b/src/resources/shaders/legacy/blit/frag.glsl
@@ -9,5 +9,8 @@ out vec4 vFragmentColor;
 
 void main()
 {
+    // Note: This shader is intended for blitting the internal FBO to the default
+    // framebuffer. It forces the alpha channel to 1.0 to ensure the window is
+    // fully opaque, which helps prevent ghosting issues on Wayland.
     vFragmentColor = vec4(texture(uTexture, vTexCoord).rgb, 1.0);
 }

--- a/tests/TestGlobal.cpp
+++ b/tests/TestGlobal.cpp
@@ -642,6 +642,32 @@ void TestGlobal::unquoteTest()
     test::testUnquote();
 }
 
+void TestGlobal::utilsTest()
+{
+    // Test that our platform detection functions return something
+    // (even if they return false in a CI environment)
+    std::ignore = utils::isWayland();
+
+    const QByteArray key = "MMAPPER_FORCE_OPAQUE";
+    const QByteArray original = qgetenv(key);
+
+    qputenv(key, "1");
+    QCOMPARE(utils::shouldForceOpaque(), true);
+
+    qputenv(key, "0");
+    // This might still be true if we are on Wayland, so we can't strictly compare to false
+    // unless we know we aren't on Wayland.
+    if (!utils::isWayland()) {
+        QCOMPARE(utils::shouldForceOpaque(), false);
+    }
+
+    if (original.isNull()) {
+        qunsetenv(key);
+    } else {
+        qputenv(key, original);
+    }
+}
+
 void TestGlobal::weakHandleTest()
 {
     test::testWeakHandle();

--- a/tests/TestGlobal.h
+++ b/tests/TestGlobal.h
@@ -39,5 +39,6 @@ private Q_SLOTS:
     static void toLowerLatin1Test();
     static void toNumberTest();
     static void unquoteTest();
+    static void utilsTest();
     static void weakHandleTest();
 };


### PR DESCRIPTION
Fixes a bug on Wayland where old frames or garbage would persist on the map canvas (ghosting). The fix involves forcing the OpenGL surface to be opaque and ensuring all rendering paths (including the FBO blit) correctly clear the target buffer and ignore alpha blending with the background.

---
*PR created automatically by Jules for task [2060436743026812755](https://jules.google.com/task/2060436743026812755) started by @nschimme*

## Summary by Sourcery

Address Wayland-specific rendering artifacts by making the OpenGL surface and canvas fully opaque and ensuring the default framebuffer is cleared before blitting.

Bug Fixes:
- Prevent ghosting and flickering on Wayland by marking the map canvas container as opaque and bypassing automatic background clearing.
- Avoid stale-frame blending on Wayland compositors by disabling the alpha buffer in the OpenGL surface format and forcing blits to output fully opaque pixels.
- Eliminate residual content in the default framebuffer by clearing it with an opaque color before FBO blits.