### PR TITLE
Show Mana column for solo players with mana

### DIFF
--- a/src/group/groupwidget.cpp
+++ b/src/group/groupwidget.cpp
@@ -1027,6 +1027,13 @@ void GroupWidget::slot_onCharacterUpdated(SharedGroupChar character)
 {
     assert(character);
     deref(m_model).updateCharacter(character);
+
+    const int manaCol = static_cast<int>(ColumnTypeEnum::MANA);
+    const bool hasMana = character->getMana() > 0 || character->getMaxMana() > 0;
+    if (m_table->isColumnHidden(manaCol) == hasMana) {
+        updateColumnVisibility();
+    }
+
     updatePulseTimer();
 }
 


### PR DESCRIPTION
This change fixes a bug where the Mana column in the GroupWidget remained hidden for solo players even if they had mana. The fix involves triggering a column visibility update when a character is updated (e.g., via GMCP vitals) if their mana state has changed or if it necessitates showing a previously hidden column.

---
*PR created automatically by Jules for task [3472155908677027235](https://jules.google.com/task/3472155908677027235) started by @nschimme*

## Summary by Sourcery

Bug Fixes:
- Fix Mana column not appearing for solo players who have mana by updating column visibility on character updates.