### PR TITLE
Reorganize "Get MMapper" section and update navigation

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -18,15 +18,16 @@
     <script src="{{ '/assets/js/download-highlight.js' | relative_url }}"></script>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
     <div class="content-wrapper">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <header style="display: flex; flex-direction: column; align-items: center;">
                 <div style="display: flex; align-items: center;">
-			<img src="{{ '/assets/img/logo.svg' | relative_url }}" alt="MMapper" style="height: 50px; margin-right: 10px;">
+			<img src="{{ '/assets/img/logo.svg' | relative_url }}" alt="" aria-hidden="true" style="height: 50px; margin-right: 10px;">
                     <h1><a href="{{ '/' | relative_url }}">{{ page.title | default: site.title }}</a></h1>
                 </div>
             </header>
-            <nav>
+            <nav aria-label="Main Navigation">
                 <ul style="list-style: none; padding: 0; margin: 0;">
                     <li style="display: inline; margin-left: 10px;"><a href="{{ '/#get-mmapper' | relative_url }}">Get</a></li>
                     <li style="display: inline; margin-left: 10px;"><a href="{{ '/changelog.html' | relative_url }}">Changelog</a></li>
@@ -35,7 +36,7 @@
             </nav>
         </div>
 
-        <main>
+        <main id="main-content">
             {{ content }}
         </main>
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -24,7 +24,9 @@
             <header style="display: flex; flex-direction: column; align-items: center;">
                 <div style="display: flex; align-items: center;">
 			<img src="{{ '/assets/img/logo.svg' | relative_url }}" alt="" aria-hidden="true" style="height: 50px; margin-right: 10px;">
-                    <a href="{{ '/' | relative_url }}" style="font-size: 2em; font-family: 'Trebuchet MS', sans-serif; color: #eee; font-weight: bold; text-decoration: none;">MMapper</a>
+                    <h1 style="font-size: 2em; font-family: 'Trebuchet MS', sans-serif; margin: 0; border: none; padding: 0;">
+                        <a href="{{ '/' | relative_url }}" style="color: #eee; font-weight: bold; text-decoration: none;">MMapper</a>
+                    </h1>
                 </div>
             </header>
             <nav aria-label="Main Navigation">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -24,7 +24,7 @@
             <header style="display: flex; flex-direction: column; align-items: center;">
                 <div style="display: flex; align-items: center;">
 			<img src="{{ '/assets/img/logo.svg' | relative_url }}" alt="" aria-hidden="true" style="height: 50px; margin-right: 10px;">
-                    <h1><a href="{{ '/' | relative_url }}">{{ page.title | default: site.title }}</a></h1>
+                    <a href="{{ '/' | relative_url }}" style="font-size: 2em; font-family: 'Trebuchet MS', sans-serif; color: #eee; font-weight: bold; text-decoration: none;">MMapper</a>
                 </div>
             </header>
             <nav aria-label="Main Navigation">
@@ -37,6 +37,9 @@
         </div>
 
         <main id="main-content">
+            {% if page.title %}
+            <h2>{{ page.title }}</h2>
+            {% endif %}
             {{ content }}
         </main>
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -23,10 +23,16 @@
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <header style="display: flex; flex-direction: column; align-items: center;">
                 <div style="display: flex; align-items: center;">
-			<img src="{{ '/assets/img/logo.svg' | relative_url }}" alt="" aria-hidden="true" style="height: 50px; margin-right: 10px;">
+                    <img src="{{ '/assets/img/logo.svg' | relative_url }}" alt="" aria-hidden="true" style="height: 50px; margin-right: 10px;">
+                    {% if page.url == "/" or page.url == "/index.html" %}
                     <h1 style="font-size: 2em; font-family: 'Trebuchet MS', sans-serif; margin: 0; border: none; padding: 0;">
                         <a href="{{ '/' | relative_url }}" style="color: #eee; font-weight: bold; text-decoration: none;">MMapper</a>
                     </h1>
+                    {% else %}
+                    <div style="font-size: 2em; font-family: 'Trebuchet MS', sans-serif; margin: 0; border: none; padding: 0; font-weight: bold;">
+                        <a href="{{ '/' | relative_url }}" style="color: #eee; text-decoration: none;">MMapper</a>
+                    </div>
+                    {% endif %}
                 </div>
             </header>
             <nav aria-label="Main Navigation">
@@ -40,7 +46,11 @@
 
         <main id="main-content">
             {% if page.title %}
-            <h2>{{ page.title }}</h2>
+                {% if page.url == "/" or page.url == "/index.html" %}
+                <h2>{{ page.title }}</h2>
+                {% else %}
+                <h1>{{ page.title }}</h1>
+                {% endif %}
             {% endif %}
             {{ content }}
         </main>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -28,8 +28,7 @@
             </header>
             <nav>
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/demo/' | relative_url }}">Demo</a></li>
-                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/#download-mmapper' | relative_url }}">Download</a></li>
+                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/#get-mmapper' | relative_url }}">Get</a></li>
                     <li style="display: inline; margin-left: 10px;"><a href="{{ '/changelog.html' | relative_url }}">Changelog</a></li>
                     <li style="display: inline; margin-left: 10px;"><a href="{{ '/about.html' | relative_url }}">About</a></li>
                 </ul>

--- a/docs/about.md
+++ b/docs/about.md
@@ -5,7 +5,6 @@ title: About MMapper
 
 <img src="{{ site.screenshot }}" alt="MMapper Screenshot" style="display: block; margin: 0 auto; width: 100%; max-width: auto; height: auto; margin-bottom: 1em;">
 
-## About MMapper
 
 MMapper is a client and graphical mapping tool that enhances the MUME (Multi-Users in Middle Earth) experience by providing a **dynamic, interactive map** of the game world. Tired of memorizing directions? MMapper acts as a bridge between the MUME server and your game client, analyzing real-time game data and visually displaying your character’s position on the map. Visualize your world, navigate easily with terrain highlighting, and enjoy enhanced gameplay with features like terrain detection, pseudo-3D views, and group map sharing. MMapper automatically maps rooms, terrain, and exits, updating the map in real time as you explore, so you always have an accurate view of your surroundings.
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -5,7 +5,6 @@ title: About MMapper
 
 <img src="{{ site.screenshot }}" alt="MMapper Screenshot" style="display: block; margin: 0 auto; width: 100%; max-width: auto; height: auto; margin-bottom: 1em;">
 
-
 MMapper is a client and graphical mapping tool that enhances the MUME (Multi-Users in Middle Earth) experience by providing a **dynamic, interactive map** of the game world. Tired of memorizing directions? MMapper acts as a bridge between the MUME server and your game client, analyzing real-time game data and visually displaying your character’s position on the map. Visualize your world, navigate easily with terrain highlighting, and enjoy enhanced gameplay with features like terrain detection, pseudo-3D views, and group map sharing. MMapper automatically maps rooms, terrain, and exits, updating the map in real time as you explore, so you always have an accurate view of your surroundings.
 
 ## Why Use MMapper?

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -12,7 +12,8 @@
     transition: top 0.3s;
 }
 
-.skip-link:focus {
+.skip-link:focus,
+.skip-link:focus-visible {
     top: 0;
 }
 

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -147,7 +147,8 @@ hr {
 
 /* Download Buttons/Links (on platform pages) */
 .download-link {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     background-color: #cc9933;
     color: #1a1a1a; /* Dark text on button */
     padding: 0.8em 1.5em;
@@ -176,6 +177,16 @@ hr {
     margin-left: 0.5em;
     vertical-align: middle;
     display: inline-block;
+}
+
+/* Ensure recommendation is readable when inside a button */
+.download-link .recommendation-text {
+    color: #1a1a1a;
+    background: #5cb85c;
+    padding: 0.2em 0.5em;
+    border-radius: 3px;
+    font-size: 0.8em;
+    text-transform: uppercase;
 }
 
 .platform-recommendation {

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,6 +1,21 @@
 /* Minimal MMapper Website Styles */
 
 /* Basic Reset & Body */
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    background: #cc9933;
+    color: #1a1a1a;
+    padding: 8px;
+    z-index: 100;
+    transition: top 0.3s;
+}
+
+.skip-link:focus {
+    top: 0;
+}
+
 body {
     margin: 0;
     padding: 0;

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -189,10 +189,10 @@ hr {
     text-transform: uppercase;
 }
 
-.platform-recommendation {
-    display: block !important;
-    margin-left: 0 !important;
-    margin-top: 0.5em !important;
+.platform-link .platform-recommendation {
+    display: block;
+    margin-left: 0;
+    margin-top: 0.5em;
     font-size: 0.9em;
 }
 

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -174,6 +174,15 @@ hr {
     color: #5cb85c;
     font-weight: bold;
     margin-left: 0.5em;
+    vertical-align: middle;
+    display: inline-block;
+}
+
+.platform-recommendation {
+    display: block !important;
+    margin-left: 0 !important;
+    margin-top: 0.5em !important;
+    font-size: 0.9em;
 }
 
 

--- a/docs/assets/js/download-highlight.js
+++ b/docs/assets/js/download-highlight.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     let detectedArch = null;
     let isChromeOS = false;
-    const downloadLinks = document.querySelectorAll('.download-link');
+    const downloadLinks = document.querySelectorAll('.download-link, .platform-link');
 
     // --- Architecture Detection (Best Effort) ---
     if (navigator.userAgentData && navigator.userAgentData.architecture) {
@@ -23,6 +23,21 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     // --- Highlight Download Link ---
+    function addRecommendation(link) {
+        link.classList.add('recommended-download');
+        const recommendation = document.createElement('span');
+        recommendation.textContent = ' Recommended';
+        recommendation.classList.add('recommendation-text');
+
+        if (link.classList.contains('platform-link')) {
+            // For homepage icons, put it inside so it doesn't break flex layout
+            recommendation.classList.add('platform-recommendation');
+            link.appendChild(recommendation);
+        } else {
+            link.parentNode.insertBefore(recommendation, link.nextSibling);
+        }
+    }
+
     downloadLinks.forEach(link => {
         const href = link.href.toLowerCase();
 
@@ -31,8 +46,9 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
 
-        // Only recommend .deb for ChromeOS
-        if (isChromeOS && (href.includes('appimage') || href.includes('flatpak'))) {
+        // Recommend Web/PWA for ChromeOS
+        if (isChromeOS && href.includes('/demo/')) {
+            addRecommendation(link);
             return;
         }
 
@@ -44,11 +60,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         if (detectedArch && linkArch === detectedArch) {
-            link.classList.add('recommended-download');
-            const recommendation = document.createElement('span');
-            recommendation.textContent = ' Recommended';
-            recommendation.classList.add('recommendation-text');
-            link.parentNode.insertBefore(recommendation, link.nextSibling);
+            addRecommendation(link);
         }
     });
 });

--- a/docs/assets/js/download-highlight.js
+++ b/docs/assets/js/download-highlight.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     downloadLinks.forEach(link => {
         const href = link.href.toLowerCase();
+        const platform = link.getAttribute('data-platform');
 
         // Do not recommend Windows .exe installers
         if (href.includes('.exe')) {
@@ -46,7 +47,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // For ChromeOS, only recommend the Web version
         if (isChromeOS) {
-            if (href.includes('/demo/')) {
+            if (platform === 'web') {
                 addRecommendation(link);
             }
             return; // Don't recommend anything else on ChromeOS

--- a/docs/assets/js/download-highlight.js
+++ b/docs/assets/js/download-highlight.js
@@ -29,13 +29,11 @@ document.addEventListener('DOMContentLoaded', function() {
         recommendation.textContent = ' Recommended';
         recommendation.classList.add('recommendation-text');
 
+        // Always place recommendation inside the link for consistent semantics and focus behavior
         if (link.classList.contains('platform-link')) {
-            // For homepage icons, put it inside so it doesn't break flex layout
             recommendation.classList.add('platform-recommendation');
-            link.appendChild(recommendation);
-        } else {
-            link.parentNode.insertBefore(recommendation, link.nextSibling);
         }
+        link.appendChild(recommendation);
     }
 
     downloadLinks.forEach(link => {
@@ -46,10 +44,12 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
 
-        // Recommend Web/PWA for ChromeOS
-        if (isChromeOS && href.includes('/demo/')) {
-            addRecommendation(link);
-            return;
+        // For ChromeOS, only recommend the Web version
+        if (isChromeOS) {
+            if (href.includes('/demo/')) {
+                addRecommendation(link);
+            }
+            return; // Don't recommend anything else on ChromeOS
         }
 
         let linkArch = null;

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,8 @@ title: Play MUME with MMapper
     MMapper is a game client and graphical mapping tool that enhances the MUME (Multi-Users in Middle Earth) experience. It acts as a bridge between the MUME server and your mud client, analyzing real-time game data and visually displaying your character’s position on the map.
 </div>
 
+MMapper is now available directly in your browser! The Web version works as a Progressive Web App (PWA), providing a near-native experience without needing to download any files.
+
 ## Get MMapper
 {: #get-mmapper}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,11 +8,16 @@ title: Play MUME with MMapper
     MMapper is a game client and graphical mapping tool that enhances the MUME (Multi-Users in Middle Earth) experience. It acts as a bridge between the MUME server and your mud client, analyzing real-time game data and visually displaying your character’s position on the map.
 </div>
 
-## Download MMapper
+## Get MMapper
+{: #get-mmapper}
 
-Choose your operating system to download the latest version {{ site.github.latest_release.tag_name }}:
+Choose your preferred platform to start using MMapper {{ site.github.latest_release.tag_name }}:
 
 <div class="platform-links">
+    <a href="{{ '/demo/' | relative_url }}" class="platform-link">
+        <i class="fas fa-globe"></i>
+        <span>Web</span>
+    </a>
     <a href="{{ '/windows.html' | relative_url }}" class="platform-link">
         <i class="fab fa-windows"></i>
         <span>Windows</span>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Play MUME with MMapper
 ---
 
 <div id="index-screenshot-flex" style="display: flex; justify-content: space-between; align-items: center;">

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,20 +14,20 @@ title: Play MUME with MMapper
 Choose your preferred platform to start using MMapper {{ site.github.latest_release.tag_name }}:
 
 <div class="platform-links">
-    <a href="{{ '/demo/' | relative_url }}" class="platform-link">
-        <i class="fas fa-globe"></i>
+    <a href="{{ '/demo/' | relative_url }}" class="platform-link" aria-label="Use MMapper in your Web Browser">
+        <i class="fas fa-globe" aria-hidden="true"></i>
         <span>Web</span>
     </a>
-    <a href="{{ '/windows.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-windows"></i>
+    <a href="{{ '/windows.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for Windows">
+        <i class="fab fa-windows" aria-hidden="true"></i>
         <span>Windows</span>
     </a>
-    <a href="{{ '/macos.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-apple"></i>
+    <a href="{{ '/macos.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for macOS">
+        <i class="fab fa-apple" aria-hidden="true"></i>
         <span>macOS</span>
     </a>
-    <a href="{{ '/linux.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-linux"></i>
+    <a href="{{ '/linux.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for Linux">
+        <i class="fab fa-linux" aria-hidden="true"></i>
         <span>Linux</span>
     </a>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ MMapper is now available directly in your browser! The Web version works as a Pr
 Choose your preferred platform to start using MMapper {{ site.github.latest_release.tag_name }}:
 
 <div class="platform-links">
-    <a href="{{ '/demo/' | relative_url }}" class="platform-link" aria-label="Use MMapper in your Web Browser">
+    <a href="{{ '/demo/' | relative_url }}" class="platform-link" aria-label="Use MMapper in your Web Browser" data-platform="web">
         <i class="fas fa-globe" aria-hidden="true"></i>
         <span>Web</span>
     </a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,5 @@
 ---
 layout: default
-title: Play MUME with MMapper
 ---
 
 <div id="index-screenshot-flex" style="display: flex; justify-content: space-between; align-items: center;">

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -3,9 +3,7 @@ layout: default
 title: Get MMapper for Linux
 ---
 
-MMapper is available on Linux through several popular packaging formats. We highly recommend using **Flathub (Flatpak)** as it provides the most consistent experience across different Linux distributions, including automatic updates and a secure sandbox.
-
-For those on Ubuntu or other Snap-enabled systems, the **Snap Store** is also a great option. Additionally, we provide a standalone **AppImage** that can be run directly without installation.
+Choose your preferred distribution method below. We recommend using Flathub for a sandboxed environment and easy updates across most Linux distributions.
 
 <a href='https://flathub.org/apps/org.mume.MMapper'>
     <img width='200' alt='Get it on Flathub' src='https://flathub.org/api/badge?locale=en' style="vertical-align: middle;"/>
@@ -14,8 +12,8 @@ For those on Ubuntu or other Snap-enabled systems, the **Snap Store** is also a 
 [![Get it from the Snap Store](https://snapcraft.io/en/dark/install.svg)](https://snapcraft.io/mmapper)
 
 {% for asset in site.github.latest_release.assets %}
-{% if asset.name contains 'sha256' %}
-{% elsif asset.name contains 'AppImage' %}
+{% if asset.name contains 'sha256' or asset.name contains 'zsync' %}
+{% elsif asset.name contains 'AppImage' or asset.name contains 'deb' or asset.name contains 'flatpak' %}
 <a href="{{ asset.browser_download_url }}" class="download-link">
     Download {{ asset.name }}
 </a>

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -3,7 +3,6 @@ layout: default
 title: Download MMapper for Linux
 ---
 
-## Download MMapper for Linux
 
 <a href='https://flathub.org/apps/org.mume.MMapper'>
     <img width='200' alt='Get it on Flathub' src='https://flathub.org/api/badge?locale=en' style="vertical-align: middle;"/>

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,8 +1,11 @@
 ---
 layout: default
-title: Download MMapper for Linux
+title: Get MMapper for Linux
 ---
 
+MMapper is available on Linux through several popular packaging formats. We highly recommend using **Flathub (Flatpak)** as it provides the most consistent experience across different Linux distributions, including automatic updates and a secure sandbox.
+
+For those on Ubuntu or other Snap-enabled systems, the **Snap Store** is also a great option. Additionally, we provide a standalone **AppImage** that can be run directly without installation.
 
 <a href='https://flathub.org/apps/org.mume.MMapper'>
     <img width='200' alt='Get it on Flathub' src='https://flathub.org/api/badge?locale=en' style="vertical-align: middle;"/>
@@ -11,8 +14,8 @@ title: Download MMapper for Linux
 [![Get it from the Snap Store](https://snapcraft.io/en/dark/install.svg)](https://snapcraft.io/mmapper)
 
 {% for asset in site.github.latest_release.assets %}
-{% if asset.name contains 'sha256' or asset.name contains 'zsync' %}
-{% elsif asset.name contains 'AppImage' or asset.name contains 'deb' or asset.name contains 'flatpak' %}
+{% if asset.name contains 'sha256' %}
+{% elsif asset.name contains 'AppImage' %}
 <a href="{{ asset.browser_download_url }}" class="download-link">
     Download {{ asset.name }}
 </a>

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,7 +1,11 @@
 ---
 layout: default
-title: Download MMapper for macOS
+title: Get MMapper for macOS
 ---
+
+To install MMapper on macOS, download the **Disk Image (DMG)** file provided below.
+
+MMapper is a universal binary, meaning it runs natively on both older **Intel-based Macs** and the latest **Apple Silicon (M1, M2, and M3)** models. After downloading, simply open the DMG file and drag MMapper to your Applications folder.
 
 {% for asset in site.github.latest_release.assets %}
 {% if asset.name contains 'sha256' %}
@@ -12,19 +16,17 @@ title: Download MMapper for macOS
 {% endif %}
 {% endfor %}
 
-<div class="notice-box" id="mac-notice">
+<div class="notice-box" id="macos-notice">
   <strong style="color: #d9534f;">Important Notice for macOS Users:</strong><br>
-  This application is not notarized by Apple, so macOS might prevent it from opening directly.<br>
-  <strong>To run the application the first time:</strong>
+  On newer versions of macOS (Sequoia and later), you might see a message stating that the app "cannot be opened because it is from an unidentified developer."<br>
+  <strong>To allow MMapper to run:</strong>
   <ol>
-    <li>Locate the downloaded <code>.dmg</code> file and open it.</li>
-    <li>Drag the MMapper application to your Applications folder (or another location).</li>
-    <li>Right-click (or Control-click) the MMapper application icon.</li>
-    <li>Select "Open" from the context menu.</li>
-    <li>A dialog box will appear warning you about the developer. Click "Open" again.</li>
+    <li>Open <strong>System Settings</strong>.</li>
+    <li>Navigate to <strong>Privacy & Security</strong>.</li>
+    <li>Scroll down to the "Security" section.</li>
+    <li>You should see a message about MMapper being blocked. Click <strong>Open Anyway</strong>.</li>
+    <li>Enter your password or use Touch ID when prompted.</li>
   </ol>
-  <small>Alternatively, you can go to System Settings > Privacy & Security, scroll down to the "Security" section, and look for an "Open Anyway" button related to MMapper after trying to open it the first time.</small><br>
-  <small>You only need to do this the first time you run this version.</small>
 </div>
 
 {% include download.md %}

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -3,9 +3,7 @@ layout: default
 title: Get MMapper for macOS
 ---
 
-To install MMapper on macOS, download the **Disk Image (DMG)** file provided below.
-
-MMapper is a universal binary, meaning it runs natively on both older **Intel-based Macs** and the latest **Apple Silicon (M1, M2, and M3)** models. After downloading, simply open the DMG file and drag MMapper to your Applications folder.
+To install MMapper on macOS, download the Disk Image (DMG) file provided below. MMapper is compatible with both Intel and Apple Silicon (M1/M2/M3) processors.
 
 {% for asset in site.github.latest_release.assets %}
 {% if asset.name contains 'sha256' %}
@@ -16,17 +14,19 @@ MMapper is a universal binary, meaning it runs natively on both older **Intel-ba
 {% endif %}
 {% endfor %}
 
-<div class="notice-box" id="macos-notice">
+<div class="notice-box" id="mac-notice">
   <strong style="color: #d9534f;">Important Notice for macOS Users:</strong><br>
-  On newer versions of macOS (Sequoia and later), you might see a message stating that the app "cannot be opened because it is from an unidentified developer."<br>
-  <strong>To allow MMapper to run:</strong>
+  This application is not notarized by Apple, so macOS might prevent it from opening directly.<br>
+  <strong>To run the application the first time:</strong>
   <ol>
-    <li>Open <strong>System Settings</strong>.</li>
-    <li>Navigate to <strong>Privacy & Security</strong>.</li>
-    <li>Scroll down to the "Security" section.</li>
-    <li>You should see a message about MMapper being blocked. Click <strong>Open Anyway</strong>.</li>
-    <li>Enter your password or use Touch ID when prompted.</li>
+    <li>Locate the downloaded <code>.dmg</code> file and open it.</li>
+    <li>Drag the MMapper application to your Applications folder (or another location).</li>
+    <li>Right-click (or Control-click) the MMapper application icon.</li>
+    <li>Select "Open" from the context menu.</li>
+    <li>A dialog box will appear warning you about the developer. Click "Open" again.</li>
   </ol>
+  <small>Alternatively, you can go to System Settings > Privacy & Security, scroll down to the "Security" section, and look for an "Open Anyway" button related to MMapper after trying to open it the first time.</small><br>
+  <small>You only need to do this the first time you run this version.</small>
 </div>
 
 {% include download.md %}

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -3,7 +3,6 @@ layout: default
 title: Download MMapper for macOS
 ---
 
-## Download MMapper for macOS
 {% for asset in site.github.latest_release.assets %}
 {% if asset.name contains 'sha256' %}
 {% elsif asset.name contains 'dmg' %}

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,8 +1,11 @@
 ---
 layout: default
-title: Download MMapper for Windows
+title: Get MMapper for Windows
 ---
 
+MMapper provides two main ways to install on Windows. The **Microsoft Store** version is the recommended choice as it offers the easiest installation process and handles updates automatically. If you prefer a traditional installation, you can download the **standalone .exe installer** below.
+
+Please note that the standalone version may trigger a security warning from Windows because it is not digitally signed; instructions for unblocking it are provided at the bottom of this page.
 
 <a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct">
      <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" style="vertical-align: middle;"/>

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -3,7 +3,6 @@ layout: default
 title: Download MMapper for Windows
 ---
 
-## Download MMapper for Windows
 
 <a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct">
      <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" style="vertical-align: middle;"/>

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -5,9 +5,10 @@ title: Get MMapper for Windows
 
 MMapper can be installed from the Microsoft Store for a seamless experience, including automatic updates. Alternatively, you can download the standalone installer below.
 
-<a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct">
+<a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct" style="display: inline-flex; align-items: center; text-decoration: none;">
      <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" style="vertical-align: middle;"/>
-</a><span class="recommendation-text"> Recommended</span>
+     <span class="recommendation-text"> Recommended</span>
+</a>
 
 {% for asset in site.github.latest_release.assets %}
 {% if asset.name contains 'sha256' %}

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -3,9 +3,7 @@ layout: default
 title: Get MMapper for Windows
 ---
 
-MMapper provides two main ways to install on Windows. The **Microsoft Store** version is the recommended choice as it offers the easiest installation process and handles updates automatically. If you prefer a traditional installation, you can download the **standalone .exe installer** below.
-
-Please note that the standalone version may trigger a security warning from Windows because it is not digitally signed; instructions for unblocking it are provided at the bottom of this page.
+MMapper can be installed from the Microsoft Store for a seamless experience, including automatic updates. Alternatively, you can download the standalone installer below.
 
 <a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct">
      <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" style="vertical-align: middle;"/>


### PR DESCRIPTION
I have reorganized the "Get MMapper" section to prioritize the Web/PWA version and updated the navigation to reflect these changes.

Key changes:
1.  **docs/index.md**:
    *   Renamed header to "Get MMapper".
    *   Added an anchor `{: #get-mmapper}` for direct navigation.
    *   Moved the "Web" link (previously "Demo") to the first position in the platform list.
    *   Updated the introductory text to "Choose your preferred platform...".
2.  **docs/_layouts/default.html**:
    *   Removed the "Demo" link from the top navigation bar.
    *   Renamed the "Download" link to "Get" and updated its target to `#get-mmapper`.
3.  **docs/assets/css/style.css**:
    *   Verified that the existing responsive styles correctly handle four platform links (it wraps to a 2x2 grid on mobile).

These changes make the PWA more discoverable and ensure the terminology is consistent across the site.

---
*PR created automatically by Jules for task [10830348006901641918](https://jules.google.com/task/10830348006901641918) started by @nschimme*

## Summary by Sourcery

Reorganize the main "Get MMapper" entry point to prioritize the web/PWA version and improve accessibility and platform guidance across the docs site.

New Features:
- Add a prominent Web platform entry to the Get MMapper section as the primary way to use MMapper.
- Introduce a skip-to-content link and better page title semantics for improved accessibility.

Enhancements:
- Standardize "Download" wording to "Get" across navigation and platform pages.
- Improve recommendation styling and placement for download/platform links, including ChromeOS-specific web recommendations and consistent in-link badges.
- Refine Windows, macOS, and Linux platform pages with clearer installation guidance and recommended distribution methods.