### PR TITLE
Persist configuration on successful parser command changes

### DIFF
--- a/src/client/HotkeyManager.cpp
+++ b/src/client/HotkeyManager.cpp
@@ -95,6 +95,7 @@ bool HotkeyManager::setHotkey(const Hotkey &hk, const std::string_view command)
     QVariantMap data = getConfig().hotkeys.data();
     data[mmqt::toQStringUtf8(hk.to_string())] = mmqt::toQStringUtf8(command);
     setConfig().hotkeys.setData(std::move(data));
+    getConfig().write();
     return true;
 }
 
@@ -110,6 +111,7 @@ bool HotkeyManager::removeHotkey(const Hotkey &hk)
     }
     data.remove(key);
     setConfig().hotkeys.setData(std::move(data));
+    getConfig().write();
     return true;
 }
 
@@ -143,9 +145,11 @@ void HotkeyManager::resetToDefaults()
     XFOREACH_DEFAULT_HOTKEYS(X_DEFAULT)
 #undef X_DEFAULT
     setConfig().hotkeys.setData(std::move(data));
+    getConfig().write();
 }
 
 void HotkeyManager::clear()
 {
     setConfig().hotkeys.setData(QVariantMap());
+    getConfig().write();
 }

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1046,6 +1046,7 @@ void MainWindow::createActions()
 static void setConfigMapMode(const MapModeEnum mode)
 {
     setConfig().general.mapMode = mode;
+    getConfig().write();
 }
 
 void MainWindow::slot_onPlayMode()

--- a/src/parser/AbstractParser-Config.cpp
+++ b/src/parser/AbstractParser-Config.cpp
@@ -198,6 +198,7 @@ void AbstractParser::doConfig(const StringView cmd)
 
                 clone.set(oldValue);
                 fp.setFloat(value);
+                getConfig().write();
                 os << "Changed " << help << " from " << clone.getFloat() << " to " << fp.getFloat()
                    << AnsiOstream::endl;
                 this->graphicsSettingsChanged();
@@ -294,6 +295,7 @@ void AbstractParser::doConfig(const StringView cmd)
                            }
 
                            conf.set(value);
+                           getConfig().write();
                            os << "Set " << conf.getName() << " = " << BoolAlpha(value)
                               << AnsiOstream::endl;
                            graphicsSettingsChanged();

--- a/src/parser/AbstractParser-Group.cpp
+++ b/src/parser/AbstractParser-Group.cpp
@@ -129,6 +129,7 @@ void AbstractParser::parseGroup(StringView input)
             member->setColor(newColor.getQColor());
             if (member->isYou()) {
                 setConfig().groupManager.color = member->getColor();
+                getConfig().write();
             }
             os << "Member " << name << " (" << id << ") has been changed from " << oldColor
                << " to " << newColor << ".\n";

--- a/src/parser/abstractparser.cpp
+++ b/src/parser/abstractparser.cpp
@@ -480,6 +480,7 @@ bool AbstractParser::setCommandPrefix(const char prefix)
         return false;
     }
     setConfig().parser.prefixChar = prefix;
+    getConfig().write();
     showCommandPrefix();
     return true;
 }


### PR DESCRIPTION
This PR ensures that configuration changes made through parser commands (CLI) are automatically persisted to the application's configuration file. Previously, these changes were often only stored in memory until the application was closed normally, which could lead to loss of settings if the application crashed or was terminated unexpectedly.

Key changes:
- Added `getConfig().write()` calls to handlers for `/set prefix`, `/hotkey`, `/config`, and `/group set color`.
- Ensured map mode changes via `/config mode` are persisted.
- Added a new unit test in `TestHotkeyManager` that uses `MMAPPER_PROFILE_PATH` to verify that hotkey changes are correctly written to disk and can be reloaded.

---
*PR created automatically by Jules for task [12696502202478030067](https://jules.google.com/task/12696502202478030067) started by @nschimme*

## Summary by Sourcery

Persist configuration changes triggered by parser commands and hotkey operations so they are immediately written to disk.

Enhancements:
- Ensure configuration changes from parser commands and map mode updates are saved to the config file when modified.
- Make hotkey configuration operations (set, remove, reset to defaults, clear) persist their changes to the config file immediately.

Tests:
- Add a hotkey manager persistence test that verifies hotkey additions and removals are written to and reloaded from a profile-backed config file via MMAPPER_PROFILE_PATH.