### PR TITLE
Optimize Wayland ghosting fix using texture swizzle

### DIFF
--- a/src/opengl/legacy/Legacy.cpp
+++ b/src/opengl/legacy/Legacy.cpp
@@ -4,6 +4,7 @@
 #include "Legacy.h"
 
 #include "../../display/Textures.h"
+#include "../../global/ConfigConsts-Computed.h"
 #include "../../global/utils.h"
 #include "../OpenGLTypes.h"
 #include "../UboManager.h"
@@ -394,6 +395,17 @@ void Functions::checkError()
 void Functions::configureFbo(int samples)
 {
     getFBO().configure(getPhysicalViewport(), samples);
+
+    // WebGL2 lacks native support for texture swizzling
+    if constexpr (CURRENT_PLATFORM != PlatformEnum::Wasm) {
+        const GLuint textureId = getFBO().resolvedTextureId();
+        if (textureId != 0) {
+            // Fix Wayland ghosting by forcing the alpha channel of the blit target to 1.0.
+            Base::glBindTexture(GL_TEXTURE_2D, textureId);
+            Base::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_ONE);
+            Base::glBindTexture(GL_TEXTURE_2D, 0);
+        }
+    }
 }
 
 void Functions::bindFbo()


### PR DESCRIPTION
Optimized the Wayland ghosting fix by using GL_TEXTURE_SWIZZLE_A set to GL_ONE on the resolved FBO texture instead of forcing it in the fragment shader. This is more efficient and handles the requirement at the texture level. The change is implemented in Functions::configureFbo within Legacy.cpp and is conditionally excluded for the Wasm platform to ensure compatibility.

---
*PR created automatically by Jules for task [10782420217640554893](https://jules.google.com/task/10782420217640554893) started by @nschimme*

## Summary by Sourcery

Optimize framebuffer configuration to apply the Wayland ghosting alpha fix via texture swizzling on the resolved FBO texture, excluding Wasm for compatibility.

Enhancements:
- Apply the Wayland ghosting alpha-channel override using GL texture swizzle on the resolved FBO texture instead of relying on fragment shader logic.
- Guard the texture swizzle-based ghosting fix from running on the Wasm platform to avoid incompatibilities.