### PR TITLE
Fix OpenGL prober to robustly handle noisy subprocess output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,9 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif()
 
     if(MMAPPER_IS_DEBUG)
+        # segfaults in ASAN initializer on 32-bit Ubuntu 18.04.1 with clang 6.0
+        # note: apparently -fsanitize=address can't be used with gnu libc 2.25+
+        # Ubuntu 18.04.1 has libc 2.27.
         message(STATUS "Building with Clang address sanitizer")
         add_compile_options(-fsanitize=address)
         add_link_options(-fsanitize=address)

--- a/cmake/MakeAppX.cmake.in
+++ b/cmake/MakeAppX.cmake.in
@@ -38,10 +38,14 @@ set(APPX_PDB_SOURCE_PATH "${CPACK_TEMPORARY_DIRECTORY}/${APPX_PDB_FILE_NAME}")
 
 ## Prepare Staging Directory
 
-# Flatten all subdirectories in the staging root for MakeAppx.
+# Flatten all subdirectories in the staging root for MakeAppx, EXCEPT Assets.
 file(GLOB staging_items "${CPACK_TEMPORARY_DIRECTORY}/*")
 foreach(item ${staging_items})
     if(IS_DIRECTORY "${item}")
+        get_filename_component(item_name "${item}" NAME)
+        if(item_name STREQUAL "Assets")
+            continue()
+        endif()
         message(STATUS "Flattening directory: ${item}")
         file(GLOB subdir_contents "${item}/*")
         foreach(subitem ${subdir_contents})

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -18,6 +18,7 @@
     <script src="{{ '/assets/js/download-highlight.js' | relative_url }}"></script>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
     <div class="content-wrapper">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <header style="display: flex; flex-direction: column; align-items: center;">
@@ -26,17 +27,16 @@
                     <h1><a href="{{ '/' | relative_url }}">{{ page.title | default: site.title }}</a></h1>
                 </div>
             </header>
-            <nav>
+            <nav aria-label="Main Navigation">
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/demo/' | relative_url }}">Demo</a></li>
-                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/#download-mmapper' | relative_url }}">Download</a></li>
+                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/#get-mmapper' | relative_url }}">Get</a></li>
                     <li style="display: inline; margin-left: 10px;"><a href="{{ '/changelog.html' | relative_url }}">Changelog</a></li>
                     <li style="display: inline; margin-left: 10px;"><a href="{{ '/about.html' | relative_url }}">About</a></li>
                 </ul>
             </nav>
         </div>
 
-        <main>
+        <main id="main-content">
             {{ content }}
         </main>
 

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,6 +1,22 @@
 /* Minimal MMapper Website Styles */
 
 /* Basic Reset & Body */
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    background: #cc9933;
+    color: #1a1a1a;
+    padding: 8px;
+    z-index: 100;
+    transition: top 0.3s;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+    top: 0;
+}
+
 body {
     margin: 0;
     padding: 0;

--- a/docs/assets/js/download-highlight.js
+++ b/docs/assets/js/download-highlight.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     let detectedArch = null;
     let isChromeOS = false;
-    const downloadLinks = document.querySelectorAll('.download-link');
+    const downloadLinks = document.querySelectorAll('.download-link, .platform-link');
 
     // --- Architecture Detection (Best Effort) ---
     if (navigator.userAgentData && navigator.userAgentData.architecture) {
@@ -23,17 +23,34 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     // --- Highlight Download Link ---
+    function addRecommendation(link) {
+        link.classList.add('recommended-download');
+        const recommendation = document.createElement('span');
+        recommendation.textContent = ' Recommended';
+        recommendation.classList.add('recommendation-text');
+
+        // Place recommendation outside the link as per user preference
+        if (link.classList.contains('platform-link')) {
+            recommendation.classList.add('platform-recommendation');
+        }
+        link.parentNode.insertBefore(recommendation, link.nextSibling);
+    }
+
     downloadLinks.forEach(link => {
         const href = link.href.toLowerCase();
+        const platform = link.getAttribute('data-platform');
 
         // Do not recommend Windows .exe installers
         if (href.includes('.exe')) {
             return;
         }
 
-        // Only recommend .deb for ChromeOS
-        if (isChromeOS && (href.includes('appimage') || href.includes('flatpak'))) {
-            return;
+        // For ChromeOS, only recommend the Web version
+        if (isChromeOS) {
+            if (platform === 'web') {
+                addRecommendation(link);
+            }
+            return; // Don't recommend anything else on ChromeOS
         }
 
         let linkArch = null;
@@ -44,11 +61,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         if (detectedArch && linkArch === detectedArch) {
-            link.classList.add('recommended-download');
-            const recommendation = document.createElement('span');
-            recommendation.textContent = ' Recommended';
-            recommendation.classList.add('recommendation-text');
-            link.parentNode.insertBefore(recommendation, link.nextSibling);
+            addRecommendation(link);
         }
     });
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,21 +8,26 @@ title: Play MUME with MMapper
     MMapper is a game client and graphical mapping tool that enhances the MUME (Multi-Users in Middle Earth) experience. It acts as a bridge between the MUME server and your mud client, analyzing real-time game data and visually displaying your character’s position on the map.
 </div>
 
-## Download MMapper
+## Get MMapper
+{: #get-mmapper}
 
-Choose your operating system to download the latest version {{ site.github.latest_release.tag_name }}:
+Choose your preferred platform to start using MMapper {{ site.github.latest_release.tag_name }}:
 
 <div class="platform-links">
-    <a href="{{ '/windows.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-windows"></i>
+    <a href="{{ '/demo/' | relative_url }}" class="platform-link" aria-label="Use MMapper in your Web Browser" data-platform="web">
+        <i class="fas fa-globe" aria-hidden="true"></i>
+        <span>Web</span>
+    </a>
+    <a href="{{ '/windows.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for Windows">
+        <i class="fab fa-windows" aria-hidden="true"></i>
         <span>Windows</span>
     </a>
-    <a href="{{ '/macos.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-apple"></i>
+    <a href="{{ '/macos.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for macOS">
+        <i class="fab fa-apple" aria-hidden="true"></i>
         <span>macOS</span>
     </a>
-    <a href="{{ '/linux.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-linux"></i>
+    <a href="{{ '/linux.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for Linux">
+        <i class="fab fa-linux" aria-hidden="true"></i>
         <span>Linux</span>
     </a>
 </div>

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,9 +1,9 @@
 ---
 layout: default
-title: Download MMapper for Linux
+title: Get MMapper for Linux
 ---
 
-## Download MMapper for Linux
+Choose your preferred distribution method below. We recommend using Flathub for a sandboxed environment and easy updates across most Linux distributions.
 
 <a href='https://flathub.org/apps/org.mume.MMapper'>
     <img width='200' alt='Get it on Flathub' src='https://flathub.org/api/badge?locale=en' style="vertical-align: middle;"/>

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,9 +1,10 @@
 ---
 layout: default
-title: Download MMapper for macOS
+title: Get MMapper for macOS
 ---
 
-## Download MMapper for macOS
+To install MMapper on macOS, download the Disk Image (DMG) file provided below. MMapper is compatible with both Intel and Apple Silicon processors.
+
 {% for asset in site.github.latest_release.assets %}
 {% if asset.name contains 'sha256' %}
 {% elsif asset.name contains 'dmg' %}

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,13 +1,14 @@
 ---
 layout: default
-title: Download MMapper for Windows
+title: Get MMapper for Windows
 ---
 
-## Download MMapper for Windows
+MMapper can be installed from the Microsoft Store for a seamless experience, including automatic updates. Alternatively, you can download the standalone installer below.
 
-<a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct">
+<a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct" style="display: inline-flex; align-items: center; text-decoration: none;">
      <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" style="vertical-align: middle;"/>
-</a><span class="recommendation-text"> Recommended</span>
+</a>
+<span class="recommendation-text"> Recommended</span>
 
 {% for asset in site.github.latest_release.assets %}
 {% if asset.name contains 'sha256' %}

--- a/src/display/mapcanvas_gl.cpp
+++ b/src/display/mapcanvas_gl.cpp
@@ -186,7 +186,7 @@ void MapCanvas::reportGLVersion()
         logMsg("Highest OpenGL:", mmqt::toQByteArrayUtf8(OpenGLConfig::getGLVersionString()));
     }
     if constexpr (!NO_GLES) {
-        logMsg("Highest GLES:", mmqt::toQByteArrayUtf8(OpenGLConfig::getESVersionString()));
+        logMsg("Highest ES:", mmqt::toQByteArrayUtf8(OpenGLConfig::getESVersionString()));
     }
 
     logMsg("Display:", QString("%1 DPI").arg(QPaintDevice::devicePixelRatioF()).toUtf8());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "./opengl/OpenGLConfig.h"
 #include "./opengl/OpenGLProber.h"
 
+#include <cstring>
 #include <memory>
 #include <optional>
 
@@ -151,13 +152,20 @@ static bool setSurfaceFormat()
         return false;
     }
     OpenGLConfig::setBackendType(probeResult.backendType);
-    OpenGLConfig::setIsCompat(probeResult.isCompat);
     QSurfaceFormat::setDefaultFormat(probeResult.format);
     return true;
 }
 
 int main(int argc, char **argv)
 {
+#ifndef Q_OS_WASM
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--probe") == 0) {
+            return OpenGLProber::runSurveyMode(argc, argv);
+        }
+    }
+#endif
+
     setHighDpiScaleFactorRoundingPolicy();
     setEnteredMain();
     if constexpr (IS_DEBUG_BUILD) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,7 +144,7 @@ static bool setSurfaceFormat()
             if constexpr (CURRENT_PLATFORM == PlatformEnum::Wasm) {
                 msg += "WebGL 2.0";
             } else {
-                msg += "GLES 3.0";
+                msg += "ES 3.0";
             }
         }
         msg += " support to run.";

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -94,12 +94,12 @@ UniqueMesh OpenGL::createPointBatch(const std::vector<ColorVert> &batch)
 
 UniqueMesh OpenGL::createPlainLineBatch(const std::vector<glm::vec3> &batch)
 {
-    return getFunctions().createPlainBatch(DrawModeEnum::LINES, batch);
+    return getFunctions().createPlainLineBatch(batch);
 }
 
 UniqueMesh OpenGL::createColoredLineBatch(const std::vector<ColorVert> &batch)
 {
-    return getFunctions().createColoredBatch(DrawModeEnum::LINES, batch);
+    return getFunctions().createColoredLineBatch(batch);
 }
 
 UniqueMesh OpenGL::createPlainTriBatch(const std::vector<glm::vec3> &batch)
@@ -165,14 +165,22 @@ void OpenGL::renderPlain(const DrawModeEnum type,
                          const std::vector<glm::vec3> &verts,
                          const GLRenderState &state)
 {
-    getFunctions().renderPlain(type, verts, state);
+    if (type == DrawModeEnum::LINES) {
+        getFunctions().renderPlainLines(verts, state);
+    } else {
+        getFunctions().renderPlain(type, verts, state);
+    }
 }
 
 void OpenGL::renderColored(const DrawModeEnum type,
                            const std::vector<ColorVert> &verts,
                            const GLRenderState &state)
 {
-    getFunctions().renderColored(type, verts, state);
+    if (type == DrawModeEnum::LINES) {
+        getFunctions().renderColoredLines(verts, state);
+    } else {
+        getFunctions().renderColored(type, verts, state);
+    }
 }
 
 void OpenGL::renderPoints(const std::vector<ColorVert> &verts, const GLRenderState &state)

--- a/src/opengl/OpenGL.cpp
+++ b/src/opengl/OpenGL.cpp
@@ -35,7 +35,7 @@ OpenGL::OpenGL()
     case OpenGLProber::BackendType::GL:
         m_opengl = Legacy::Functions::alloc<Legacy::FunctionsGL33>(m_uboManager);
         break;
-    case OpenGLProber::BackendType::GLES:
+    case OpenGLProber::BackendType::ES:
         m_opengl = Legacy::Functions::alloc<Legacy::FunctionsES30>(m_uboManager);
         break;
     case OpenGLProber::BackendType::None:

--- a/src/opengl/OpenGLConfig.cpp
+++ b/src/opengl/OpenGLConfig.cpp
@@ -6,7 +6,6 @@
 namespace OpenGLConfig {
 
 static OpenGLProber::BackendType g_backendType;
-static bool g_isCompat = false;
 static std::string g_glVersionString;
 static std::string g_esVersionString;
 static int g_maxSamples = 0;
@@ -19,16 +18,6 @@ NODISCARD OpenGLProber::BackendType getBackendType()
 void setBackendType(OpenGLProber::BackendType type)
 {
     g_backendType = type;
-}
-
-NODISCARD bool getIsCompat()
-{
-    return g_isCompat;
-}
-
-void setIsCompat(bool isCompat)
-{
-    g_isCompat = isCompat;
 }
 
 NODISCARD std::string getGLVersionString()

--- a/src/opengl/OpenGLConfig.h
+++ b/src/opengl/OpenGLConfig.h
@@ -11,9 +11,6 @@ namespace OpenGLConfig {
 NODISCARD extern OpenGLProber::BackendType getBackendType();
 extern void setBackendType(OpenGLProber::BackendType type);
 
-NODISCARD extern bool getIsCompat();
-extern void setIsCompat(bool isCompat);
-
 NODISCARD extern std::string getGLVersionString();
 extern void setGLVersionString(const std::string &versionString);
 

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -4,13 +4,21 @@
 #include "OpenGLProber.h"
 
 #include "../global/ConfigConsts.h"
+#include "../global/TextUtils.h"
 #include "../global/logging.h"
 #include "OpenGLConfig.h"
 
-#include <optional>
-#include <sstream>
-
+#include <QCoreApplication>
+#include <QDir>
+#include <QJsonDocument>
+#include <QJsonObject>
+#ifndef Q_OS_WASM
+#include <QGuiApplication>
 #include <QOpenGLContext>
+#include <QProcess>
+#include <QSurfaceFormat>
+#endif
+#include <QString>
 
 #ifdef WIN32
 #include <windows.h>
@@ -22,299 +30,162 @@ __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 }
 #endif
 
-namespace { // anonymous
+namespace {
 
-struct GLVersion
+OpenGLProber::ProbeResult getFallbackResult()
 {
-    int major = 0;
-    int minor = 0;
-
-    NODISCARD bool operator>(const GLVersion &other) const
-    {
-        return (major > other.major) || (major == other.major && minor > other.minor);
-    }
-
-    NODISCARD bool operator<(const GLVersion &other) const
-    {
-        return (major < other.major) || (major == other.major && minor < other.minor);
-    }
-};
-
-inline std::ostream &operator<<(std::ostream &os, const GLVersion &version)
-{
-    os << version.major << "." << version.minor;
-    return os;
-}
-
-struct GLContextCheckResult
-{
-    bool valid = false;
-    GLVersion version = {0, 0};
-    bool isCore = false;
-    bool isCompat = false;
-    bool isDeprecated = false;
-    bool isDebug = false;
-};
-
-NODISCARD GLContextCheckResult checkContext(QSurfaceFormat format,
-                                            GLVersion version,
-                                            QSurfaceFormat::OpenGLContextProfile profile)
-{
-    GLContextCheckResult result;
-    QOpenGLContext context;
-    context.setFormat(format);
-    if (!context.create()) {
-        MMLOG_DEBUG() << "[GL Check] context.create() failed for requested " << version
-                      << (profile == QSurfaceFormat::CoreProfile ? " Core" : " Compat");
-        return result;
-    }
-
-    QSurfaceFormat actualFormat = context.format();
-
-    result.isCore = (actualFormat.profile() & QSurfaceFormat::CoreProfile);
-    result.isCompat = (actualFormat.profile() & QSurfaceFormat::CompatibilityProfile);
-    result.isDeprecated = (actualFormat.options() & QSurfaceFormat::DeprecatedFunctions);
-    result.isDebug = (actualFormat.options() & QSurfaceFormat::DebugContext);
-    result.version = GLVersion{actualFormat.majorVersion(), actualFormat.minorVersion()};
-
-    context.doneCurrent();
-
-    // Check if the actual OpenGL context meets the minimum requirements
-    bool profileOk = false;
-
-    if (version < GLVersion{3, 2}) {
-        if (profile == QSurfaceFormat::CoreProfile) {
-            // Core profile did not exist before GL 3.2
-            profileOk = false;
-        } else {
-            // Must be compatibility-like
-            profileOk = result.isCompat || result.isDeprecated;
-        }
-    } else {
-        // For GL 3.2+
-        if (profile == QSurfaceFormat::CoreProfile) {
-            profileOk = result.isCore;
-        } else if (profile == QSurfaceFormat::CompatibilityProfile) {
-            profileOk = result.isCompat && result.isDeprecated;
-        }
-    }
-
-    // If the profile is ok, we consider the context valid even if the version is lower than requested.
-    if (profileOk) {
-        result.valid = true;
-        MMLOG_DEBUG() << "[GL Probe] GL " << result.version << (result.isCore ? " Core" : " Compat")
-                      << " is valid";
-    }
-    return result;
-}
-
-NODISCARD std::string formatGLVersionString(const GLContextCheckResult &result)
-{
-    std::ostringstream oss;
-    oss << "GL" << result.version;
-    if (!result.isDeprecated && result.version > GLVersion{3, 1}) {
-        oss << "core";
-    }
-    return oss.str();
-}
-
-NODISCARD std::optional<GLContextCheckResult> probeCore(QSurfaceFormat &testFormat,
-                                                        std::vector<GLVersion> &coreVersions,
-                                                        QSurfaceFormat::FormatOptions optionsCoreOnly)
-{
-    std::optional<GLContextCheckResult> coreResult = std::nullopt;
-    for (auto it = coreVersions.begin(); it != coreVersions.end();) {
-        const auto &version = *it;
-        testFormat.setVersion(version.major, version.minor);
-        testFormat.setProfile(QSurfaceFormat::CoreProfile);
-        testFormat.setOptions(optionsCoreOnly);
-
-        GLContextCheckResult contextCheckResult = checkContext(testFormat,
-                                                               version,
-                                                               QSurfaceFormat::CoreProfile);
-        if (contextCheckResult.valid) {
-            coreResult = contextCheckResult;
-            MMLOG_DEBUG() << "[GL Probe] Found highest supported Core version: "
-                          << contextCheckResult.version;
-            break;
-        } else {
-            it = coreVersions.erase(it);
-        }
-    }
-    return coreResult;
-}
-
-NODISCARD std::optional<GLContextCheckResult> probeCompat(
-    QSurfaceFormat &format,
-    std::vector<GLVersion> versions,
-    QSurfaceFormat::FormatOptions options,
-    std::optional<GLContextCheckResult> coreResult)
-{
-    std::optional<GLContextCheckResult> compatResult = std::nullopt;
-
-    std::vector<GLVersion> compatVersionsToTest = versions;
-    if (coreResult) {
-        // Filter compatVersions to only include versions <= coreResult
-        compatVersionsToTest.erase(std::remove_if(compatVersionsToTest.begin(),
-                                                  compatVersionsToTest.end(),
-                                                  [resultVer = coreResult->version](
-                                                      const GLVersion &ver) {
-                                                      return ver > resultVer;
-                                                  }),
-                                   compatVersionsToTest.end());
-    }
-
-    for (const auto &version : compatVersionsToTest) {
-        format.setVersion(version.major, version.minor);
-        format.setProfile(QSurfaceFormat::CompatibilityProfile);
-        format.setOptions(options);
-        GLContextCheckResult contextCheckResult = checkContext(format,
-                                                               version,
-                                                               QSurfaceFormat::CompatibilityProfile);
-        if (contextCheckResult.valid) {
-            compatResult = contextCheckResult;
-            MMLOG_DEBUG() << "[GL Probe] Found highest supported Compat version: "
-                          << compatResult->version;
-            break;
-        }
-    }
-    return compatResult;
-}
-
-NODISCARD std::string getHighestGLVersion(std::optional<GLContextCheckResult> coreResult,
-                                          std::optional<GLContextCheckResult> compatResult)
-{
-    std::string highestGLVersion;
-    if (coreResult && compatResult) {
-        if (coreResult->version > compatResult->version) {
-            highestGLVersion = formatGLVersionString(*coreResult);
-        } else {
-            highestGLVersion = formatGLVersionString(*compatResult);
-        }
-    } else if (coreResult) {
-        highestGLVersion = formatGLVersionString(*coreResult);
-    } else if (compatResult) {
-        highestGLVersion = formatGLVersionString(*compatResult);
-    } else {
-        highestGLVersion = "Fallback";
-    }
-    return highestGLVersion;
-}
-
-NODISCARD QSurfaceFormat getOptimalFormat(std::optional<GLContextCheckResult> result)
-{
-    QSurfaceFormat format;
-    format.setRenderableType(QSurfaceFormat::OpenGL);
-    format.setDepthBufferSize(24);
-    if (result) {
-        format.setVersion(result->version.major, result->version.minor);
-        format.setProfile(result->isCore ? QSurfaceFormat::CoreProfile
-                                         : QSurfaceFormat::CompatibilityProfile);
-        QSurfaceFormat::FormatOptions options;
-        if (result->isDebug) {
-            options |= QSurfaceFormat::DebugContext;
-        }
-        if (result->isCompat) {
-            options |= QSurfaceFormat::DeprecatedFunctions;
-        }
-        format.setOptions(options);
-        MMLOG_INFO() << "[GL Probe] Optimal running format determined: GL " << format.majorVersion()
-                     << "." << format.minorVersion()
-                     << " Profile: " << (result->isCore ? "Core" : "Compat")
-                     << (result->isDebug ? " (Debug)" : " (NO Debug)");
-    } else {
-        // Fallback for optimal running format if no context was found at all
-        format.setVersion(3, 3);
-        format.setProfile(QSurfaceFormat::CoreProfile);
-        format.setOptions(QSurfaceFormat::DebugContext);
-        MMLOG_ERROR() << "[GL Probe] No suitable GL context found for running format.";
-    }
-    return format;
-}
-
-OpenGLProber::ProbeResult probeOpenGL()
-{
-    if constexpr (NO_OPENGL) {
-        return {};
-    }
-
-    MMLOG_DEBUG() << "Probing for OpenGL support...";
-
-    QSurfaceFormat format;
-    format.setRenderableType(QSurfaceFormat::OpenGL);
-    format.setDepthBufferSize(24);
-
-    QSurfaceFormat::FormatOptions optionsCompat = QSurfaceFormat::DebugContext
-                                                  | QSurfaceFormat::DeprecatedFunctions;
-    QSurfaceFormat::FormatOptions optionsCore = QSurfaceFormat::DebugContext;
-
-    // Define lists of versions to try.
-    std::vector<GLVersion> versions
-        = {{4, 6}, {4, 5}, {4, 4}, {4, 3}, {4, 2}, {4, 1}, {4, 0}, {3, 3}, {3, 2}};
-
-    std::optional<GLContextCheckResult> coreResult = probeCore(format, versions, optionsCore);
-    std::optional<GLContextCheckResult> compatResult = probeCompat(format,
-                                                                   versions,
-                                                                   optionsCompat,
-                                                                   coreResult);
-
     OpenGLProber::ProbeResult result;
-    if (compatResult || coreResult) {
-        result.backendType = OpenGLProber::BackendType::GL;
-        result.highestVersionString = getHighestGLVersion(coreResult, compatResult);
-        OpenGLConfig::setGLVersionString(result.highestVersionString);
-        result.format = getOptimalFormat(compatResult ? compatResult : coreResult);
-        result.isCompat = (compatResult && compatResult->isCompat);
-    }
+    result.backendType = OpenGLProber::BackendType::GL;
+    result.format.setRenderableType(QSurfaceFormat::OpenGL);
+    result.format.setVersion(3, 3);
+    result.format.setProfile(QSurfaceFormat::CoreProfile);
+    result.format.setDepthBufferSize(24);
+    result.highestVersionString = "Fallback";
     return result;
-}
-
-OpenGLProber::ProbeResult probeOpenGLES()
-{
-    if constexpr (NO_GLES) {
-        return {};
-    }
-
-    MMLOG_DEBUG() << "Probing for OpenGL ES support...";
-
-    std::vector<GLVersion> glesVersions = {{3, 2}, {3, 1}, {3, 0}};
-
-    for (const auto &version : glesVersions) {
-        QSurfaceFormat format;
-        format.setRenderableType(QSurfaceFormat::OpenGLES);
-        format.setVersion(version.major, version.minor);
-
-        QOpenGLContext context;
-        context.setFormat(format);
-        if (context.create()) {
-            MMLOG_DEBUG() << "[GL Probe] Found highest supported GLES version: " << version;
-            OpenGLProber::ProbeResult result;
-            result.backendType = OpenGLProber::BackendType::GLES;
-            result.format = format;
-            std::ostringstream oss;
-            oss << "ES" << version;
-            result.highestVersionString = oss.str();
-            OpenGLConfig::setESVersionString(result.highestVersionString);
-            return result;
-        }
-    }
-
-    MMLOG_DEBUG() << "No suitable GLES context found.";
-    return {};
 }
 
 } // namespace
 
 OpenGLProber::ProbeResult OpenGLProber::probe()
 {
-    auto glResult = probeOpenGL();
-    auto glesResult = probeOpenGLES();
-    if (glResult.backendType != BackendType::None) {
-        return glResult;
+#ifdef Q_OS_WASM
+    MMLOG_DEBUG() << "Probing for OpenGL support (Wasm/WebGL 2.0)...";
+    ProbeResult result;
+    result.backendType = BackendType::GLES;
+    result.format.setRenderableType(QSurfaceFormat::OpenGLES);
+    result.format.setVersion(3, 0);
+    result.format.setDepthBufferSize(24);
+    result.highestVersionString = "WebGL 2.0";
+    OpenGLConfig::setESVersionString(result.highestVersionString);
+    return result;
+#else
+    if constexpr (NO_OPENGL && NO_GLES) {
+        return {};
     }
-    if (glesResult.backendType != BackendType::None) {
-        return glesResult;
+
+    MMLOG_DEBUG() << "Probing for OpenGL support via --probe subprocess...";
+
+    const QString selfPath = QCoreApplication::applicationFilePath();
+    QProcess process;
+    process.start(selfPath, {"--probe"});
+    if (!process.waitForFinished(5000)) {
+        MMLOG_ERROR() << "OpenGL probe subprocess timed out or failed to start. Using fallback.";
+        process.kill();
+        return getFallbackResult();
     }
-    MMLOG_DEBUG() << "No suitable backend found.";
-    return {};
+
+    return parseSurveyResult(process.readAllStandardOutput());
+#endif
 }
+
+OpenGLProber::ProbeResult OpenGLProber::parseSurveyResult(const QByteArray &json)
+{
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    if (doc.isNull() || !doc.isObject()) {
+        MMLOG_ERROR() << "OpenGL survey returned invalid JSON. Using fallback.";
+        return getFallbackResult();
+    }
+
+    QJsonObject obj = doc.object();
+    QString backend = obj["backend"].toString();
+
+    ProbeResult result;
+    if (backend == "GL") {
+        result.backendType = BackendType::GL;
+        int major = obj["major"].toInt();
+        int minor = obj["minor"].toInt();
+        result.format.setRenderableType(QSurfaceFormat::OpenGL);
+        result.format.setVersion(major, minor);
+        result.format.setProfile(QSurfaceFormat::CoreProfile);
+        result.format.setDepthBufferSize(24);
+        result.highestVersionString = mmqt::toStdStringUtf8(
+            QString("GL%1.%2core").arg(major).arg(minor));
+        OpenGLConfig::setGLVersionString(result.highestVersionString);
+    } else if (backend == "GLES") {
+        result.backendType = BackendType::GLES;
+        int major = obj["major"].toInt();
+        int minor = obj["minor"].toInt();
+        result.format.setRenderableType(QSurfaceFormat::OpenGLES);
+        result.format.setVersion(major, minor);
+        result.format.setDepthBufferSize(24);
+        result.highestVersionString = mmqt::toStdStringUtf8(
+            QString("ES%1.%2").arg(major).arg(minor));
+        OpenGLConfig::setESVersionString(result.highestVersionString);
+    } else {
+        MMLOG_DEBUG() << "No suitable backend found by survey.";
+        return {};
+    }
+
+    MMLOG_INFO() << "[GL Probe] Survey determined:" << result.highestVersionString.c_str();
+    return result;
+}
+
+#ifndef Q_OS_WASM
+int OpenGLProber::runSurveyMode(int argc, char **argv)
+{
+    QGuiApplication app(argc, argv);
+
+    QJsonObject result;
+
+    struct GLVersion
+    {
+        int major;
+        int minor;
+    };
+
+    // Try OpenGL Core versions from highest to lowest
+    const std::vector<GLVersion> coreVersions
+        = {{4, 6}, {4, 5}, {4, 4}, {4, 3}, {4, 2}, {4, 1}, {4, 0}, {3, 3}};
+
+    bool foundGL = false;
+    for (const auto &v : coreVersions) {
+        QSurfaceFormat format;
+        format.setRenderableType(QSurfaceFormat::OpenGL);
+        format.setVersion(v.major, v.minor);
+        format.setProfile(QSurfaceFormat::CoreProfile);
+
+        QOpenGLContext context;
+        context.setFormat(format);
+        if (context.create()) {
+            const QSurfaceFormat actual = context.format();
+            if (actual.profile() == QSurfaceFormat::CoreProfile
+                && (actual.majorVersion() > v.major
+                    || (actual.majorVersion() == v.major
+                        && actual.minorVersion() >= v.minor))) {
+                result["backend"] = "GL";
+                result["major"] = actual.majorVersion();
+                result["minor"] = actual.minorVersion();
+                foundGL = true;
+                break;
+            }
+        }
+    }
+
+    if (!foundGL) {
+        const std::vector<GLVersion> glesVersions = {{3, 2}, {3, 1}, {3, 0}};
+        for (const auto &v : glesVersions) {
+            QSurfaceFormat format;
+            format.setRenderableType(QSurfaceFormat::OpenGLES);
+            format.setVersion(v.major, v.minor);
+
+            QOpenGLContext context;
+            context.setFormat(format);
+            if (context.create()) {
+                const QSurfaceFormat actual = context.format();
+                result["backend"] = "GLES";
+                result["major"] = actual.majorVersion();
+                result["minor"] = actual.minorVersion();
+                break;
+            }
+        }
+    }
+
+    if (result.isEmpty()) {
+        result["backend"] = "None";
+    }
+
+    const QByteArray output = QJsonDocument(result).toJson(QJsonDocument::Compact);
+    fprintf(stdout, "%s\n", output.constData());
+    return 0;
+}
+#endif

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -70,29 +70,39 @@ OpenGLProber::ProbeResult OpenGLProber::probe()
     env.insert("ASAN_OPTIONS", "detect_leaks=0");
     process.setProcessEnvironment(env);
 
-    process.start(selfPath, {"--probe", "-platform", "offscreen"});
+    QStringList args = {"--probe"};
+    const QString platform = QGuiApplication::platformName();
+    if (!platform.isEmpty()) {
+        args << "-platform" << platform;
+    }
+    process.start(selfPath, args);
     if (!process.waitForFinished(5000)) {
         MMLOG_ERROR() << "OpenGL probe subprocess timed out or failed to start. Using fallback.";
         process.kill();
         return getFallbackResult();
     }
 
-    return parseSurveyResult(process.readAllStandardOutput());
+    const QByteArray stdoutData = process.readAllStandardOutput();
+    const QByteArray stderrData = process.readAllStandardError();
+    return parseSurveyResult(stdoutData, stderrData);
 #endif
 }
 
-OpenGLProber::ProbeResult OpenGLProber::parseSurveyResult(const QByteArray &json)
+OpenGLProber::ProbeResult OpenGLProber::parseSurveyResult(const QByteArray &stdoutData,
+                                                          const QByteArray &stderrData)
 {
-    const qsizetype start = json.indexOf('{');
-    const qsizetype end = json.lastIndexOf('}');
+    const qsizetype start = stdoutData.indexOf('{');
+    const qsizetype end = stdoutData.lastIndexOf('}');
 
     QJsonDocument doc;
     if (start != -1 && end != -1 && end > start) {
-        doc = QJsonDocument::fromJson(json.mid(start, end - start + 1));
+        doc = QJsonDocument::fromJson(stdoutData.mid(start, end - start + 1));
     }
 
     if (doc.isNull() || !doc.isObject()) {
-        MMLOG_ERROR() << "OpenGL survey returned invalid JSON. Using fallback.";
+        MMLOG_WARNING() << "OpenGL survey returned invalid JSON. Using fallback."
+                        << "\n  stdout:" << stdoutData.toStdString()
+                        << "\n  stderr:" << stderrData.toStdString();
         return getFallbackResult();
     }
 

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -23,14 +23,9 @@
 #ifdef WIN32
 #include <windows.h>
 
-extern "C" {
 // Prefer discrete nVidia and AMD GPUs by default on Windows
-__declspec(dllexport) extern DWORD NvOptimusEnablement;
-__declspec(dllexport) extern int AmdPowerXpressRequestHighPerformance;
-
-__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
-__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
-}
+extern "C" __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+extern "C" __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 #endif
 
 namespace {

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -25,6 +25,9 @@
 
 extern "C" {
 // Prefer discrete nVidia and AMD GPUs by default on Windows
+__declspec(dllexport) extern DWORD NvOptimusEnablement;
+__declspec(dllexport) extern int AmdPowerXpressRequestHighPerformance;
+
 __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
 __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 }
@@ -85,8 +88,8 @@ OpenGLProber::ProbeResult OpenGLProber::probe()
 
 OpenGLProber::ProbeResult OpenGLProber::parseSurveyResult(const QByteArray &json)
 {
-    const int start = json.indexOf('{');
-    const int end = json.lastIndexOf('}');
+    const qsizetype start = json.indexOf('{');
+    const qsizetype end = json.lastIndexOf('}');
 
     QJsonDocument doc;
     if (start != -1 && end != -1 && end > start) {

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -54,7 +54,7 @@ OpenGLProber::ProbeResult OpenGLProber::probe()
 #ifdef Q_OS_WASM
     MMLOG_DEBUG() << "Probing for OpenGL support (Wasm/WebGL 2.0)...";
     ProbeResult result;
-    result.backendType = BackendType::GLES;
+    result.backendType = BackendType::ES;
     result.format.setRenderableType(QSurfaceFormat::OpenGLES);
     result.format.setVersion(3, 0);
     result.format.setDepthBufferSize(24);
@@ -103,8 +103,14 @@ OpenGLProber::ProbeResult OpenGLProber::parseSurveyResult(const QByteArray &json
 
     QJsonObject obj = doc.object();
     QString backend = obj["backend"].toString();
+    const bool debugSupported = obj["debug"].toBool();
 
     ProbeResult result;
+    result.debugSupported = debugSupported;
+    if (debugSupported) {
+        result.format.setOption(QSurfaceFormat::DebugContext);
+    }
+
     if (backend == "GL") {
         result.backendType = BackendType::GL;
         int major = obj["major"].toInt();
@@ -116,8 +122,8 @@ OpenGLProber::ProbeResult OpenGLProber::parseSurveyResult(const QByteArray &json
         result.highestVersionString = mmqt::toStdStringUtf8(
             QString("GL%1.%2").arg(major).arg(minor));
         OpenGLConfig::setGLVersionString(result.highestVersionString);
-    } else if (backend == "GLES") {
-        result.backendType = BackendType::GLES;
+    } else if (backend == "ES") {
+        result.backendType = BackendType::ES;
         int major = obj["major"].toInt();
         int minor = obj["minor"].toInt();
         result.format.setRenderableType(QSurfaceFormat::OpenGLES);
@@ -152,12 +158,13 @@ int OpenGLProber::runSurveyMode(int argc, char **argv)
     const std::vector<GLVersion> coreVersions
         = {{4, 6}, {4, 5}, {4, 4}, {4, 3}, {4, 2}, {4, 1}, {4, 0}, {3, 3}};
 
-    bool foundGL = false;
+    bool foundBackend = false;
     for (const auto &v : coreVersions) {
         QSurfaceFormat format;
         format.setRenderableType(QSurfaceFormat::OpenGL);
         format.setVersion(v.major, v.minor);
         format.setProfile(QSurfaceFormat::CoreProfile);
+        format.setOption(QSurfaceFormat::DebugContext);
 
         QOpenGLContext context;
         context.setFormat(format);
@@ -169,26 +176,30 @@ int OpenGLProber::runSurveyMode(int argc, char **argv)
                 result["backend"] = "GL";
                 result["major"] = actual.majorVersion();
                 result["minor"] = actual.minorVersion();
-                foundGL = true;
+                result["debug"] = actual.testOption(QSurfaceFormat::DebugContext);
+                foundBackend = true;
                 break;
             }
         }
     }
 
-    if (!foundGL) {
+    if (!foundBackend) {
         const std::vector<GLVersion> glesVersions = {{3, 2}, {3, 1}, {3, 0}};
         for (const auto &v : glesVersions) {
             QSurfaceFormat format;
             format.setRenderableType(QSurfaceFormat::OpenGLES);
             format.setVersion(v.major, v.minor);
+            format.setOption(QSurfaceFormat::DebugContext);
 
             QOpenGLContext context;
             context.setFormat(format);
             if (context.create()) {
                 const QSurfaceFormat actual = context.format();
-                result["backend"] = "GLES";
+                result["backend"] = "ES";
                 result["major"] = actual.majorVersion();
                 result["minor"] = actual.minorVersion();
+                result["debug"] = actual.testOption(QSurfaceFormat::DebugContext);
+                foundBackend = true;
                 break;
             }
         }

--- a/src/opengl/OpenGLProber.cpp
+++ b/src/opengl/OpenGLProber.cpp
@@ -67,7 +67,12 @@ OpenGLProber::ProbeResult OpenGLProber::probe()
 
     const QString selfPath = QCoreApplication::applicationFilePath();
     QProcess process;
-    process.start(selfPath, {"--probe"});
+
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.insert("ASAN_OPTIONS", "detect_leaks=0");
+    process.setProcessEnvironment(env);
+
+    process.start(selfPath, {"--probe", "-platform", "offscreen"});
     if (!process.waitForFinished(5000)) {
         MMLOG_ERROR() << "OpenGL probe subprocess timed out or failed to start. Using fallback.";
         process.kill();
@@ -80,7 +85,14 @@ OpenGLProber::ProbeResult OpenGLProber::probe()
 
 OpenGLProber::ProbeResult OpenGLProber::parseSurveyResult(const QByteArray &json)
 {
-    QJsonDocument doc = QJsonDocument::fromJson(json);
+    const int start = json.indexOf('{');
+    const int end = json.lastIndexOf('}');
+
+    QJsonDocument doc;
+    if (start != -1 && end != -1 && end > start) {
+        doc = QJsonDocument::fromJson(json.mid(start, end - start + 1));
+    }
+
     if (doc.isNull() || !doc.isObject()) {
         MMLOG_ERROR() << "OpenGL survey returned invalid JSON. Using fallback.";
         return getFallbackResult();
@@ -99,7 +111,7 @@ OpenGLProber::ProbeResult OpenGLProber::parseSurveyResult(const QByteArray &json
         result.format.setProfile(QSurfaceFormat::CoreProfile);
         result.format.setDepthBufferSize(24);
         result.highestVersionString = mmqt::toStdStringUtf8(
-            QString("GL%1.%2core").arg(major).arg(minor));
+            QString("GL%1.%2").arg(major).arg(minor));
         OpenGLConfig::setGLVersionString(result.highestVersionString);
     } else if (backend == "GLES") {
         result.backendType = BackendType::GLES;
@@ -150,8 +162,7 @@ int OpenGLProber::runSurveyMode(int argc, char **argv)
             const QSurfaceFormat actual = context.format();
             if (actual.profile() == QSurfaceFormat::CoreProfile
                 && (actual.majorVersion() > v.major
-                    || (actual.majorVersion() == v.major
-                        && actual.minorVersion() >= v.minor))) {
+                    || (actual.majorVersion() == v.major && actual.minorVersion() >= v.minor))) {
                 result["backend"] = "GL";
                 result["major"] = actual.majorVersion();
                 result["minor"] = actual.minorVersion();
@@ -185,7 +196,8 @@ int OpenGLProber::runSurveyMode(int argc, char **argv)
     }
 
     const QByteArray output = QJsonDocument(result).toJson(QJsonDocument::Compact);
-    fprintf(stdout, "%s\n", output.constData());
+    fprintf(stdout, "\n%s\n", output.constData());
+    fflush(stdout);
     return 0;
 }
 #endif

--- a/src/opengl/OpenGLProber.h
+++ b/src/opengl/OpenGLProber.h
@@ -19,7 +19,6 @@ public:
         BackendType backendType = BackendType::None;
         QSurfaceFormat format;
         std::string highestVersionString = "Unknown";
-        bool isCompat = false;
     };
 
 public:
@@ -28,4 +27,10 @@ public:
     DTOR(OpenGLProber) = default;
 
     NODISCARD ProbeResult probe();
+
+    NODISCARD ProbeResult parseSurveyResult(const QByteArray &json);
+
+#ifndef Q_OS_WASM
+    NODISCARD static int runSurveyMode(int argc, char **argv);
+#endif
 };

--- a/src/opengl/OpenGLProber.h
+++ b/src/opengl/OpenGLProber.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include <QByteArray>
 #include <QSurfaceFormat>
 
 class NODISCARD OpenGLProber final
@@ -29,7 +30,8 @@ public:
 
     NODISCARD ProbeResult probe();
 
-    NODISCARD ProbeResult parseSurveyResult(const QByteArray &json);
+    NODISCARD ProbeResult parseSurveyResult(const QByteArray &stdoutData,
+                                            const QByteArray &stderrData = {});
 
 #ifndef Q_OS_WASM
     NODISCARD static int runSurveyMode(int argc, char **argv);

--- a/src/opengl/OpenGLProber.h
+++ b/src/opengl/OpenGLProber.h
@@ -12,13 +12,14 @@
 class NODISCARD OpenGLProber final
 {
 public:
-    enum class BackendType { None, GL, GLES };
+    enum class BackendType { None, GL, ES };
 
     struct ProbeResult
     {
         BackendType backendType = BackendType::None;
         QSurfaceFormat format;
         std::string highestVersionString = "Unknown";
+        bool debugSupported = false;
     };
 
 public:

--- a/src/opengl/OpenGLTypes.h
+++ b/src/opengl/OpenGLTypes.h
@@ -139,9 +139,9 @@ enum class NODISCARD DrawModeEnum {
 
 struct NODISCARD LineParams final
 {
-    float width = 1.f;
-    LineParams() = default;
+    float width = 1.0f;
 
+    LineParams() = default;
     explicit LineParams(const float width_)
         : width{width_}
     {}

--- a/src/opengl/legacy/AbstractShaderProgram.cpp
+++ b/src/opengl/legacy/AbstractShaderProgram.cpp
@@ -171,4 +171,10 @@ void AbstractShaderProgram::setViewport(const char *const name, const Viewport &
     setUniform4iv(location, 1, glm::value_ptr(viewport));
 }
 
+void AbstractShaderProgram::setFloat(const char *const name, const float value)
+{
+    const GLint location = getUniformLocation(name);
+    setUniform1fv(location, 1, &value);
+}
+
 } // namespace Legacy

--- a/src/opengl/legacy/AbstractShaderProgram.h
+++ b/src/opengl/legacy/AbstractShaderProgram.h
@@ -92,6 +92,7 @@ public:
     void setMatrix(const char *name, const glm::mat4 &m);
     void setTexture(const char *name, int textureUnit);
     void setViewport(const char *name, const Viewport &input_viewport);
+    void setFloat(const char *name, float value);
 };
 
 } // namespace Legacy

--- a/src/opengl/legacy/Binders.cpp
+++ b/src/opengl/legacy/Binders.cpp
@@ -106,22 +106,9 @@ DepthBinder::~DepthBinder()
     }
 }
 
-LineParamsBinder::LineParamsBinder(Functions &functions, const LineParams &lineParams)
-    : m_functions{functions}
-    , m_lineParams{lineParams}
-{
-    m_functions.glLineWidth(m_lineParams.width);
-}
+LineParamsBinder::LineParamsBinder(Functions & /*functions*/, const LineParams & /*lineParams*/) {}
 
-LineParamsBinder::~LineParamsBinder()
-{
-    const auto &width = m_lineParams.width;
-    const float ONE = 1.f;
-    static_assert(sizeof(ONE) == sizeof(width));
-    if (!utils::equals(&width, &ONE)) {
-        m_functions.glLineWidth(ONE);
-    }
-}
+LineParamsBinder::~LineParamsBinder() {}
 
 PointSizeBinder::PointSizeBinder(Functions &functions, const std::optional<GLfloat> &pointSize)
     : m_functions{functions}

--- a/src/opengl/legacy/Binders.h
+++ b/src/opengl/legacy/Binders.h
@@ -56,10 +56,6 @@ public:
 
 struct NODISCARD LineParamsBinder
 {
-private:
-    Functions &m_functions;
-    const LineParams &m_lineParams;
-
 public:
     explicit LineParamsBinder(Functions &functions, const LineParams &lineParams);
     ~LineParamsBinder();

--- a/src/opengl/legacy/FunctionsES30.cpp
+++ b/src/opengl/legacy/FunctionsES30.cpp
@@ -4,14 +4,7 @@ namespace Legacy {
 
 FunctionsES30::FunctionsES30(Badge<Functions> badge, UboManager &uboManager)
     : Functions(badge, uboManager)
-{
-    assert(!OpenGLConfig::getIsCompat());
-}
-
-bool FunctionsES30::virt_canRenderQuads()
-{
-    return false;
-}
+{}
 
 std::optional<GLenum> FunctionsES30::virt_toGLenum(const DrawModeEnum mode)
 {

--- a/src/opengl/legacy/FunctionsES30.h
+++ b/src/opengl/legacy/FunctionsES30.h
@@ -17,7 +17,6 @@ public:
 private:
     void virt_enableProgramPointSize(bool enable) override;
     NODISCARD const char *virt_getShaderVersion() const override;
-    NODISCARD bool virt_canRenderQuads() override;
     NODISCARD std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) override;
 };
 

--- a/src/opengl/legacy/FunctionsGL33.cpp
+++ b/src/opengl/legacy/FunctionsGL33.cpp
@@ -1,7 +1,6 @@
 #include "FunctionsGL33.h"
 
 #include "../../global/ConfigConsts.h"
-#include "../OpenGLConfig.h"
 
 #include <optional>
 
@@ -10,11 +9,6 @@ namespace Legacy {
 FunctionsGL33::FunctionsGL33(Badge<Functions> badge, UboManager &uboManager)
     : Functions(badge, uboManager)
 {}
-
-bool FunctionsGL33::virt_canRenderQuads()
-{
-    return OpenGLConfig::getIsCompat();
-}
 
 std::optional<GLenum> FunctionsGL33::virt_toGLenum(const DrawModeEnum mode)
 {
@@ -26,11 +20,6 @@ std::optional<GLenum> FunctionsGL33::virt_toGLenum(const DrawModeEnum mode)
     case DrawModeEnum::TRIANGLES:
         return GL_TRIANGLES;
     case DrawModeEnum::QUADS:
-#ifndef MMAPPER_NO_OPENGL
-        return canRenderQuads() ? std::make_optional(GL_QUADS) : std::nullopt;
-#else
-        FALLTHROUGH;
-#endif
     case DrawModeEnum::INSTANCED_QUADS:
     case DrawModeEnum::INVALID:
         break;
@@ -49,14 +38,8 @@ void FunctionsGL33::virt_enableProgramPointSize(const bool enable)
 #ifndef MMAPPER_NO_OPENGL
     if (enable) {
         Base::glEnable(GL_PROGRAM_POINT_SIZE);
-        if (OpenGLConfig::getIsCompat()) {
-            Base::glEnable(GL_POINT_SPRITE);
-        }
     } else {
         Base::glDisable(GL_PROGRAM_POINT_SIZE);
-        if (OpenGLConfig::getIsCompat()) {
-            Base::glDisable(GL_POINT_SPRITE);
-        }
     }
 #endif
 }

--- a/src/opengl/legacy/FunctionsGL33.h
+++ b/src/opengl/legacy/FunctionsGL33.h
@@ -17,7 +17,6 @@ public:
 private:
     void virt_enableProgramPointSize(bool enable) override;
     NODISCARD const char *virt_getShaderVersion() const override;
-    NODISCARD bool virt_canRenderQuads() override;
     NODISCARD std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) override;
 };
 

--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -112,9 +112,21 @@ UniqueMesh Functions::createPointBatch(const std::vector<ColorVert> &batch)
     return createUniqueMesh<PointMesh>(shared_from_this(), DrawModeEnum::POINTS, batch, prog);
 }
 
+UniqueMesh Functions::createPlainLineBatch(const std::vector<glm::vec3> &batch)
+{
+    const auto &prog = getShaderPrograms().getLineUColorShader();
+    return createUniqueMesh<LineMesh>(shared_from_this(), DrawModeEnum::LINES, batch, prog);
+}
+
+UniqueMesh Functions::createColoredLineBatch(const std::vector<ColorVert> &batch)
+{
+    const auto &prog = getShaderPrograms().getLineAColorShader();
+    return createUniqueMesh<ColoredLineMesh>(shared_from_this(), DrawModeEnum::LINES, batch, prog);
+}
+
 UniqueMesh Functions::createPlainBatch(const DrawModeEnum mode, const std::vector<glm::vec3> &batch)
 {
-    assert(static_cast<size_t>(mode) >= VERTS_PER_LINE);
+    assert(static_cast<size_t>(mode) >= VERTS_PER_TRI);
     const auto &prog = getShaderPrograms().getPlainUColorShader();
     return createUniqueMesh<PlainMesh>(shared_from_this(), mode, batch, prog);
 }
@@ -122,7 +134,7 @@ UniqueMesh Functions::createPlainBatch(const DrawModeEnum mode, const std::vecto
 UniqueMesh Functions::createColoredBatch(const DrawModeEnum mode,
                                          const std::vector<ColorVert> &batch)
 {
-    assert(static_cast<size_t>(mode) >= VERTS_PER_LINE);
+    assert(static_cast<size_t>(mode) >= VERTS_PER_TRI);
     const auto &prog = getShaderPrograms().getPlainAColorShader();
     return createUniqueMesh<ColoredMesh>(shared_from_this(), mode, batch, prog);
 }
@@ -201,11 +213,29 @@ static void renderImmediate(const SharedFunctions &sharedFunctions,
     sharedFunctions->clearVbo(vbo.get());
 }
 
+void Functions::renderPlainLines(const std::vector<glm::vec3> &verts, const GLRenderState &state)
+{
+    const auto &shared = shared_from_this();
+    const auto &prog = getShaderPrograms().getLineUColorShader();
+    renderImmediate<glm::vec3, Legacy::LineMesh>(shared, DrawModeEnum::LINES, verts, prog, state);
+}
+
+void Functions::renderColoredLines(const std::vector<ColorVert> &verts, const GLRenderState &state)
+{
+    const auto &shared = shared_from_this();
+    const auto &prog = getShaderPrograms().getLineAColorShader();
+    renderImmediate<ColorVert, Legacy::ColoredLineMesh>(shared,
+                                                        DrawModeEnum::LINES,
+                                                        verts,
+                                                        prog,
+                                                        state);
+}
+
 void Functions::renderPlain(const DrawModeEnum mode,
                             const std::vector<glm::vec3> &verts,
                             const GLRenderState &state)
 {
-    assert(static_cast<size_t>(mode) >= VERTS_PER_LINE);
+    assert(static_cast<size_t>(mode) >= VERTS_PER_TRI);
     const auto &shared = shared_from_this();
     const auto &prog = getShaderPrograms().getPlainUColorShader();
     renderImmediate<glm::vec3, Legacy::PlainMesh>(shared, mode, verts, prog, state);
@@ -215,7 +245,7 @@ void Functions::renderColored(const DrawModeEnum mode,
                               const std::vector<ColorVert> &verts,
                               const GLRenderState &state)
 {
-    assert(static_cast<size_t>(mode) >= VERTS_PER_LINE);
+    assert(static_cast<size_t>(mode) >= VERTS_PER_TRI);
     const auto &prog = getShaderPrograms().getPlainAColorShader();
     renderImmediate<ColorVert, Legacy::ColoredMesh>(shared_from_this(), mode, verts, prog, state);
 }

--- a/src/opengl/legacy/Legacy.h
+++ b/src/opengl/legacy/Legacy.h
@@ -260,15 +260,6 @@ public:
     using Base::glVertexAttribPointer;
 
 public:
-    void glLineWidth(const GLfloat lineWidth)
-    {
-        // REVISIT: Only width 1 is guaranteed to be supported for core profiles
-        if (OpenGLConfig::getIsCompat()) {
-            Base::glLineWidth(lineWidth);
-        }
-    }
-
-public:
     void glViewport(const GLint x, const GLint y, const GLsizei width, const GLsizei height)
     {
         m_viewport = Viewport{{x, y}, {width, height}};
@@ -331,7 +322,6 @@ public:
     NODISCARD const char *getShaderVersion() const { return virt_getShaderVersion(); }
 
 protected:
-    NODISCARD virtual bool virt_canRenderQuads() = 0;
     NODISCARD virtual std::optional<GLenum> virt_toGLenum(DrawModeEnum mode) = 0;
     virtual void virt_enableProgramPointSize(bool enable) = 0;
     NODISCARD virtual const char *virt_getShaderVersion() const = 0;
@@ -339,9 +329,6 @@ protected:
 
 public:
     NODISCARD static const char *getUniformBlockName(SharedVboEnum block);
-
-    /// platform-specific (ES vs GL)
-    NODISCARD bool canRenderQuads() { return virt_canRenderQuads(); }
 
     /// platform-specific (ES vs GL)
     NODISCARD std::optional<GLenum> toGLenum(DrawModeEnum mode) { return virt_toGLenum(mode); }
@@ -412,7 +399,7 @@ public:
         const std::vector<T, A> &batch,
         const BufferUsageEnum usage = BufferUsageEnum::DYNAMIC_DRAW)
     {
-        if (mode == DrawModeEnum::QUADS && !canRenderQuads()) {
+        if (mode == DrawModeEnum::QUADS) {
             return std::pair(DrawModeEnum::TRIANGLES,
                              setVbo(GL_ARRAY_BUFFER, vbo, convertQuadsToTris(batch), usage));
         }
@@ -428,6 +415,8 @@ public:
 
 public:
     NODISCARD UniqueMesh createPointBatch(const std::vector<ColorVert> &batch);
+    NODISCARD UniqueMesh createPlainLineBatch(const std::vector<glm::vec3> &batch);
+    NODISCARD UniqueMesh createColoredLineBatch(const std::vector<ColorVert> &batch);
 
 public:
     NODISCARD UniqueMesh createPlainBatch(DrawModeEnum mode, const std::vector<glm::vec3> &batch);
@@ -450,6 +439,8 @@ public:
 
 public:
     void renderPoints(const std::vector<ColorVert> &verts, const GLRenderState &state);
+    void renderPlainLines(const std::vector<glm::vec3> &verts, const GLRenderState &state);
+    void renderColoredLines(const std::vector<ColorVert> &verts, const GLRenderState &state);
 
     void renderPlain(DrawModeEnum mode,
                      const std::vector<glm::vec3> &verts,

--- a/src/opengl/legacy/Meshes.h
+++ b/src/opengl/legacy/Meshes.h
@@ -63,6 +63,99 @@ private:
     }
 };
 
+template<typename VertexType_>
+class NODISCARD LineMesh final : public SimpleMesh<VertexType_, UColorLineShader>
+{
+public:
+    using Base = SimpleMesh<VertexType_, UColorLineShader>;
+    using Base::Base;
+
+private:
+    struct NODISCARD Attribs final
+    {
+        GLuint vert1Pos = INVALID_ATTRIB_LOCATION;
+        GLuint vert2Pos = INVALID_ATTRIB_LOCATION;
+
+        NODISCARD static Attribs getLocations(AbstractShaderProgram &shader)
+        {
+            Attribs result;
+            result.vert1Pos = shader.getAttribLocation("aVert1");
+            result.vert2Pos = shader.getAttribLocation("aVert2");
+            return result;
+        }
+    };
+
+    std::optional<Attribs> m_boundAttribs;
+
+    void virt_bind() override
+    {
+        const auto vertSize = static_cast<GLsizei>(sizeof(VertexType_));
+        Functions &gl = Base::m_functions;
+        const auto attribs = Attribs::getLocations(Base::m_program);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, Base::m_vbo.get());
+        // aVert1
+        gl.enableAttrib(attribs.vert1Pos, 3, GL_FLOAT, GL_FALSE, 2 * vertSize, nullptr);
+        // aVert2
+        gl.enableAttrib(attribs.vert2Pos, 3, GL_FLOAT, GL_FALSE, 2 * vertSize, VPO_PTR(vertSize));
+
+        // instancing: one line per 4 vertices (quad)
+        gl.glVertexAttribDivisor(attribs.vert1Pos, 1);
+        gl.glVertexAttribDivisor(attribs.vert2Pos, 1);
+
+        m_boundAttribs = attribs;
+    }
+
+    void virt_render(const GLRenderState &renderState) override
+    {
+        if (Base::isEmpty()) {
+            return;
+        }
+
+        Functions &gl = Base::m_functions;
+        gl.checkError();
+
+        const glm::mat4 mvp = renderState.mvp.value_or(gl.getProjectionMatrix());
+        auto programUnbinder = Base::m_program.bind();
+        Base::m_program.setUniforms(mvp, renderState.uniforms);
+        Base::m_program.setViewport("uViewport", gl.getPhysicalViewport());
+        Base::m_program.setFloat("uLineWidth",
+                                 renderState.lineParams.width * gl.getDevicePixelRatio());
+
+        RenderStateBinder renderStateBinder(gl, gl.getTexLookup(), renderState);
+
+        gl.glBindVertexArray(Base::m_vao.get());
+        RAIICallback vaoUnbinder([&gl]() {
+            gl.glBindVertexArray(0);
+            gl.checkError();
+        });
+
+        auto attribUnbinder = Base::bindAttribs();
+
+        const GLsizei numInstances = Base::m_numVerts / 2;
+        gl.glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, numInstances);
+    }
+
+    void virt_unbind() override
+    {
+        if (!m_boundAttribs) {
+            return;
+        }
+        auto &attribs = m_boundAttribs.value();
+        Functions &gl = Base::m_functions;
+        gl.glDisableVertexAttribArray(attribs.vert1Pos);
+        gl.glDisableVertexAttribArray(attribs.vert2Pos);
+        gl.glVertexAttribDivisor(attribs.vert1Pos, 0);
+        gl.glVertexAttribDivisor(attribs.vert2Pos, 0);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, 0);
+        m_boundAttribs.reset();
+    }
+
+    NODISCARD static const void *VPO_PTR(size_t offset)
+    {
+        return reinterpret_cast<const void *>(offset);
+    }
+};
+
 // Per-vertex color
 // flat-shaded in MMapper, due to glShadeModel(GL_FLAT)
 template<typename VertexType_>
@@ -117,7 +210,114 @@ private:
         gl.glBindBuffer(GL_ARRAY_BUFFER, 0);
         m_boundAttribs.reset();
     }
-}; // namespace Legacy
+};
+
+template<typename VertexType_>
+class NODISCARD ColoredLineMesh final : public SimpleMesh<VertexType_, AColorLineShader>
+{
+public:
+    using Base = SimpleMesh<VertexType_, AColorLineShader>;
+    using Base::Base;
+
+private:
+    struct NODISCARD Attribs final
+    {
+        GLuint colorPos = INVALID_ATTRIB_LOCATION;
+        GLuint vert1Pos = INVALID_ATTRIB_LOCATION;
+        GLuint vert2Pos = INVALID_ATTRIB_LOCATION;
+
+        NODISCARD static Attribs getLocations(AbstractShaderProgram &shader)
+        {
+            Attribs result;
+            result.colorPos = shader.getAttribLocation("aColor");
+            result.vert1Pos = shader.getAttribLocation("aVert1");
+            result.vert2Pos = shader.getAttribLocation("aVert2");
+            return result;
+        }
+    };
+
+    std::optional<Attribs> m_boundAttribs;
+
+    void virt_bind() override
+    {
+        const auto vertSize = static_cast<GLsizei>(sizeof(VertexType_));
+        Functions &gl = Base::m_functions;
+        const auto attribs = Attribs::getLocations(Base::m_program);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, Base::m_vbo.get());
+
+        // We assume the color comes from the first vertex of the segment
+        // aColor
+        gl.enableAttrib(attribs.colorPos, 4, GL_UNSIGNED_BYTE, GL_TRUE, 2 * vertSize, VPO(color));
+        // aVert1
+        gl.enableAttrib(attribs.vert1Pos, 3, GL_FLOAT, GL_FALSE, 2 * vertSize, VPO(vert));
+        // aVert2
+        gl.enableAttrib(attribs.vert2Pos,
+                        3,
+                        GL_FLOAT,
+                        GL_FALSE,
+                        2 * vertSize,
+                        VPO_PTR(VPO(vert), vertSize));
+
+        // instancing
+        gl.glVertexAttribDivisor(attribs.colorPos, 1);
+        gl.glVertexAttribDivisor(attribs.vert1Pos, 1);
+        gl.glVertexAttribDivisor(attribs.vert2Pos, 1);
+
+        m_boundAttribs = attribs;
+    }
+
+    void virt_render(const GLRenderState &renderState) override
+    {
+        if (Base::isEmpty()) {
+            return;
+        }
+
+        Functions &gl = Base::m_functions;
+        gl.checkError();
+
+        const glm::mat4 mvp = renderState.mvp.value_or(gl.getProjectionMatrix());
+        auto programUnbinder = Base::m_program.bind();
+        Base::m_program.setUniforms(mvp, renderState.uniforms);
+        Base::m_program.setViewport("uViewport", gl.getPhysicalViewport());
+        Base::m_program.setFloat("uLineWidth",
+                                 renderState.lineParams.width * gl.getDevicePixelRatio());
+
+        RenderStateBinder renderStateBinder(gl, gl.getTexLookup(), renderState);
+
+        gl.glBindVertexArray(Base::m_vao.get());
+        RAIICallback vaoUnbinder([&gl]() {
+            gl.glBindVertexArray(0);
+            gl.checkError();
+        });
+
+        auto attribUnbinder = Base::bindAttribs();
+
+        const GLsizei numInstances = Base::m_numVerts / 2;
+        gl.glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, numInstances);
+    }
+
+    void virt_unbind() override
+    {
+        if (!m_boundAttribs) {
+            return;
+        }
+        auto &attribs = m_boundAttribs.value();
+        Functions &gl = Base::m_functions;
+        gl.glDisableVertexAttribArray(attribs.colorPos);
+        gl.glDisableVertexAttribArray(attribs.vert1Pos);
+        gl.glDisableVertexAttribArray(attribs.vert2Pos);
+        gl.glVertexAttribDivisor(attribs.colorPos, 0);
+        gl.glVertexAttribDivisor(attribs.vert1Pos, 0);
+        gl.glVertexAttribDivisor(attribs.vert2Pos, 0);
+        gl.glBindBuffer(GL_ARRAY_BUFFER, 0);
+        m_boundAttribs.reset();
+    }
+
+    NODISCARD static const void *VPO_PTR(const void *base, size_t offset)
+    {
+        return static_cast<const char *>(base) + offset;
+    }
+};
 
 // Textured mesh with color modulated by uniform
 template<typename VertexType_>

--- a/src/opengl/legacy/Shaders.cpp
+++ b/src/opengl/legacy/Shaders.cpp
@@ -30,6 +30,8 @@ namespace Legacy {
 
 AColorPlainShader::~AColorPlainShader() = default;
 UColorPlainShader::~UColorPlainShader() = default;
+AColorLineShader::~AColorLineShader() = default;
+UColorLineShader::~UColorLineShader() = default;
 AColorTexturedShader::~AColorTexturedShader() = default;
 UColorTexturedShader::~UColorTexturedShader() = default;
 
@@ -48,6 +50,8 @@ void ShaderPrograms::early_init()
 {
     std::ignore = getPlainAColorShader();
     std::ignore = getPlainUColorShader();
+    std::ignore = getLineAColorShader();
+    std::ignore = getLineUColorShader();
     std::ignore = getTexturedAColorShader();
     std::ignore = getTexturedUColorShader();
 
@@ -67,6 +71,8 @@ void ShaderPrograms::resetAll()
 {
     m_aColorShader.reset();
     m_uColorShader.reset();
+    m_aLineShader.reset();
+    m_uLineShader.reset();
     m_aTexturedShader.reset();
     m_uTexturedShader.reset();
 
@@ -119,6 +125,16 @@ const std::shared_ptr<AColorPlainShader> &ShaderPrograms::getPlainAColorShader()
 const std::shared_ptr<UColorPlainShader> &ShaderPrograms::getPlainUColorShader()
 {
     return getInitialized<UColorPlainShader>(m_uColorShader, getFunctions(), "plain/ucolor");
+}
+
+const std::shared_ptr<AColorLineShader> &ShaderPrograms::getLineAColorShader()
+{
+    return getInitialized<AColorLineShader>(m_aLineShader, getFunctions(), "line/acolor");
+}
+
+const std::shared_ptr<UColorLineShader> &ShaderPrograms::getLineUColorShader()
+{
+    return getInitialized<UColorLineShader>(m_uLineShader, getFunctions(), "line/ucolor");
 }
 
 const std::shared_ptr<AColorTexturedShader> &ShaderPrograms::getTexturedAColorShader()

--- a/src/opengl/legacy/Shaders.h
+++ b/src/opengl/legacy/Shaders.h
@@ -23,6 +23,36 @@ private:
     }
 };
 
+struct NODISCARD AColorLineShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~AColorLineShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms) final
+    {
+        setColor("uColor", uniforms.color);
+        setMatrix("uMVP", mvp);
+    }
+};
+
+struct NODISCARD UColorLineShader final : public AbstractShaderProgram
+{
+public:
+    using AbstractShaderProgram::AbstractShaderProgram;
+
+    ~UColorLineShader() final;
+
+private:
+    void virt_setUniforms(const glm::mat4 &mvp, const GLRenderState::Uniforms &uniforms) final
+    {
+        setColor("uColor", uniforms.color);
+        setMatrix("uMVP", mvp);
+    }
+};
+
 struct NODISCARD UColorPlainShader final : public AbstractShaderProgram
 {
 public:
@@ -219,6 +249,8 @@ private:
 private:
     std::shared_ptr<AColorPlainShader> m_aColorShader;
     std::shared_ptr<UColorPlainShader> m_uColorShader;
+    std::shared_ptr<AColorLineShader> m_aLineShader;
+    std::shared_ptr<UColorLineShader> m_uLineShader;
     std::shared_ptr<AColorTexturedShader> m_aTexturedShader;
     std::shared_ptr<UColorTexturedShader> m_uTexturedShader;
 
@@ -253,6 +285,8 @@ public:
     NODISCARD const std::shared_ptr<AColorPlainShader> &getPlainAColorShader();
     // uniform color (aka "Plain")
     NODISCARD const std::shared_ptr<UColorPlainShader> &getPlainUColorShader();
+    NODISCARD const std::shared_ptr<AColorLineShader> &getLineAColorShader();
+    NODISCARD const std::shared_ptr<UColorLineShader> &getLineUColorShader();
     // attribute color + textured (aka "ColoredTextured")
     NODISCARD const std::shared_ptr<AColorTexturedShader> &getTexturedAColorShader();
     // uniform color + textured (aka "Textured")

--- a/src/opengl/legacy/SimpleMesh.h
+++ b/src/opengl/legacy/SimpleMesh.h
@@ -166,7 +166,7 @@ private:
     }
 
 private:
-    void virt_render(const GLRenderState &renderState) final
+    void virt_render(const GLRenderState &renderState) override
     {
         if (isEmpty()) {
             return;

--- a/src/resources/mmapper2.qrc
+++ b/src/resources/mmapper2.qrc
@@ -213,6 +213,10 @@
         <file>pixmaps/wall-west.png</file>
         <file>shaders/legacy/font/frag.glsl</file>
         <file>shaders/legacy/font/vert.glsl</file>
+        <file>shaders/legacy/line/acolor/frag.glsl</file>
+        <file>shaders/legacy/line/acolor/vert.glsl</file>
+        <file>shaders/legacy/line/ucolor/frag.glsl</file>
+        <file>shaders/legacy/line/ucolor/vert.glsl</file>
         <file>shaders/legacy/room/tex/acolor/frag.glsl</file>
         <file>shaders/legacy/room/tex/acolor/vert.glsl</file>
         <file>shaders/legacy/plain/acolor/frag.glsl</file>

--- a/src/resources/shaders/legacy/line/acolor/frag.glsl
+++ b/src/resources/shaders/legacy/line/acolor/frag.glsl
@@ -1,0 +1,10 @@
+uniform vec4 uColor;
+
+in vec4 vColor;
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    vFragmentColor = vColor * uColor;
+}

--- a/src/resources/shaders/legacy/line/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/line/acolor/vert.glsl
@@ -1,0 +1,44 @@
+uniform mat4 uMVP;
+uniform float uLineWidth;
+uniform ivec4 uViewport; // x, y, width, height
+
+layout(location = 0) in vec4 aColor;
+layout(location = 1) in vec3 aVert1;
+layout(location = 2) in vec3 aVert2;
+
+out vec4 vColor;
+
+void main()
+{
+    vColor = aColor;
+
+    vec4 clip1 = uMVP * vec4(aVert1, 1.0);
+    vec4 clip2 = uMVP * vec4(aVert2, 1.0);
+
+    vec2 ndc1 = clip1.xy / clip1.w;
+    vec2 ndc2 = clip2.xy / clip2.w;
+
+    vec2 screen1 = (ndc1 + 1.0) * 0.5 * vec2(uViewport.zw);
+    vec2 screen2 = (ndc2 + 1.0) * 0.5 * vec2(uViewport.zw);
+
+    vec2 dir = screen2 - screen1;
+    float len = length(dir);
+    if (len < 0.0001) {
+        dir = vec2(1.0, 0.0);
+    } else {
+        dir /= len;
+    }
+    vec2 normal = vec2(-dir.y, dir.x);
+
+    vec2 offset = normal * uLineWidth * 0.5;
+
+    vec2 pos;
+    float z;
+    if (gl_VertexID == 0) { pos = screen1 + offset; z = clip1.z / clip1.w; }
+    else if (gl_VertexID == 1) { pos = screen1 - offset; z = clip1.z / clip1.w; }
+    else if (gl_VertexID == 2) { pos = screen2 - offset; z = clip2.z / clip2.w; }
+    else { pos = screen2 + offset; z = clip2.z / clip2.w; }
+
+    vec2 final_ndc = (pos / vec2(uViewport.zw)) * 2.0 - 1.0;
+    gl_Position = vec4(final_ndc, z, 1.0);
+}

--- a/src/resources/shaders/legacy/line/ucolor/frag.glsl
+++ b/src/resources/shaders/legacy/line/ucolor/frag.glsl
@@ -1,0 +1,8 @@
+uniform vec4 uColor;
+
+out vec4 vFragmentColor;
+
+void main()
+{
+    vFragmentColor = uColor;
+}

--- a/src/resources/shaders/legacy/line/ucolor/vert.glsl
+++ b/src/resources/shaders/legacy/line/ucolor/vert.glsl
@@ -1,0 +1,39 @@
+uniform mat4 uMVP;
+uniform float uLineWidth;
+uniform ivec4 uViewport; // x, y, width, height
+
+layout(location = 0) in vec3 aVert1;
+layout(location = 1) in vec3 aVert2;
+
+void main()
+{
+    vec4 clip1 = uMVP * vec4(aVert1, 1.0);
+    vec4 clip2 = uMVP * vec4(aVert2, 1.0);
+
+    vec2 ndc1 = clip1.xy / clip1.w;
+    vec2 ndc2 = clip2.xy / clip2.w;
+
+    vec2 screen1 = (ndc1 + 1.0) * 0.5 * vec2(uViewport.zw);
+    vec2 screen2 = (ndc2 + 1.0) * 0.5 * vec2(uViewport.zw);
+
+    vec2 dir = screen2 - screen1;
+    float len = length(dir);
+    if (len < 0.0001) {
+        dir = vec2(1.0, 0.0);
+    } else {
+        dir /= len;
+    }
+    vec2 normal = vec2(-dir.y, dir.x);
+
+    vec2 offset = normal * uLineWidth * 0.5;
+
+    vec2 pos;
+    float z;
+    if (gl_VertexID == 0) { pos = screen1 + offset; z = clip1.z / clip1.w; }
+    else if (gl_VertexID == 1) { pos = screen1 - offset; z = clip1.z / clip1.w; }
+    else if (gl_VertexID == 2) { pos = screen2 - offset; z = clip2.z / clip2.w; }
+    else { pos = screen2 + offset; z = clip2.z / clip2.w; }
+
+    vec2 final_ndc = (pos / vec2(uViewport.zw)) * 2.0 - 1.0;
+    gl_Position = vec4(final_ndc, z, 1.0);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -335,3 +335,18 @@ set_target_properties(
         COMPILE_FLAGS "${WARNING_FLAGS}"
 )
 add_test(NAME TestHotkeyManager COMMAND TestHotkeyManager)
+
+# OpenGL
+set(TestOpenGL_SRCS testopengl.cpp)
+add_executable(TestOpenGL ${TestOpenGL_SRCS} ../src/opengl/OpenGLProber.cpp ../src/opengl/OpenGLConfig.cpp)
+target_include_directories(TestOpenGL PRIVATE ../src)
+add_dependencies(TestOpenGL mm_global)
+target_link_libraries(TestOpenGL mm_global Qt6::Test Qt6::Gui Qt6::OpenGL coverage_config)
+set_target_properties(
+    TestOpenGL PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+    COMPILE_FLAGS "${WARNING_FLAGS}"
+)
+add_test(NAME TestOpenGL COMMAND TestOpenGL)

--- a/tests/testopengl.cpp
+++ b/tests/testopengl.cpp
@@ -1,0 +1,69 @@
+#include <opengl/OpenGLConfig.h>
+#include <opengl/OpenGLProber.h>
+
+#include <QtTest>
+
+class TestOpenGL : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testParseSurveyResult_GL()
+    {
+        OpenGLProber prober;
+        QByteArray json = R"({"backend": "GL", "major": 4, "minor": 5})";
+        auto result = prober.parseSurveyResult(json);
+
+        QCOMPARE(result.backendType, OpenGLProber::BackendType::GL);
+        QCOMPARE(result.format.majorVersion(), 4);
+        QCOMPARE(result.format.minorVersion(), 5);
+        QCOMPARE(result.format.profile(), QSurfaceFormat::CoreProfile);
+        QCOMPARE(result.highestVersionString, std::string("GL4.5core"));
+
+        QCOMPARE(OpenGLConfig::getGLVersionString(), std::string("GL4.5core"));
+    }
+
+    void testParseSurveyResult_GLES()
+    {
+        OpenGLProber prober;
+        QByteArray json = R"({"backend": "GLES", "major": 3, "minor": 1})";
+        auto result = prober.parseSurveyResult(json);
+
+        QCOMPARE(result.backendType, OpenGLProber::BackendType::GLES);
+        QCOMPARE(result.format.majorVersion(), 3);
+        QCOMPARE(result.format.minorVersion(), 1);
+        QCOMPARE(result.format.renderableType(), QSurfaceFormat::OpenGLES);
+        QCOMPARE(result.highestVersionString, std::string("ES3.1"));
+
+        QCOMPARE(OpenGLConfig::getESVersionString(), std::string("ES3.1"));
+    }
+
+    void testParseSurveyResult_Invalid()
+    {
+        OpenGLProber prober;
+        QByteArray json = R"({"backend": "None"})";
+        auto result = prober.parseSurveyResult(json);
+        QCOMPARE(result.backendType, OpenGLProber::BackendType::None);
+
+        json = "garbage";
+        result = prober.parseSurveyResult(json);
+        // Fallback is GL 3.3 Core
+        QCOMPARE(result.backendType, OpenGLProber::BackendType::GL);
+        QCOMPARE(result.highestVersionString, std::string("Fallback"));
+    }
+
+    void testGetBackendType()
+    {
+        OpenGLConfig::setBackendType(OpenGLProber::BackendType::GLES);
+        QCOMPARE(OpenGLConfig::getBackendType(), OpenGLProber::BackendType::GLES);
+    }
+
+    void testMaxSamples()
+    {
+        OpenGLConfig::setMaxSamples(4);
+        QCOMPARE(OpenGLConfig::getMaxSamples(), 4);
+    }
+};
+
+QTEST_MAIN(TestOpenGL)
+#include "testopengl.moc"

--- a/tests/testopengl.cpp
+++ b/tests/testopengl.cpp
@@ -24,7 +24,7 @@ private slots:
         QCOMPARE(OpenGLConfig::getGLVersionString(), std::string("GL4.5"));
     }
 
-    void testParseSurveyResult_GLES()
+    void testParseSurveyResult_ES()
     {
         OpenGLProber prober;
         QByteArray json = R"({"backend": "ES", "major": 3, "minor": 1, "debug": false})";

--- a/tests/testopengl.cpp
+++ b/tests/testopengl.cpp
@@ -18,9 +18,9 @@ private slots:
         QCOMPARE(result.format.majorVersion(), 4);
         QCOMPARE(result.format.minorVersion(), 5);
         QCOMPARE(result.format.profile(), QSurfaceFormat::CoreProfile);
-        QCOMPARE(result.highestVersionString, std::string("GL4.5core"));
+        QCOMPARE(result.highestVersionString, std::string("GL4.5"));
 
-        QCOMPARE(OpenGLConfig::getGLVersionString(), std::string("GL4.5core"));
+        QCOMPARE(OpenGLConfig::getGLVersionString(), std::string("GL4.5"));
     }
 
     void testParseSurveyResult_GLES()
@@ -50,6 +50,23 @@ private slots:
         // Fallback is GL 3.3 Core
         QCOMPARE(result.backendType, OpenGLProber::BackendType::GL);
         QCOMPARE(result.highestVersionString, std::string("Fallback"));
+    }
+
+    void testParseSurveyResult_Robustness()
+    {
+        OpenGLProber prober;
+        QByteArray json = R"(
+Some random log message
+More noise
+{"backend": "GL", "major": 4, "minor": 6}
+Sanitizer output: leak detected
+)";
+        auto result = prober.parseSurveyResult(json);
+
+        QCOMPARE(result.backendType, OpenGLProber::BackendType::GL);
+        QCOMPARE(result.format.majorVersion(), 4);
+        QCOMPARE(result.format.minorVersion(), 6);
+        QCOMPARE(result.highestVersionString, std::string("GL4.6"));
     }
 
     void testGetBackendType()

--- a/tests/testopengl.cpp
+++ b/tests/testopengl.cpp
@@ -11,13 +11,14 @@ private slots:
     void testParseSurveyResult_GL()
     {
         OpenGLProber prober;
-        QByteArray json = R"({"backend": "GL", "major": 4, "minor": 5})";
+        QByteArray json = R"({"backend": "GL", "major": 4, "minor": 5, "debug": true})";
         auto result = prober.parseSurveyResult(json);
 
         QCOMPARE(result.backendType, OpenGLProber::BackendType::GL);
         QCOMPARE(result.format.majorVersion(), 4);
         QCOMPARE(result.format.minorVersion(), 5);
         QCOMPARE(result.format.profile(), QSurfaceFormat::CoreProfile);
+        QCOMPARE(result.format.testOption(QSurfaceFormat::DebugContext), true);
         QCOMPARE(result.highestVersionString, std::string("GL4.5"));
 
         QCOMPARE(OpenGLConfig::getGLVersionString(), std::string("GL4.5"));
@@ -26,13 +27,14 @@ private slots:
     void testParseSurveyResult_GLES()
     {
         OpenGLProber prober;
-        QByteArray json = R"({"backend": "GLES", "major": 3, "minor": 1})";
+        QByteArray json = R"({"backend": "ES", "major": 3, "minor": 1, "debug": false})";
         auto result = prober.parseSurveyResult(json);
 
-        QCOMPARE(result.backendType, OpenGLProber::BackendType::GLES);
+        QCOMPARE(result.backendType, OpenGLProber::BackendType::ES);
         QCOMPARE(result.format.majorVersion(), 3);
         QCOMPARE(result.format.minorVersion(), 1);
         QCOMPARE(result.format.renderableType(), QSurfaceFormat::OpenGLES);
+        QCOMPARE(result.format.testOption(QSurfaceFormat::DebugContext), false);
         QCOMPARE(result.highestVersionString, std::string("ES3.1"));
 
         QCOMPARE(OpenGLConfig::getESVersionString(), std::string("ES3.1"));
@@ -71,8 +73,8 @@ Sanitizer output: leak detected
 
     void testGetBackendType()
     {
-        OpenGLConfig::setBackendType(OpenGLProber::BackendType::GLES);
-        QCOMPARE(OpenGLConfig::getBackendType(), OpenGLProber::BackendType::GLES);
+        OpenGLConfig::setBackendType(OpenGLProber::BackendType::ES);
+        QCOMPARE(OpenGLConfig::getBackendType(), OpenGLProber::BackendType::ES);
     }
 
     void testMaxSamples()


### PR DESCRIPTION
This change fixes the OpenGL prober which was failing to parse the JSON output from its survey subprocess when extraneous logs (e.g., from Qt theme plugins or AddressSanitizer) were present.

Key changes:
- Modified OpenGLProber::parseSurveyResult to robustly extract the JSON block from noisy output by searching for the first '{' and last '}'.
- Updated the probe subprocess execution to use '-platform offscreen' and set 'ASAN_OPTIONS=detect_leaks=0' to minimize output noise.
- Removed the "core" suffix from the OpenGL version string as MMapper now exclusively supports Core profile.
- Added a new unit test 'testParseSurveyResult_Robustness' to verify the fix and prevent regressions.
- Ensured proper output formatting and flushing in the survey subprocess.

---
*PR created automatically by Jules for task [5779355015471748127](https://jules.google.com/task/5779355015471748127) started by @nschimme*

## Summary by Sourcery

Improve robustness of the OpenGL capability probe when collecting and parsing survey data from a subprocess.

Bug Fixes:
- Handle noisy subprocess output by extracting the JSON block from the first '{' to the last '}' before parsing.

Enhancements:
- Run the OpenGL probe subprocess with an offscreen platform and adjusted ASAN options to reduce spurious output.
- Normalize reported OpenGL Core profile versions by removing the "core" suffix from the stored version string.
- Ensure the survey subprocess flushes its JSON output with surrounding newlines for reliable capture.

Tests:
- Add a robustness unit test that verifies JSON parsing succeeds even when surrounded by arbitrary log noise.