### PR TITLE
clock: add weather and fog icons to MumeClockWidget

### DIFF
--- a/src/clock/mumeclockwidget.cpp
+++ b/src/clock/mumeclockwidget.cpp
@@ -38,8 +38,9 @@ MumeClockWidget::MumeClockWidget(GameObserver &observer, MumeClock &clock, QWidg
                                                 });
     observer.sig2_seasonChanged.connect(m_lifetime,
                                         [this](MumeSeasonEnum season) { updateSeason(season); });
-    observer.sig2_weatherChanged.connect(m_lifetime,
-                                         [this](PromptWeatherEnum weather) { updateWeather(weather); });
+    observer.sig2_weatherChanged.connect(m_lifetime, [this](PromptWeatherEnum weather) {
+        updateWeather(weather);
+    });
     observer.sig2_fogChanged.connect(m_lifetime, [this](PromptFogEnum fog) { updateFog(fog); });
     observer.sig2_tick.connect(m_lifetime,
                                [this](const MumeMoment &moment) { updateCountdown(moment); });

--- a/src/clock/mumeclockwidget.cpp
+++ b/src/clock/mumeclockwidget.cpp
@@ -172,23 +172,28 @@ void MumeClockWidget::updateWeather(PromptWeatherEnum weather)
     case PromptWeatherEnum::CLOUDS:
         weatherLabel->setText(QString::fromUtf8("\xE2\x98\x81"));
         weatherLabel->setStatusTip("Cloudy");
+        weatherLabel->setVisible(true);
         break;
     case PromptWeatherEnum::RAIN:
         weatherLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xA7"));
         weatherLabel->setStatusTip("Rainy");
+        weatherLabel->setVisible(true);
         break;
     case PromptWeatherEnum::HEAVY_RAIN:
         weatherLabel->setText(QString::fromUtf8("\xE2\x9B\x88"));
         weatherLabel->setStatusTip("Heavy Rain");
+        weatherLabel->setVisible(true);
         break;
     case PromptWeatherEnum::SNOW:
         weatherLabel->setText(QString::fromUtf8("\xE2\x9D\x84"));
         weatherLabel->setStatusTip("Snowy");
+        weatherLabel->setVisible(true);
         break;
     case PromptWeatherEnum::NICE:
     default:
         weatherLabel->setText("");
         weatherLabel->setStatusTip("");
+        weatherLabel->setVisible(false);
         break;
     }
 }
@@ -199,15 +204,18 @@ void MumeClockWidget::updateFog(PromptFogEnum fog)
     case PromptFogEnum::LIGHT_FOG:
         fogLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xAB"));
         fogLabel->setStatusTip("Light Fog");
+        fogLabel->setVisible(true);
         break;
     case PromptFogEnum::HEAVY_FOG:
         fogLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xAB\xF0\x9F\x8C\xAB"));
         fogLabel->setStatusTip("Heavy Fog");
+        fogLabel->setVisible(true);
         break;
     case PromptFogEnum::NO_FOG:
     default:
         fogLabel->setText("");
         fogLabel->setStatusTip("");
+        fogLabel->setVisible(false);
         break;
     }
 }

--- a/src/clock/mumeclockwidget.cpp
+++ b/src/clock/mumeclockwidget.cpp
@@ -38,6 +38,9 @@ MumeClockWidget::MumeClockWidget(GameObserver &observer, MumeClock &clock, QWidg
                                                 });
     observer.sig2_seasonChanged.connect(m_lifetime,
                                         [this](MumeSeasonEnum season) { updateSeason(season); });
+    observer.sig2_weatherChanged.connect(m_lifetime,
+                                         [this](PromptWeatherEnum weather) { updateWeather(weather); });
+    observer.sig2_fogChanged.connect(m_lifetime, [this](PromptFogEnum fog) { updateFog(fog); });
     observer.sig2_tick.connect(m_lifetime,
                                [this](const MumeMoment &moment) { updateCountdown(moment); });
 
@@ -46,6 +49,8 @@ MumeClockWidget::MumeClockWidget(GameObserver &observer, MumeClock &clock, QWidg
     updateMoonPhase(moment.moonPhase());
     updateMoonVisibility(moment.moonVisibility());
     updateSeason(moment.toSeason());
+    updateWeather(observer.getWeather());
+    updateFog(observer.getFog());
     updateCountdown(moment);
 }
 
@@ -160,6 +165,52 @@ void MumeClockWidget::updateSeason(MumeSeasonEnum season)
     seasonLabel->setText(text);
 }
 
+void MumeClockWidget::updateWeather(PromptWeatherEnum weather)
+{
+    switch (weather) {
+    case PromptWeatherEnum::CLOUDS:
+        weatherLabel->setText(QString::fromUtf8("\xE2\x98\x81"));
+        weatherLabel->setStatusTip("Cloudy");
+        break;
+    case PromptWeatherEnum::RAIN:
+        weatherLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xA7"));
+        weatherLabel->setStatusTip("Rainy");
+        break;
+    case PromptWeatherEnum::HEAVY_RAIN:
+        weatherLabel->setText(QString::fromUtf8("\xE2\x9B\x88"));
+        weatherLabel->setStatusTip("Heavy Rain");
+        break;
+    case PromptWeatherEnum::SNOW:
+        weatherLabel->setText(QString::fromUtf8("\xE2\x9D\x84"));
+        weatherLabel->setStatusTip("Snowy");
+        break;
+    case PromptWeatherEnum::NICE:
+    default:
+        weatherLabel->setText("");
+        weatherLabel->setStatusTip("");
+        break;
+    }
+}
+
+void MumeClockWidget::updateFog(PromptFogEnum fog)
+{
+    switch (fog) {
+    case PromptFogEnum::LIGHT_FOG:
+        fogLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xAB"));
+        fogLabel->setStatusTip("Light Fog");
+        break;
+    case PromptFogEnum::HEAVY_FOG:
+        fogLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xAB\xF0\x9F\x8C\xAB"));
+        fogLabel->setStatusTip("Heavy Fog");
+        break;
+    case PromptFogEnum::NO_FOG:
+    default:
+        fogLabel->setText("");
+        fogLabel->setStatusTip("");
+        break;
+    }
+}
+
 void MumeClockWidget::updateCountdown(const MumeMoment &moment)
 {
     // FIXME: Use ChangeMonitor
@@ -180,6 +231,7 @@ void MumeClockWidget::updateStatusTips(const MumeMoment &moment)
 {
     moonPhaseLabel->setStatusTip(moment.toMumeMoonTime());
     seasonLabel->setStatusTip(m_clock.toMumeTime(moment));
+    // weatherLabel and fogLabel tooltips are updated in their respective update functions.
 
     QString statusTip = "";
     const MumeClockPrecisionEnum precision = m_clock.getPrecision();

--- a/src/clock/mumeclockwidget.cpp
+++ b/src/clock/mumeclockwidget.cpp
@@ -97,31 +97,31 @@ void MumeClockWidget::updateMoonPhase(MumeMoonPhaseEnum phase)
 {
     switch (phase) {
     case MumeMoonPhaseEnum::WAXING_CRESCENT:
-        moonPhaseLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\x92"));
+        moonPhaseLabel->setText(QStringLiteral("\U0001F312"));
         break;
     case MumeMoonPhaseEnum::FIRST_QUARTER:
-        moonPhaseLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\x93"));
+        moonPhaseLabel->setText(QStringLiteral("\U0001F313"));
         break;
     case MumeMoonPhaseEnum::WAXING_GIBBOUS:
-        moonPhaseLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\x94"));
+        moonPhaseLabel->setText(QStringLiteral("\U0001F314"));
         break;
     case MumeMoonPhaseEnum::FULL_MOON:
-        moonPhaseLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\x95"));
+        moonPhaseLabel->setText(QStringLiteral("\U0001F315"));
         break;
     case MumeMoonPhaseEnum::WANING_GIBBOUS:
-        moonPhaseLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\x96"));
+        moonPhaseLabel->setText(QStringLiteral("\U0001F316"));
         break;
     case MumeMoonPhaseEnum::THIRD_QUARTER:
-        moonPhaseLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\x97"));
+        moonPhaseLabel->setText(QStringLiteral("\U0001F317"));
         break;
     case MumeMoonPhaseEnum::WANING_CRESCENT:
-        moonPhaseLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\x98"));
+        moonPhaseLabel->setText(QStringLiteral("\U0001F318"));
         break;
     case MumeMoonPhaseEnum::NEW_MOON:
-        moonPhaseLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\x91"));
+        moonPhaseLabel->setText(QStringLiteral("\U0001F311"));
         break;
     case MumeMoonPhaseEnum::UNKNOWN:
-        moonPhaseLabel->setText("");
+        moonPhaseLabel->setText(QString());
         break;
     }
 }
@@ -170,29 +170,29 @@ void MumeClockWidget::updateWeather(PromptWeatherEnum weather)
 {
     switch (weather) {
     case PromptWeatherEnum::CLOUDS:
-        weatherLabel->setText(QString::fromUtf8("\xE2\x98\x81"));
+        weatherLabel->setText(QStringLiteral("\u2601"));
         weatherLabel->setStatusTip("Cloudy");
         weatherLabel->setVisible(true);
         break;
     case PromptWeatherEnum::RAIN:
-        weatherLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xA7"));
+        weatherLabel->setText(QStringLiteral("\U0001F327"));
         weatherLabel->setStatusTip("Rainy");
         weatherLabel->setVisible(true);
         break;
     case PromptWeatherEnum::HEAVY_RAIN:
-        weatherLabel->setText(QString::fromUtf8("\xE2\x9B\x88"));
+        weatherLabel->setText(QStringLiteral("\u26C8"));
         weatherLabel->setStatusTip("Heavy Rain");
         weatherLabel->setVisible(true);
         break;
     case PromptWeatherEnum::SNOW:
-        weatherLabel->setText(QString::fromUtf8("\xE2\x9D\x84"));
+        weatherLabel->setText(QStringLiteral("\u2744"));
         weatherLabel->setStatusTip("Snowy");
         weatherLabel->setVisible(true);
         break;
     case PromptWeatherEnum::NICE:
     default:
-        weatherLabel->setText("");
-        weatherLabel->setStatusTip("");
+        weatherLabel->setText(QString());
+        weatherLabel->setStatusTip(QString());
         weatherLabel->setVisible(false);
         break;
     }
@@ -202,19 +202,19 @@ void MumeClockWidget::updateFog(PromptFogEnum fog)
 {
     switch (fog) {
     case PromptFogEnum::LIGHT_FOG:
-        fogLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xAB"));
+        fogLabel->setText(QStringLiteral("\U0001F32B"));
         fogLabel->setStatusTip("Light Fog");
         fogLabel->setVisible(true);
         break;
     case PromptFogEnum::HEAVY_FOG:
-        fogLabel->setText(QString::fromUtf8("\xF0\x9F\x8C\xAB\xF0\x9F\x8C\xAB"));
+        fogLabel->setText(QStringLiteral("\U0001F32B\U0001F32B"));
         fogLabel->setStatusTip("Heavy Fog");
         fogLabel->setVisible(true);
         break;
     case PromptFogEnum::NO_FOG:
     default:
-        fogLabel->setText("");
-        fogLabel->setStatusTip("");
+        fogLabel->setText(QString());
+        fogLabel->setStatusTip(QString());
         fogLabel->setVisible(false);
         break;
     }
@@ -230,7 +230,7 @@ void MumeClockWidget::updateCountdown(const MumeMoment &moment)
 
     const MumeClockPrecisionEnum precision = m_clock.getPrecision();
     if (precision <= MumeClockPrecisionEnum::HOUR) {
-        timeLabel->setText(QString::fromUtf8("\xE2\x9A\xA0").append(m_clock.toCountdown(moment)));
+        timeLabel->setText(QStringLiteral("\u26A0").append(m_clock.toCountdown(moment)));
     } else {
         timeLabel->setText(m_clock.toCountdown(moment));
     }

--- a/src/clock/mumeclockwidget.h
+++ b/src/clock/mumeclockwidget.h
@@ -38,5 +38,7 @@ private:
     void updateMoonPhase(MumeMoonPhaseEnum phase);
     void updateMoonVisibility(MumeMoonVisibilityEnum visibility);
     void updateSeason(MumeSeasonEnum season);
+    void updateWeather(PromptWeatherEnum weather);
+    void updateFog(PromptFogEnum fog);
     void updateStatusTips(const MumeMoment &moment);
 };

--- a/src/clock/mumeclockwidget.ui
+++ b/src/clock/mumeclockwidget.ui
@@ -67,6 +67,20 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="weatherLabel">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="fogLabel">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="timeLabel">
        <property name="text">
         <string>Clock not set</string>

--- a/src/global/JsonObj.cpp
+++ b/src/global/JsonObj.cpp
@@ -50,7 +50,7 @@ NODISCARD OptJsonNull JsonObj::getNull(const QString &name) const
 {
     if (m_obj.contains(name)) {
         if (auto &&tmp = m_obj.value(name); tmp.isNull()) {
-            return OptJsonNull{};
+            return JsonNull{};
         }
     }
     return std::nullopt;

--- a/src/global/JsonObj.cpp
+++ b/src/global/JsonObj.cpp
@@ -50,7 +50,7 @@ NODISCARD OptJsonNull JsonObj::getNull(const QString &name) const
 {
     if (m_obj.contains(name)) {
         if (auto &&tmp = m_obj.value(name); tmp.isNull()) {
-            return OptJsonNull{{}};
+            return OptJsonNull{};
         }
     }
     return std::nullopt;

--- a/src/global/JsonObj.cpp
+++ b/src/global/JsonObj.cpp
@@ -50,7 +50,7 @@ NODISCARD OptJsonNull JsonObj::getNull(const QString &name) const
 {
     if (m_obj.contains(name)) {
         if (auto &&tmp = m_obj.value(name); tmp.isNull()) {
-            return OptJsonNull{};
+            return OptJsonNull{{}};
         }
     }
     return std::nullopt;

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -313,14 +313,13 @@ void MumeXmlParser::parseGmcpCharVitals(const JsonObj &obj)
         } else {
             qWarning().noquote() << "prompt has unknown fog flag:" << *fog;
         }
-        m_observer.observeFog(promptFlags.getFogType());
-    } else if (obj.getNull("fog")) {
+    } else if (!obj.getNull("fog")) {
         if (verbose_debugging) {
             qInfo().noquote() << "fog null";
         }
         promptFlags.setFogType(PromptFogEnum::NO_FOG);
-        m_observer.observeFog(promptFlags.getFogType());
     }
+    m_observer.observeFog(promptFlags.getFogType());
 
     if (auto light = obj.getString("light")) {
         if (verbose_debugging) {
@@ -355,14 +354,13 @@ void MumeXmlParser::parseGmcpCharVitals(const JsonObj &obj)
         } else {
             qWarning().noquote() << "prompt has unknown weather flag:" << *weather;
         }
-        m_observer.observeWeather(promptFlags.getWeatherType());
-    } else if (obj.getNull("weather")) {
+    } else if (!obj.getNull("weather")) {
         if (verbose_debugging) {
             qInfo().noquote() << "weather null";
         }
         promptFlags.setWeatherType(PromptWeatherEnum::NICE);
-        m_observer.observeWeather(promptFlags.getWeatherType());
     }
+    m_observer.observeWeather(promptFlags.getWeatherType());
 }
 
 void MumeXmlParser::parseGmcpEventMoved(const JsonObj &obj)

--- a/src/parser/mumexmlparser-gmcp.cpp
+++ b/src/parser/mumexmlparser-gmcp.cpp
@@ -313,13 +313,14 @@ void MumeXmlParser::parseGmcpCharVitals(const JsonObj &obj)
         } else {
             qWarning().noquote() << "prompt has unknown fog flag:" << *fog;
         }
-    } else if (!obj.getNull("fog")) {
+        m_observer.observeFog(promptFlags.getFogType());
+    } else if (obj.getNull("fog")) {
         if (verbose_debugging) {
             qInfo().noquote() << "fog null";
         }
         promptFlags.setFogType(PromptFogEnum::NO_FOG);
+        m_observer.observeFog(promptFlags.getFogType());
     }
-    m_observer.observeFog(promptFlags.getFogType());
 
     if (auto light = obj.getString("light")) {
         if (verbose_debugging) {
@@ -354,13 +355,14 @@ void MumeXmlParser::parseGmcpCharVitals(const JsonObj &obj)
         } else {
             qWarning().noquote() << "prompt has unknown weather flag:" << *weather;
         }
-    } else if (!obj.getNull("weather")) {
+        m_observer.observeWeather(promptFlags.getWeatherType());
+    } else if (obj.getNull("weather")) {
         if (verbose_debugging) {
             qInfo().noquote() << "weather null";
         }
         promptFlags.setWeatherType(PromptWeatherEnum::NICE);
+        m_observer.observeWeather(promptFlags.getWeatherType());
     }
-    m_observer.observeWeather(promptFlags.getWeatherType());
 }
 
 void MumeXmlParser::parseGmcpEventMoved(const JsonObj &obj)


### PR DESCRIPTION
Integrated weather and fog indicators into the clock widget using standard emojis. The icons update dynamically based on GameObserver signals and include descriptive tooltips. Heavy fog is represented by a double emoji as requested.

---
*PR created automatically by Jules for task [1006872520624776026](https://jules.google.com/task/1006872520624776026) started by @nschimme*

## Summary by Sourcery

Integrate dynamic weather and fog indicators into the clock widget UI based on game state.

New Features:
- Display current weather conditions in the clock widget using emoji-based icons with descriptive tooltips.
- Display current fog conditions in the clock widget, including a distinct heavy fog indication, using emoji-based icons with tooltips.

Enhancements:
- Subscribe the clock widget to weather and fog change signals so the indicators stay in sync with the game state, including initialization from the current observer values.