### PR TITLE
GPU-based Anti-Aliased Line Rendering

### DIFF
--- a/src/display/Characters.cpp
+++ b/src/display/Characters.cpp
@@ -107,7 +107,8 @@ void CharacterBatch::CharFakeGL::drawPathSegment(const glm::vec3 &p1,
                                                  const glm::vec3 &p2,
                                                  const Color color)
 {
-    mmgl::generateLineQuadsSafe(m_pathLineQuads, p1, p2, PATH_LINE_WIDTH, color);
+    m_pathLines.emplace_back(color, p1);
+    m_pathLines.emplace_back(color, p2);
 }
 
 void CharacterBatch::drawPreSpammedPath(const Coordinate &c1,
@@ -359,8 +360,9 @@ void CharacterBatch::CharFakeGL::reallyDrawPaths(OpenGL &gl)
         = GLRenderState().withDepthFunction(std::nullopt).withBlend(BlendModeEnum::TRANSPARENCY);
 
     gl.renderPoints(m_pathPoints, blended_noDepth.withPointSize(PATH_POINT_SIZE));
-    if (!m_pathLineQuads.empty()) {
-        gl.renderColoredQuads(m_pathLineQuads, blended_noDepth);
+    if (!m_pathLines.empty()) {
+        gl.renderColoredLines(m_pathLines,
+                              blended_noDepth.withLineParams(LineParams{PATH_LINE_WIDTH}));
     }
 }
 

--- a/src/display/Characters.h
+++ b/src/display/Characters.h
@@ -105,7 +105,7 @@ private:
         std::vector<ColorVert> m_charLines;
         std::vector<ColoredTexVert> m_charRoomQuads;
         std::vector<ColorVert> m_pathPoints;
-        std::vector<ColorVert> m_pathLineQuads;
+        std::vector<ColorVert> m_pathLines;
         std::vector<FontVert3d> m_screenSpaceArrows;
         std::vector<GLText> m_names;
         std::map<Coordinate, int, CoordCompare> m_coordCounts;

--- a/src/display/Infomarks.cpp
+++ b/src/display/Infomarks.cpp
@@ -196,8 +196,7 @@ void InfomarksBatch::renderImmediate(const GLRenderState &state)
         gl.renderColoredTris(m_tris, state);
     }
     if (!m_lines.empty()) {
-        gl.renderColoredLines(m_lines,
-                              state.withLineParams(LineParams{INFOMARK_ARROW_LINE_WIDTH}));
+        gl.renderColoredLines(m_lines, state.withLineParams(LineParams{INFOMARK_ARROW_LINE_WIDTH}));
     }
     if (!m_quads.empty()) {
         gl.renderColoredQuads(m_quads, state);

--- a/src/display/Infomarks.cpp
+++ b/src/display/Infomarks.cpp
@@ -144,7 +144,8 @@ void InfomarksBatch::drawLine(const glm::vec3 &a, const glm::vec3 &b)
     const glm::vec3 start_v = a + m_offset;
     const glm::vec3 end_v = b + m_offset;
 
-    mmgl::generateLineQuadsSafe(m_quads, start_v, end_v, INFOMARK_ARROW_LINE_WIDTH, m_color);
+    m_lines.emplace_back(m_color, start_v);
+    m_lines.emplace_back(m_color, end_v);
 }
 
 void InfomarksBatch::drawTriangle(const glm::vec3 &a, const glm::vec3 &b, const glm::vec3 &c)
@@ -172,6 +173,7 @@ InfomarksMeshes InfomarksBatch::getMeshes()
     auto &gl = m_realGL;
     result.points = gl.createPointBatch(m_points);
     result.tris = gl.createColoredTriBatch(m_tris);
+    result.lines = gl.createColoredLineBatch(m_lines);
     result.quads = gl.createColoredQuadBatch(m_quads);
 
     {
@@ -192,6 +194,10 @@ void InfomarksBatch::renderImmediate(const GLRenderState &state)
 
     if (!m_tris.empty()) {
         gl.renderColoredTris(m_tris, state);
+    }
+    if (!m_lines.empty()) {
+        gl.renderColoredLines(m_lines,
+                              state.withLineParams(LineParams{INFOMARK_ARROW_LINE_WIDTH}));
     }
     if (!m_quads.empty()) {
         gl.renderColoredQuads(m_quads, state);
@@ -215,6 +221,7 @@ void InfomarksMeshes::render()
 
     points.render(common_state.withPointSize(INFOMARK_POINT_SIZE));
     tris.render(common_state);
+    lines.render(common_state.withLineParams(LineParams{INFOMARK_ARROW_LINE_WIDTH}));
     quads.render(common_state);
     textMesh.render(common_state);
 }

--- a/src/display/Infomarks.h
+++ b/src/display/Infomarks.h
@@ -23,6 +23,7 @@ struct NODISCARD InfomarksMeshes final
 {
     UniqueMesh points;
     UniqueMesh tris;
+    UniqueMesh lines;
     UniqueMesh quads;
     UniqueMesh textMesh;
     bool isValid = false;
@@ -41,6 +42,7 @@ private:
 
     std::vector<ColorVert> m_points;
     std::vector<ColorVert> m_tris;
+    std::vector<ColorVert> m_lines;
     std::vector<ColorVert> m_quads;
 
     // REVISIT: This is ill-advised and may contain bugs.

--- a/src/resources/shaders/legacy/line/acolor/frag.glsl
+++ b/src/resources/shaders/legacy/line/acolor/frag.glsl
@@ -1,10 +1,30 @@
 uniform vec4 uColor;
 
 in vec4 vColor;
+in vec2 vUv;
+in float vLineLength;
+in float vWidth;
 
 out vec4 vFragmentColor;
 
 void main()
 {
+    float halfWidth = vWidth * 0.5;
+
+    // Calculate distance to the segment
+    float dx = max(-vUv.x, 0.0) + max(vUv.x - vLineLength, 0.0);
+    float dy = vUv.y;
+    float dist = sqrt(dx*dx + dy*dy);
+
+    // Anti-aliasing
+    // Smoothstep creates a nice alpha ramp over 1 pixel
+    float feather = 1.0;
+    float alpha = 1.0 - smoothstep(halfWidth - feather, halfWidth + feather, dist);
+
+    if (alpha <= 0.0) {
+        discard;
+    }
+
     vFragmentColor = vColor * uColor;
+    vFragmentColor.a *= alpha;
 }

--- a/src/resources/shaders/legacy/line/acolor/frag.glsl
+++ b/src/resources/shaders/legacy/line/acolor/frag.glsl
@@ -14,7 +14,7 @@ void main()
     // Calculate distance to the segment
     float dx = max(-vUv.x, 0.0) + max(vUv.x - vLineLength, 0.0);
     float dy = vUv.y;
-    float dist = sqrt(dx*dx + dy*dy);
+    float dist = sqrt(dx * dx + dy * dy);
 
     // Anti-aliasing
     // Smoothstep creates a nice alpha ramp over 1 pixel

--- a/src/resources/shaders/legacy/line/acolor/vert.glsl
+++ b/src/resources/shaders/legacy/line/acolor/vert.glsl
@@ -7,6 +7,9 @@ layout(location = 1) in vec3 aVert1;
 layout(location = 2) in vec3 aVert2;
 
 out vec4 vColor;
+out vec2 vUv;
+out float vLineLength;
+out float vWidth;
 
 void main()
 {
@@ -15,9 +18,11 @@ void main()
     vec4 clip1 = uMVP * vec4(aVert1, 1.0);
     vec4 clip2 = uMVP * vec4(aVert2, 1.0);
 
+    // Standard perspective divide
     vec2 ndc1 = clip1.xy / clip1.w;
     vec2 ndc2 = clip2.xy / clip2.w;
 
+    // Screen coordinates
     vec2 screen1 = (ndc1 + 1.0) * 0.5 * vec2(uViewport.zw);
     vec2 screen2 = (ndc2 + 1.0) * 0.5 * vec2(uViewport.zw);
 
@@ -30,14 +35,38 @@ void main()
     }
     vec2 normal = vec2(-dir.y, dir.x);
 
-    vec2 offset = normal * uLineWidth * 0.5;
+    // Padding for anti-aliasing (e.g. 1 pixel)
+    float feather = 1.0;
+    float halfWidth = uLineWidth * 0.5;
+    float totalHalfWidth = halfWidth + feather;
+
+    vLineLength = len;
+    vWidth = uLineWidth;
 
     vec2 pos;
     float z;
-    if (gl_VertexID == 0) { pos = screen1 + offset; z = clip1.z / clip1.w; }
-    else if (gl_VertexID == 1) { pos = screen1 - offset; z = clip1.z / clip1.w; }
-    else if (gl_VertexID == 2) { pos = screen2 - offset; z = clip2.z / clip2.w; }
-    else { pos = screen2 + offset; z = clip2.z / clip2.w; }
+
+    // Expand longitudinally to allow for round caps
+    vec2 offsetL = dir * totalHalfWidth;
+    vec2 offsetP = normal * totalHalfWidth;
+
+    if (gl_VertexID == 0) {
+        pos = screen1 - offsetL + offsetP;
+        z = clip1.z / clip1.w;
+        vUv = vec2(-totalHalfWidth, totalHalfWidth);
+    } else if (gl_VertexID == 1) {
+        pos = screen1 - offsetL - offsetP;
+        z = clip1.z / clip1.w;
+        vUv = vec2(-totalHalfWidth, -totalHalfWidth);
+    } else if (gl_VertexID == 2) {
+        pos = screen2 + offsetL - offsetP;
+        z = clip2.z / clip2.w;
+        vUv = vec2(len + totalHalfWidth, -totalHalfWidth);
+    } else { // gl_VertexID == 3
+        pos = screen2 + offsetL + offsetP;
+        z = clip2.z / clip2.w;
+        vUv = vec2(len + totalHalfWidth, totalHalfWidth);
+    }
 
     vec2 final_ndc = (pos / vec2(uViewport.zw)) * 2.0 - 1.0;
     gl_Position = vec4(final_ndc, z, 1.0);

--- a/src/resources/shaders/legacy/line/ucolor/frag.glsl
+++ b/src/resources/shaders/legacy/line/ucolor/frag.glsl
@@ -1,8 +1,26 @@
 uniform vec4 uColor;
 
+in vec2 vUv;
+in float vLineLength;
+in float vWidth;
+
 out vec4 vFragmentColor;
 
 void main()
 {
+    float halfWidth = vWidth * 0.5;
+
+    float dx = max(-vUv.x, 0.0) + max(vUv.x - vLineLength, 0.0);
+    float dy = vUv.y;
+    float dist = sqrt(dx*dx + dy*dy);
+
+    float feather = 1.0;
+    float alpha = 1.0 - smoothstep(halfWidth - feather, halfWidth + feather, dist);
+
+    if (alpha <= 0.0) {
+        discard;
+    }
+
     vFragmentColor = uColor;
+    vFragmentColor.a *= alpha;
 }

--- a/src/resources/shaders/legacy/line/ucolor/frag.glsl
+++ b/src/resources/shaders/legacy/line/ucolor/frag.glsl
@@ -12,7 +12,7 @@ void main()
 
     float dx = max(-vUv.x, 0.0) + max(vUv.x - vLineLength, 0.0);
     float dy = vUv.y;
-    float dist = sqrt(dx*dx + dy*dy);
+    float dist = sqrt(dx * dx + dy * dy);
 
     float feather = 1.0;
     float alpha = 1.0 - smoothstep(halfWidth - feather, halfWidth + feather, dist);

--- a/src/resources/shaders/legacy/line/ucolor/vert.glsl
+++ b/src/resources/shaders/legacy/line/ucolor/vert.glsl
@@ -5,6 +5,10 @@ uniform ivec4 uViewport; // x, y, width, height
 layout(location = 0) in vec3 aVert1;
 layout(location = 1) in vec3 aVert2;
 
+out vec2 vUv;
+out float vLineLength;
+out float vWidth;
+
 void main()
 {
     vec4 clip1 = uMVP * vec4(aVert1, 1.0);
@@ -25,14 +29,36 @@ void main()
     }
     vec2 normal = vec2(-dir.y, dir.x);
 
-    vec2 offset = normal * uLineWidth * 0.5;
+    float feather = 1.0;
+    float halfWidth = uLineWidth * 0.5;
+    float totalHalfWidth = halfWidth + feather;
+
+    vLineLength = len;
+    vWidth = uLineWidth;
 
     vec2 pos;
     float z;
-    if (gl_VertexID == 0) { pos = screen1 + offset; z = clip1.z / clip1.w; }
-    else if (gl_VertexID == 1) { pos = screen1 - offset; z = clip1.z / clip1.w; }
-    else if (gl_VertexID == 2) { pos = screen2 - offset; z = clip2.z / clip2.w; }
-    else { pos = screen2 + offset; z = clip2.z / clip2.w; }
+
+    vec2 offsetL = dir * totalHalfWidth;
+    vec2 offsetP = normal * totalHalfWidth;
+
+    if (gl_VertexID == 0) {
+        pos = screen1 - offsetL + offsetP;
+        z = clip1.z / clip1.w;
+        vUv = vec2(-totalHalfWidth, totalHalfWidth);
+    } else if (gl_VertexID == 1) {
+        pos = screen1 - offsetL - offsetP;
+        z = clip1.z / clip1.w;
+        vUv = vec2(-totalHalfWidth, -totalHalfWidth);
+    } else if (gl_VertexID == 2) {
+        pos = screen2 + offsetL - offsetP;
+        z = clip2.z / clip2.w;
+        vUv = vec2(len + totalHalfWidth, -totalHalfWidth);
+    } else {
+        pos = screen2 + offsetL + offsetP;
+        z = clip2.z / clip2.w;
+        vUv = vec2(len + totalHalfWidth, totalHalfWidth);
+    }
 
     vec2 final_ndc = (pos / vec2(uViewport.zw)) * 2.0 - 1.0;
     gl_Position = vec4(final_ndc, z, 1.0);


### PR DESCRIPTION
This change introduces a more efficient way to draw thick lines in OpenGL by performing expansion and anti-aliasing on the GPU.

Key improvements:
- **Efficiency**: Replaces CPU-intensive vertex generation with GPU-side expansion.
- **Visual Quality**: Adds high-quality shader-based anti-aliasing and round caps/joins.
- **Maintainability**: Centralizes line expansion logic in the shaders.
- **Performance**: Reduces memory bandwidth by sending only segment endpoints to the GPU.

Call-sites in `Infomarks` and `Character` movement paths have been updated to use the new system.

---
*PR created automatically by Jules for task [2099568735187312187](https://jules.google.com/task/2099568735187312187) started by @nschimme*

## Summary by Sourcery

Switch line rendering to a GPU-driven, anti-aliased pipeline and update call sites to emit line segments instead of CPU-generated quads.

New Features:
- Introduce shader-based line expansion and anti-aliasing for colored lines with support for rounded caps and joins.

Enhancements:
- Refactor infomark and character path rendering to use generic colored line batches instead of precomputed line quads.