### PR TITLE
Revert header and recommendation badge style

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>{{ page.title | default: site.title }} | {{ site.title }}</title>
+    <title>{{ site.title }}</title>
     <meta name="description" content="{{ page.description | default: site.description }}">
 
     <!-- Link CSS -->
@@ -24,7 +24,7 @@
             <header style="display: flex; flex-direction: column; align-items: center;">
                 <div style="display: flex; align-items: center;">
 			<img src="{{ '/assets/img/logo.svg' | relative_url }}" alt="MMapper" style="height: 50px; margin-right: 10px;">
-                    <h1><a href="{{ '/' | relative_url }}">{{ page.title | default: site.title }}</a></h1>
+                    <h1><a href="{{ '/' | relative_url }}">MMapper</a></h1>
                 </div>
             </header>
             <nav aria-label="Main Navigation">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -36,7 +36,7 @@
             </nav>
         </div>
 
-        <main>
+        <main id="main-content">
             {{ content }}
         </main>
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -18,6 +18,7 @@
     <script src="{{ '/assets/js/download-highlight.js' | relative_url }}"></script>
 </head>
 <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
     <div class="content-wrapper">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <header style="display: flex; flex-direction: column; align-items: center;">
@@ -26,10 +27,9 @@
                     <h1><a href="{{ '/' | relative_url }}">{{ page.title | default: site.title }}</a></h1>
                 </div>
             </header>
-            <nav>
+            <nav aria-label="Main Navigation">
                 <ul style="list-style: none; padding: 0; margin: 0;">
-                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/demo/' | relative_url }}">Demo</a></li>
-                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/#download-mmapper' | relative_url }}">Download</a></li>
+                    <li style="display: inline; margin-left: 10px;"><a href="{{ '/#get-mmapper' | relative_url }}">Get</a></li>
                     <li style="display: inline; margin-left: 10px;"><a href="{{ '/changelog.html' | relative_url }}">Changelog</a></li>
                     <li style="display: inline; margin-left: 10px;"><a href="{{ '/about.html' | relative_url }}">About</a></li>
                 </ul>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,6 +1,22 @@
 /* Minimal MMapper Website Styles */
 
 /* Basic Reset & Body */
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    background: #cc9933;
+    color: #1a1a1a;
+    padding: 8px;
+    z-index: 100;
+    transition: top 0.3s;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+    top: 0;
+}
+
 body {
     margin: 0;
     padding: 0;
@@ -131,7 +147,8 @@ hr {
 
 /* Download Buttons/Links (on platform pages) */
 .download-link {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     background-color: #cc9933;
     color: #1a1a1a; /* Dark text on button */
     padding: 0.8em 1.5em;
@@ -158,6 +175,25 @@ hr {
     color: #5cb85c;
     font-weight: bold;
     margin-left: 0.5em;
+    vertical-align: middle;
+    display: inline-block;
+}
+
+/* Ensure recommendation is readable when inside a button */
+.download-link .recommendation-text {
+    color: #1a1a1a;
+    background: #5cb85c;
+    padding: 0.2em 0.5em;
+    border-radius: 3px;
+    font-size: 0.8em;
+    text-transform: uppercase;
+}
+
+.platform-link .platform-recommendation {
+    display: block;
+    margin-left: 0;
+    margin-top: 0.5em;
+    font-size: 0.9em;
 }
 
 

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -147,8 +147,7 @@ hr {
 
 /* Download Buttons/Links (on platform pages) */
 .download-link {
-    display: inline-flex;
-    align-items: center;
+    display: inline-block;
     background-color: #cc9933;
     color: #1a1a1a; /* Dark text on button */
     padding: 0.8em 1.5em;
@@ -175,25 +174,6 @@ hr {
     color: #5cb85c;
     font-weight: bold;
     margin-left: 0.5em;
-    vertical-align: middle;
-    display: inline-block;
-}
-
-/* Ensure recommendation is readable when inside a button */
-.download-link .recommendation-text {
-    color: #1a1a1a;
-    background: #5cb85c;
-    padding: 0.2em 0.5em;
-    border-radius: 3px;
-    font-size: 0.8em;
-    text-transform: uppercase;
-}
-
-.platform-link .platform-recommendation {
-    display: block;
-    margin-left: 0;
-    margin-top: 0.5em;
-    font-size: 0.9em;
 }
 
 

--- a/docs/assets/js/download-highlight.js
+++ b/docs/assets/js/download-highlight.js
@@ -29,11 +29,11 @@ document.addEventListener('DOMContentLoaded', function() {
         recommendation.textContent = ' Recommended';
         recommendation.classList.add('recommendation-text');
 
-        // Always place recommendation inside the link for consistent semantics and focus behavior
+        // Place recommendation outside the link as per user preference
         if (link.classList.contains('platform-link')) {
             recommendation.classList.add('platform-recommendation');
         }
-        link.appendChild(recommendation);
+        link.parentNode.insertBefore(recommendation, link.nextSibling);
     }
 
     downloadLinks.forEach(link => {

--- a/docs/assets/js/download-highlight.js
+++ b/docs/assets/js/download-highlight.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     let detectedArch = null;
     let isChromeOS = false;
-    const downloadLinks = document.querySelectorAll('.download-link');
+    const downloadLinks = document.querySelectorAll('.download-link, .platform-link');
 
     // --- Architecture Detection (Best Effort) ---
     if (navigator.userAgentData && navigator.userAgentData.architecture) {
@@ -23,17 +23,34 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     // --- Highlight Download Link ---
+    function addRecommendation(link) {
+        link.classList.add('recommended-download');
+        const recommendation = document.createElement('span');
+        recommendation.textContent = ' Recommended';
+        recommendation.classList.add('recommendation-text');
+
+        // Always place recommendation inside the link for consistent semantics and focus behavior
+        if (link.classList.contains('platform-link')) {
+            recommendation.classList.add('platform-recommendation');
+        }
+        link.appendChild(recommendation);
+    }
+
     downloadLinks.forEach(link => {
         const href = link.href.toLowerCase();
+        const platform = link.getAttribute('data-platform');
 
         // Do not recommend Windows .exe installers
         if (href.includes('.exe')) {
             return;
         }
 
-        // Only recommend .deb for ChromeOS
-        if (isChromeOS && (href.includes('appimage') || href.includes('flatpak'))) {
-            return;
+        // For ChromeOS, only recommend the Web version
+        if (isChromeOS) {
+            if (platform === 'web') {
+                addRecommendation(link);
+            }
+            return; // Don't recommend anything else on ChromeOS
         }
 
         let linkArch = null;
@@ -44,11 +61,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         if (detectedArch && linkArch === detectedArch) {
-            link.classList.add('recommended-download');
-            const recommendation = document.createElement('span');
-            recommendation.textContent = ' Recommended';
-            recommendation.classList.add('recommendation-text');
-            link.parentNode.insertBefore(recommendation, link.nextSibling);
+            addRecommendation(link);
         }
     });
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,19 +10,26 @@ title: Play MUME with MMapper
 
 ## Download MMapper
 
-Choose your operating system to download the latest version {{ site.github.latest_release.tag_name }}:
+## Get MMapper
+{: #get-mmapper}
+
+Choose your preferred platform to start using MMapper {{ site.github.latest_release.tag_name }}:
 
 <div class="platform-links">
-    <a href="{{ '/windows.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-windows"></i>
+    <a href="{{ '/demo/' | relative_url }}" class="platform-link" aria-label="Use MMapper in your Web Browser" data-platform="web">
+        <i class="fas fa-globe" aria-hidden="true"></i>
+        <span>Web</span>
+    </a>
+    <a href="{{ '/windows.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for Windows">
+        <i class="fab fa-windows" aria-hidden="true"></i>
         <span>Windows</span>
     </a>
-    <a href="{{ '/macos.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-apple"></i>
+    <a href="{{ '/macos.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for macOS">
+        <i class="fab fa-apple" aria-hidden="true"></i>
         <span>macOS</span>
     </a>
-    <a href="{{ '/linux.html' | relative_url }}" class="platform-link">
-        <i class="fab fa-linux"></i>
+    <a href="{{ '/linux.html' | relative_url }}" class="platform-link" aria-label="Get MMapper for Linux">
+        <i class="fab fa-linux" aria-hidden="true"></i>
         <span>Linux</span>
     </a>
 </div>

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Download MMapper for Linux
+title: Get MMapper for Linux
 ---
 
 ## Download MMapper for Linux

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Download MMapper for macOS
+title: Get MMapper for macOS
 ---
 
 ## Download MMapper for macOS

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -7,8 +7,8 @@ title: Get MMapper for Windows
 
 <a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct" style="display: inline-flex; align-items: center; text-decoration: none;">
      <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" style="vertical-align: middle;"/>
-     <span class="recommendation-text"> Recommended</span>
 </a>
+<span class="recommendation-text"> Recommended</span>
 
 {% for asset in site.github.latest_release.assets %}
 {% if asset.name contains 'sha256' %}

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,13 +1,14 @@
 ---
 layout: default
-title: Download MMapper for Windows
+title: Get MMapper for Windows
 ---
 
 ## Download MMapper for Windows
 
-<a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct">
+<a href="https://apps.microsoft.com/detail/9p6f2b68rf7g?referrer=appbadge&mode=direct" style="display: inline-flex; align-items: center; text-decoration: none;">
      <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" style="vertical-align: middle;"/>
-</a><span class="recommendation-text"> Recommended</span>
+     <span class="recommendation-text"> Recommended</span>
+</a>
 
 {% for asset in site.github.latest_release.assets %}
 {% if asset.name contains 'sha256' %}


### PR DESCRIPTION
I've reverted the header style, page title, and "Recommended" badge placement to match the original style as requested.

Specifically:
1.  **Header & Title:** The main header now consistently displays "MMapper", and the page title has been simplified to just the site name.
2.  **Recommendation Badges:** The "Recommended" labels are now placed immediately after the download links instead of inside them. This was updated in both the dynamic JavaScript logic and the manual Microsoft Store link on the Windows page.
3.  **Styling:** Download buttons have been returned to `inline-block` display, and the recommendation text styling has been simplified to its previous state.
4.  **Accessibility:** I have kept the recently added accessibility features, such as the "Skip to content" link and semantic navigation labels, while restoring the visual style.
5.  **Navigation:** The navigation continues to use "Get" and excludes the "Demo" button as per your preference.

---
*PR created automatically by Jules for task [4761332656860111038](https://jules.google.com/task/4761332656860111038) started by @nschimme*

## Summary by Sourcery

Revert site header, page title, and download recommendation badge presentation to the previous visual style while keeping recent accessibility and navigation behavior intact.

Bug Fixes:
- Move dynamically generated and Windows Microsoft Store "Recommended" badges outside the download links to align with the original layout and user preference.

Enhancements:
- Simplify the HTML page title to always use the site name.
- Standardize the main header text to always display the site name.
- Restore download links to use inline-block display and revert recommendation text styling and placement to match the prior design.