### PR TITLE
Fix build error in JsonObj::getNull

### DIFF
--- a/src/global/JsonObj.cpp
+++ b/src/global/JsonObj.cpp
@@ -50,7 +50,7 @@ NODISCARD OptJsonNull JsonObj::getNull(const QString &name) const
 {
     if (m_obj.contains(name)) {
         if (auto &&tmp = m_obj.value(name); tmp.isNull()) {
-            return OptJsonNull{{}};
+            return JsonNull{};
         }
     }
     return std::nullopt;


### PR DESCRIPTION
Fixed a build error in `src/global/JsonObj.cpp` caused by ambiguous `std::optional` construction. Changed `return OptJsonNull{{}}` to `return JsonNull{}` to avoid conflict with `std::in_place_t` constructor. Verified that the build succeeds and all tests pass.

---
*PR created automatically by Jules for task [7531293979124146950](https://jules.google.com/task/7531293979124146950) started by @nschimme*

## Summary by Sourcery

Bug Fixes:
- Correct JsonObj::getNull to return a JsonNull value instead of an ambiguous optional construction that conflicted with std::in_place_t.